### PR TITLE
End stream safely (wait for flush)

### DIFF
--- a/src/connection/http_connection.ts
+++ b/src/connection/http_connection.ts
@@ -68,7 +68,7 @@ export class HttpConnection implements Connection {
   }
 
   end() {
-    this.stream.end();
+    this.restate.end();
   }
 }
 

--- a/src/connection/restate_duplex_stream.ts
+++ b/src/connection/restate_duplex_stream.ts
@@ -26,6 +26,10 @@ export class RestateDuplexStream {
     this.sdkOutput.write(msg);
   }
 
+  end() {
+    this.sdkOutput.end();
+  }
+
   onMessage(handler: (msg: Message) => void) {
     this.sdkInput.on("data", (data) => {
       handler(data);


### PR DESCRIPTION
It appears that ending the http2 stream directly leads it to not wait for data to be flushed. If we instead end the sdkOutput writer, it does flush. This is bad behaviour by node!