### PR TITLE
Retries

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,22 @@
+"use strict";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export class RestateError extends Error {
+  constructor(public readonly message: string, public readonly cause?: any) {
+    super(message);
+  }
+
+  public hasCause(): boolean {
+    return this.cause;
+  }
+
+  public getRestateRootCause(): any {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let curr = this;
+    while (curr instanceof RestateError && (curr as RestateError).cause) {
+      curr = (curr as RestateError).cause;
+    }
+    return curr;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,148 @@
+"use strict";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-inferrable-types */
+
+import { RestateContext } from "./context";
+import { RestateError } from "./errors";
+
+/**
+ * Calls a side effect function and retries the call on failure, with a timed backoff.
+ * The side effect function is retried until it returns true or until it throws an error.
+ *
+ * Between retries, the call this function will do a suspendable Restate sleep.
+ * The sleep time starts with the 'initialDelayMs' value and doubles on each retry, up to
+ * a maximum of maxDelayMs.
+ *
+ * The returned Promise will be resolved successfully once the side effect actions completes
+ * successfully and will be rejected with an error if
+ *   (a) the side effect function throws an error
+ *   (b) the maximum number of retries (as specified by 'maxRetries') is exhausted .
+ *
+ * @example
+ * const ctx = restate.useContext(this);
+ * const paymentAction = async () =>
+ *   (await paymentClient.call(txId, methodIdentifier, amount)).success;
+ * await retrySideEffectWithBackoff(ctx, paymentAction, 1000, 60000, 10);
+ *
+ * @param ctx              The RestateContext object to call the side effect to sleep on.
+ * @param sideEffectAction The side effect action to run.
+ * @param initialDelayMs   The initial number of milliseconds to wait before retrying.
+ * @param maxDelayMs       The maxim number of milliseconds to wait between retries.
+ * @param maxRetries       (Optional) The maximum number of retries before this function fails with an exception.
+ * @param name             (Optional) The name of side effect action, to be used in log and error messages.
+ *
+ * @returns A promises that resolves successfully when the side effect completed successfully,
+ *          and rejected if the side effect fails or the maximum retries are exhausted.
+ */
+export async function retrySideEffectWithBackoff(
+  ctx: RestateContext,
+  sideEffectAction: () => Promise<boolean>,
+  initialDelayMs: number,
+  maxDelayMs: number,
+  maxRetries: number = 2147483647,
+  name: string = "unnamed-retryable-side-effect"
+): Promise<void> {
+  let delayMs = initialDelayMs;
+  let retriesLeft = maxRetries;
+
+  while (!(await ctx.sideEffect(sideEffectAction))) {
+    console.info(`Unsuccessful execution of side effect '${name}'.`);
+    if (retriesLeft > 0) {
+      console.info(`Retrying in ${delayMs}ms`);
+    } else {
+      console.info("No retries left.");
+      throw new RestateError(`Retries exhaused for '${name}'.`);
+    }
+
+    await ctx.sleep(delayMs);
+
+    retriesLeft -= 1;
+    delayMs = Math.min(delayMs * 2, maxDelayMs);
+  }
+}
+
+/**
+ * Calls a side effect function and retries the call on failure, with a timed backoff.
+ * The side effect function is retried when it throws an Error, until returns a successfully
+ * resolved Promise.
+ *
+ * Between retries, the call this function will do a suspendable Restate sleep.
+ * The sleep time starts with the 'initialDelayMs' value and doubles on each retry, up to
+ * a maximum of maxDelayMs.
+ *
+ * The returned Promise will be resolved successfully once the side effect actions completes
+ * successfully and will be rejected with an error if the maximum number of retries
+ * (as specified by 'maxRetries') is exhausted .
+ *
+ * @example
+ * const ctx = restate.useContext(this);
+ * const paymentAction = async () => {
+ *   const result = await paymentClient.call(txId, methodIdentifier, amount);
+ *   if (result.error) {
+ *     throw result.error;
+ *   } else {
+ *     return result.isSuccess;
+ *   }
+ * }
+ * boolean paymentAccepted =
+ *   await retryExceptionalSideEffectWithBackoff(ctx, paymentAction, 1000, 60000, 10);
+ *
+ * @param ctx              The RestateContext object to call the side effect to sleep on.
+ * @param sideEffectAction The side effect action to run.
+ * @param initialDelayMs   The initial number of milliseconds to wait before retrying.
+ * @param maxDelayMs       The maxim number of milliseconds to wait between retries.
+ * @param maxRetries       (Optional) The maximum number of retries before this function fails with an exception.
+ * @param name             (Optional) The name of side effect action, to be used in log and error messages.
+ *
+ * @returns A promises that resolves successfully when the side effect completed,
+ *          and rejected if the retries are exhausted.
+ */
+export async function retryExceptionalSideEffectWithBackoff<T>(
+  ctx: RestateContext,
+  sideEffectAction: () => Promise<T>,
+  initialDelayMs: number,
+  maxDelayMs: number,
+  maxRetries: number = 2147483647,
+  name: string = "unnamed-retryable-side-effect"
+): Promise<T> {
+  let delayMs = initialDelayMs;
+  let retriesLeft = maxRetries;
+  let lastError: Error | null = null;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await ctx.sideEffect(sideEffectAction);
+    } catch (e) {
+      let errorName: string;
+      let errorMessage: string;
+
+      if (e instanceof Error) {
+        lastError = e;
+        errorName = e.name;
+        errorMessage = e.message;
+      } else {
+        lastError = new RestateError("Uncategorized error", e);
+        errorName = "Error";
+        errorMessage = JSON.stringify(e);
+      }
+
+      console.info(
+        `Error while executing side effect '${name}': ${errorName} - ${errorMessage}`
+      );
+
+      if (retriesLeft > 0) {
+        console.info(`Retrying in ${delayMs}ms`);
+      } else {
+        console.info("No retries left.");
+        throw new RestateError(`Retries exhaused for {name}`, lastError);
+      }
+    }
+
+    await ctx.sleep(delayMs);
+
+    retriesLeft -= 1;
+    delayMs = Math.min(delayMs * 2, maxDelayMs);
+  }
+}

