### PR TITLE
Logging improvements

### DIFF
--- a/src/server/base_restate_server.ts
+++ b/src/server/base_restate_server.ts
@@ -107,6 +107,7 @@ export abstract class BaseRestateServer {
       const url = `/invoke/${spec.packge}.${spec.name}/${method.name}`;
       this.methods[url] = new HostedGrpcServiceMethod(
         instance,
+        spec.packge,
         service,
         method
       );
@@ -130,6 +131,7 @@ export abstract class BaseRestateServer {
     // create new instance each time as reject and resolve must not be shared across invocations
     return new HostedGrpcServiceMethod<I, O>(
       method.instance,
+      method.packge,
       method.service,
       method.method as GrpcServiceMethod<I, O>
     );

--- a/src/state_machine.ts
+++ b/src/state_machine.ts
@@ -109,7 +109,7 @@ export class DurableExecutionStateMachine<I, O> implements RestateContext {
   public invocationId!: Buffer;
   // Parsed string representation of the invocationId
   public invocationIdString!: string;
-  // We set the log prefix to [service-name] [method-name] [invocation-id] upon receiving the start message
+  // We set the log prefix to [sid] [method-name] upon receiving the start message
   private logPrefix = "";
   // Number of journal entries that will be replayed by the runtime
   private nbEntriesToReplay!: number;
@@ -823,7 +823,7 @@ export class DurableExecutionStateMachine<I, O> implements RestateContext {
 
   handleInputMessage(m: PollInputStreamEntryMessage) {
     this.invocationIdString = uuidV7FromBuffer(this.invocationId);
-    this.logPrefix = `[${this.serviceName}] [${this.method.method.name}] [${this.invocationIdString}]`;
+    this.logPrefix = `[${this.method.packge}.${this.method.service}-${this.instanceKey.toString('base64')}-${this.invocationIdString}] [${this.method.method.name}]`;
     rlog.debugJournalMessage(this.logPrefix, "Received input message.", m);
 
     this.method.invoke(this, m.value).then(

--- a/src/types/grpc.ts
+++ b/src/types/grpc.ts
@@ -37,6 +37,7 @@ export class HostedGrpcServiceMethod<I, O> {
 
   constructor(
     readonly instance: unknown,
+    readonly packge: string,
     readonly service: string,
     readonly method: GrpcServiceMethod<I, O>
   ) {}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -100,7 +100,7 @@ restate_logger.debugJournalMessage = function (
     ? " message: " + printMessageAsJson(journalMessageObject)
     : "";
   console.debug(
-    `[restate] [${new Date().toISOString()}] ${invocationInfo} : ${logMessage}${journalEvent}`
+    `[restate] [${new Date().toISOString()}] DEBUG: ${invocationInfo} : ${logMessage}${journalEvent}`
   );
 };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,13 +26,9 @@ export function uuidV7FromBuffer(buffer: Buffer): string {
   //   throw new Error('Invalid UUIDv7 buffer length');
   // }
   const bytes = new Uint8Array(buffer);
-  const uuid = Array.from(bytes, (byte) =>
+  return Array.from(bytes, (byte) =>
     byte.toString(16).padStart(2, "0")
   ).join("");
-  return `${uuid.slice(0, 8)}-${uuid.slice(8, 12)}-${uuid.slice(
-    12,
-    16
-  )}-${uuid.slice(16, 20)}-${uuid.slice(20)}`;
 }
 
 /**


### PR DESCRIPTION
- Move sdk to use sid, the new identifier that we now use in runtime, which contains service name, uuid, and instance key in base64
- Ensure that a loglevel is produced for debug journal messages