### PR TITLE
Fix inconsistency between lambda and http server

### DIFF
--- a/examples/lambda_example.ts
+++ b/examples/lambda_example.ts
@@ -34,10 +34,10 @@ export class GreeterService implements TestGreeter {
 }
 
 export const handler = restate
-  .lambdaApiGatewayHandler()
+  .createLambdaApiGatewayHandler()
   .bindService({
     descriptor: protoMetadata,
     service: "TestGreeter",
     instance: new GreeterService(),
   })
-  .create();
+  .handle();

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -3,6 +3,6 @@ export { RestateServer, createServer } from "./server/restate_server";
 export { ServiceOpts } from "./server/base_restate_server";
 export {
   LambdaRestateServer,
-  lambdaApiGatewayHandler,
+  createLambdaApiGatewayHandler,
 } from "./server/restate_lambda_handler";
 export * as RestateUtils from "./utils/public_utils";

--- a/src/server/restate_lambda_handler.ts
+++ b/src/server/restate_lambda_handler.ts
@@ -15,7 +15,7 @@ import { LambdaConnection } from "../connection/lambda_connection";
  * through API Gateway.
  *
  * Register services on this entrypoint via {@link LambdaRestateServer.bindService } and
- * then create the Lambda invocation handler via {@link LambdaRestateServer.create }.
+ * then create the Lambda invocation handler via {@link LambdaRestateServer.handle }.
  *
  * @example
  * A typical AWS Lambda entry point would look like this
@@ -23,16 +23,16 @@ import { LambdaConnection } from "../connection/lambda_connection";
  * import * as restate from "@restatedev/restate-sdk";
  *
  * export const handler = restate
- *   .lambdaApiGatewayHandler()
+ *   .createLambdaApiGatewayHandler()
  *   .bindService({
  *      service: "MyService",
  *      instance: new myService.MyServiceImpl(),
  *      descriptor: myService.protoMetadata,
  *    })
- *   .create();
+ *   .handle();
  * ```
  */
-export function lambdaApiGatewayHandler(): LambdaRestateServer {
+export function createLambdaApiGatewayHandler(): LambdaRestateServer {
   return new LambdaRestateServer();
 }
 
@@ -101,19 +101,19 @@ export class LambdaRestateServer extends BaseRestateServer {
    * import * as restate from "@restatedev/restate-sdk";
    *
    * export const handler = restate
-   *   .lambdaApiGatewayHandler()
+   *   .createLambdaApiGatewayHandler()
    *   .bindService({
    *      service: "MyService",
    *      instance: new myService.MyServiceImpl(),
    *      descriptor: myService.protoMetadata,
    *    })
-   *   .create();
+   *   .handle();
    * ```
    *
    * @returns The invocation handler function for to be called by AWS Lambda.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public create(): (event: any) => Promise<any> {
+  public handle(): (event: any) => Promise<any> {
     // return the handler and bind the current context to it, so that it can find the other methods in this class.
     return this.handleRequest.bind(this);
   }

--- a/test/lambda.test.ts
+++ b/test/lambda.test.ts
@@ -241,13 +241,13 @@ describe("LambdaGreeter: discovery of Lambda function", () => {
 
 function getTestHandler() {
   return restate
-    .lambdaApiGatewayHandler()
+    .createLambdaApiGatewayHandler()
     .bindService({
       descriptor: protoMetadata,
       service: "TestGreeter",
       instance: new LambdaGreeter(),
     })
-    .create();
+    .handle();
 }
 
 function apiProxyGatewayEvent(


### PR DESCRIPTION
#46 
--> Lambda server creation is not more consistent with long-running http server:

```
restate
    .createLambdaApiGatewayHandler()
    .bindService({
      descriptor: protoMetadata,
      service: "TestGreeter",
      instance: new LambdaGreeter(),
    })
    .handle();
```