### PR TITLE
Wait for pending messages to be resolved before responding success

### DIFF
--- a/src/state_machine.ts
+++ b/src/state_machine.ts
@@ -802,9 +802,8 @@ export class DurableExecutionStateMachine<I, O> implements RestateContext {
   handleInputMessage(m: PollInputStreamEntryMessage) {
     this.invocationIdString = uuidV7FromBuffer(this.invocationId);
     this.logPrefix = `[${this.method.packge}.${this.method.service}-${this.instanceKey.toString('base64')}-${this.invocationIdString}] [${this.method.method.name}]`;
-    rlog.debugJournalMessage(this.logPrefix, "Received input message.", m);
 
-    this.method.invoke(this, m.value).then(
+    this.method.invoke(this, m.value, this.logPrefix).then(
       (value) => this.onCallSuccess(value),
       (failure) => this.onCallFailure(failure)
     );


### PR DESCRIPTION
Fix for https://github.com/restatedev/sdk-typescript/issues/52
The issue: In the case of a replay of messages that do not require completion (e.g. set state and then output response),
the state machine did not wait until the replay had finished before sending back the response and closing the state machine.
So if the set state had to be replayed, then the user code just skipped it and continued to send back the response.

Fix: wait for all the promises in the pending messages map to be resolved before sending back the response.
This avoids warnings like State machine is closed. Cancelling all execution. And makes sure journal mismatch checks are always done.