--- a/test/test_context.ts
+++ b/test/test_context.ts
@@ -1,0 +1,63 @@
+"use strict";
+
+import { RestateContext } from "../src/context";
+import { AwakeableIdentifier } from "../src/types";
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export class TestingContext implements RestateContext {
+  /**
+   * Creates a TestingContext with sample default values for the
+   * 'instanceKey', 'servicName', and 'invocationId' properties.
+   */
+  public static create(): TestingContext {
+    const instanceKey = Buffer.from("test-instance-key");
+    const invocationId = Buffer.from("test-invocation-id");
+    const serviceName = "test-service";
+
+    return new TestingContext(instanceKey, serviceName, invocationId);
+  }
+
+  constructor(
+    readonly instanceKey: Buffer,
+    readonly serviceName: string,
+    readonly invocationId: Buffer
+  ) {}
+
+  // ------------------------------------------------------
+  //  RestateContext methods
+  // ------------------------------------------------------
+
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array
+  ): Promise<Uint8Array> {
+    throw new Error("Method not implemented.");
+  }
+  get<T>(name: string): Promise<T | null> {
+    throw new Error("Method not implemented.");
+  }
+  set<T>(name: string, value: T): void {
+    throw new Error("Method not implemented.");
+  }
+  clear(name: string): void {
+    throw new Error("Method not implemented.");
+  }
+  inBackground<T>(call: () => Promise<T>): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  sideEffect<T>(fn: () => Promise<T>): Promise<T> {
+    // we simply call the side effect here
+    return fn();
+  }
+  awakeable<T>(): Promise<T> {
+    throw new Error("Method not implemented.");
+  }
+  completeAwakeable<T>(id: AwakeableIdentifier, payload: T): void {
+    throw new Error("Method not implemented.");
+  }
+  sleep(millis: number): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,241 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+"use strict";
+
+import { describe, expect } from "@jest/globals";
+import { TestingContext } from "./test_context";
+import * as restate_utils from "../src/utils";
+import { RestateError } from "../src/errors";
+import { RestateContext } from "../src/context";
+
+async function exceptionOnFalse(x: Promise<boolean>): Promise<boolean> {
+  return (await x) ? x : Promise.reject(new Error("test error"));
+}
+
+/**
+ * Tests for the method {@linkcode restate_utils.retrySideEffectWithBackoff}.
+ */
+describe("retrySideEffectWithBackoff()", () => {
+  it("should return immediately upon success", async () => {
+    await testReturnImmediatelyUponSuccess(
+      restate_utils.retrySideEffectWithBackoff,
+      true
+    );
+  });
+
+  it("should retry until success", async () => {
+    await testRetryUntilSuccess(
+      restate_utils.retrySideEffectWithBackoff,
+      async (x) => x
+    );
+  });
+
+  it("should retry until the maximum attemps", async () => {
+    await testRetryMaxAttempts(restate_utils.retrySideEffectWithBackoff);
+  });
+
+  it("should initially sleep the minimum time", async () => {
+    await testInitialSleepTime(restate_utils.retrySideEffectWithBackoff);
+  });
+
+  it("should ultimately sleep the maximum time", async () => {
+    await testUltimateSleepTime(restate_utils.retrySideEffectWithBackoff);
+  });
+});
+
+/**
+ * Tests for the method {@linkcode restate_utils.retryExceptionalSideEffectWithBackoff}.
+ */
+describe("retryExceptionalSideEffectWithBackoff()", () => {
+  it("should return immediately upon success", async () => {
+    const result = await testReturnImmediatelyUponSuccess(
+      restate_utils.retryExceptionalSideEffectWithBackoff,
+      "great!"
+    );
+
+    expect(result).toStrictEqual("great!");
+  });
+
+  it("should retry until success", async () => {
+    const finalValue = "success!!!";
+    const resultProducer = async (val: boolean) =>
+      val ? finalValue : Promise.reject(new Error("..."));
+
+    const result = await testRetryUntilSuccess(
+      restate_utils.retryExceptionalSideEffectWithBackoff,
+      resultProducer
+    );
+
+    expect(result).toStrictEqual(finalValue);
+  });
+
+  it("should retry until the maximum attemps", async () => {
+    await testRetryMaxAttempts(
+      restate_utils.retryExceptionalSideEffectWithBackoff<boolean>,
+      exceptionOnFalse
+    );
+  });
+
+  it("should initially sleep the minimum time", async () => {
+    await testInitialSleepTime(
+      restate_utils.retryExceptionalSideEffectWithBackoff<boolean>,
+      exceptionOnFalse
+    );
+  });
+
+  it("should ultimately sleep the maximum time", async () => {
+    await testUltimateSleepTime(
+      restate_utils.retryExceptionalSideEffectWithBackoff<boolean>,
+      exceptionOnFalse
+    );
+  });
+});
+
+// --------------------------------------------------------
+//  shared test implementations
+// --------------------------------------------------------
+
+async function testReturnImmediatelyUponSuccess<E, R>(
+  method: (
+    ctx: RestateContext,
+    action: () => Promise<E>,
+    minSleep: number,
+    maxSleep: number,
+    numRetries: number,
+    name: string
+  ) => Promise<R>,
+  actionResult: E
+): Promise<R> {
+  const ctx = TestingContext.create();
+  let timesSleepCalled = 0;
+  ctx.sleep = (millis: number) => {
+    timesSleepCalled++;
+    return Promise.resolve();
+  };
+
+  let invocations = 0;
+  const action: () => Promise<E> = async () => {
+    invocations++;
+    return actionResult;
+  };
+
+  const result = await method(ctx, action, 10, 100, 1000000, "test action");
+
+  expect(invocations).toStrictEqual(1);
+  expect(timesSleepCalled).toStrictEqual(0);
+
+  return result;
+}
+
+async function testRetryUntilSuccess<E, R>(
+  method: (
+    ctx: RestateContext,
+    action: () => Promise<E>,
+    minSleep: number,
+    maxSleep: number,
+    numRetries: number,
+    name: string
+  ) => Promise<R>,
+  resultProducer: (result: boolean) => Promise<E>
+): Promise<R> {
+  const ctx = TestingContext.create();
+
+  let remainingFailures = 3;
+  const action: () => Promise<E> = () =>
+    resultProducer(--remainingFailures === 0);
+
+  const result = await method(ctx, action, 10, 100, 1000000, "test action");
+
+  expect(remainingFailures).toStrictEqual(0);
+
+  return result;
+}
+
+async function testRetryMaxAttempts<R>(
+  method: (
+    ctx: RestateContext,
+    action: () => Promise<boolean>,
+    minSleep: number,
+    maxSleep: number,
+    numRetries: number,
+    name: string
+  ) => Promise<R>,
+  sideEffectWrapper: (result: Promise<boolean>) => Promise<boolean> = (x) => x
+) {
+  const ctx = TestingContext.create();
+  const numRetries = 2;
+
+  let numInvocationsHappened = 0;
+  const action: () => Promise<boolean> = () => {
+    numInvocationsHappened++;
+    return Promise.resolve(false);
+  };
+  const wrappedAction = () => sideEffectWrapper(action());
+
+  try {
+    await method(ctx, wrappedAction, 10, 100, numRetries, "test action");
+
+    fail("expected an exception to be thrown");
+  } catch (e) {
+    expect(e).toBeInstanceOf(RestateError);
+  }
+
+  expect(numInvocationsHappened).toStrictEqual(numRetries + 1);
+}
+
+async function testInitialSleepTime<R>(
+  method: (
+    ctx: RestateContext,
+    action: () => Promise<boolean>,
+    minSleep: number,
+    maxSleep: number,
+    numRetries: number,
+    name: string
+  ) => Promise<R>,
+  sideEffectWrapper: (result: Promise<boolean>) => Promise<boolean> = (x) => x
+) {
+  let initSleep = -1;
+
+  const ctx = TestingContext.create();
+  ctx.sleep = (millis: number) => {
+    initSleep = initSleep == -1 ? millis : initSleep;
+    return Promise.resolve();
+  };
+
+  let callsLeft = 20;
+  const action: () => Promise<boolean> = () =>
+    Promise.resolve(--callsLeft <= 0);
+
+  const wrappedAction = () => sideEffectWrapper(action());
+  await method(ctx, wrappedAction, 10, 100, 100000, "test action");
+
+  expect(initSleep).toStrictEqual(10);
+}
+
+async function testUltimateSleepTime<R>(
+  method: (
+    ctx: RestateContext,
+    action: () => Promise<boolean>,
+    minSleep: number,
+    maxSleep: number,
+    numRetries: number,
+    name: string
+  ) => Promise<R>,
+  sideEffectWrapper: (result: Promise<boolean>) => Promise<boolean> = (x) => x
+) {
+  let lastSleepTime = 0;
+
+  const ctx = TestingContext.create();
+  ctx.sleep = (millis: number) => {
+    lastSleepTime = millis;
+    return Promise.resolve();
+  };
+
+  let callsLeft = 20;
+  const action: () => Promise<boolean> = () =>
+    Promise.resolve(--callsLeft <= 0);
+
+  const wrappedAction = () => sideEffectWrapper(action());
+  await method(ctx, wrappedAction, 10, 100, 100000, "test action");
+
+  expect(lastSleepTime).toStrictEqual(100);
+}


