### PR TITLE
Restate 'send' -> 'buffer' and 'flush'

### DIFF
--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -5,7 +5,9 @@ import { Message } from "../types/types";
 export interface Connection {
   addOnErrorListener(listener: () => void): void;
 
-  send(msg: Message): void;
+  buffer(msg: Message): void
+
+  flush(): Promise<void>
 
   onMessage(handler: (msg: Message) => void): void;
 

--- a/src/connection/restate_duplex_stream.ts
+++ b/src/connection/restate_duplex_stream.ts
@@ -5,6 +5,8 @@ import { Message } from "../types/types";
 import { streamEncoder } from "../io/encoder";
 import { streamDecoder } from "../io/decoder";
 import { rlog } from "../utils/logger";
+import {promisify} from "util";
+const pipeline = promisify(stream.pipeline);
 
 export class RestateDuplexStream {
   // create a RestateDuplex stream from an http2 (duplex) stream.
@@ -22,8 +24,12 @@ export class RestateDuplexStream {
     private readonly sdkOutput: stream.Writable
   ) {}
 
-  send(msg: Message) {
-    this.sdkOutput.write(msg);
+  async send(msgs: Message[]): Promise<void> {
+    const readable = stream.Readable.from(msgs)
+    await pipeline(
+      readable,
+      this.sdkOutput
+    )
   }
 
   end() {

--- a/test/protocol_stream.test.ts
+++ b/test/protocol_stream.test.ts
@@ -59,7 +59,7 @@ describe("Stream", () => {
     });
 
     // now, let's simulate sending a message
-    restateStream.send(
+    await restateStream.send([
       new Message(
         START_MESSAGE_TYPE,
         StartMessage.create({
@@ -67,7 +67,7 @@ describe("Stream", () => {
           knownEntries: 1337,
         })
       )
-    );
+    ]);
 
     http2stream.end();
 

--- a/test/testdriver.ts
+++ b/test/testdriver.ts
@@ -95,7 +95,7 @@ export class TestDriver<I, O> implements Connection {
     return this.getResultPromise;
   }
 
-  send(msg: Message) {
+  buffer(msg: Message): void {
     this.result.push(msg);
     rlog.debug(
       `Adding result to the result array. Message type: ${
@@ -107,11 +107,17 @@ export class TestDriver<I, O> implements Connection {
             : printMessageAsJson(msg.message)
         }`
     );
+  }
 
+  async flush(): Promise<void> {
+    if (this.result.length == 0) {
+      return
+    }
+    const tail = this.result[this.result.length - 1]
     // For an output message, flush immediately
     if (
-      msg.messageType === OUTPUT_STREAM_ENTRY_MESSAGE_TYPE ||
-      msg.messageType === SUSPENSION_MESSAGE_TYPE
+      tail.messageType === OUTPUT_STREAM_ENTRY_MESSAGE_TYPE ||
+      tail.messageType === SUSPENSION_MESSAGE_TYPE
     ) {
       rlog.debug("End of test: Flushing test results");
       this.resolveOnClose(this.result);


### PR DESCRIPTION
1. We now only send stuff to the runtime when we want a response, making bidi more similar to lambda
2. We are now able to respect the backpressure semantics of the http2 stream send api, which is *not* synchronous