### PR DESCRIPTION
**NOTE:** This PR builds on the PR #5 .Only the last commit 5e32fc2338b3352f20a5bb6ecd9151362e9536a4 here is relevant.

------

This adds the utilities `retryExceptionalSideEffectWithBackoff(...)` `retryExceptionalSideEffectWithBackoff(...)`.
Both are implemented purely on top of public API features.

Both functions execute the side effect function and retry it until it succeeds (returns true or until it no longer throws an error).

Between retries, the call this function will do a suspendable Restate sleep. The sleep time starts with an initial delay and doubles on each retry, up to maximum delay.

**retrySideEffectWithBackoff** example:
```typescript
const ctx = restate.useContext(this);
const paymentAction = async () =>
    (await paymentClient.call(txId, methodIdentifier, amount)).success;

await retrySideEffectWithBackoff(
    ctx,
    paymentAction,
    1000,   // initial retry delay (millis)
    60000,  // maximum retry delay (millis)
    10);    // maximum number of re-tries
```

**retryExceptionalSideEffectWithBackoff()`** example:
 ```typescript  
const ctx = restate.useContext(this);
const paymentAction = async () => {
    const result = await paymentClient.call(txId, methodIdentifier, amount);
    if (result.error) {
        throw result.error;
    } else {
        return result.isApproved;
    }
}
const paymentAccepted = await retryExceptionalSideEffectWithBackoff(
    ctx,
    paymentAction,
    100,    // initial retry delay (millis)
    10000,  // maximum retry delay (millis)
    50);    // maximum number of re-tries
```

