### PR TITLE
Fix for empty side effects on replay

### DIFF
--- a/src/connection/restate_duplex_stream.ts
+++ b/src/connection/restate_duplex_stream.ts
@@ -1,11 +1,11 @@
 "use strict";
 
 import stream from "stream";
-import {Message} from "../types/types";
-import {streamEncoder} from "../io/encoder";
-import {streamDecoder} from "../io/decoder";
-import {rlog} from "../utils/logger";
-import {pipeline} from "stream/promises";
+import { Message } from "../types/types";
+import { streamEncoder } from "../io/encoder";
+import { streamDecoder } from "../io/decoder";
+import { rlog } from "../utils/logger";
+import { pipeline } from "stream/promises";
 
 export class RestateDuplexStream {
   // create a RestateDuplex stream from an http2 (duplex) stream.
@@ -21,20 +21,15 @@ export class RestateDuplexStream {
   constructor(
     private readonly sdkInput: stream.Readable,
     private readonly sdkOutput: stream.Writable
-  ) {
-  }
+  ) {}
 
   async send(msgs: Message[]): Promise<void> {
-    const max = this.sdkOutput.getMaxListeners()
+    const max = this.sdkOutput.getMaxListeners();
     // pipeline creates a huge number of listeners, but it is not a leak; they are cleaned up by the time we complete
     // set to unlimited briefly
-    this.sdkOutput.setMaxListeners(0)
-    await pipeline(
-      stream.Readable.from(msgs),
-      this.sdkOutput,
-      {end: false}
-    )
-    this.sdkOutput.setMaxListeners(max)
+    this.sdkOutput.setMaxListeners(0);
+    await pipeline(stream.Readable.from(msgs), this.sdkOutput, { end: false });
+    this.sdkOutput.setMaxListeners(max);
   }
 
   end() {

--- a/test/send_request.test.ts
+++ b/test/send_request.test.ts
@@ -56,7 +56,7 @@ class UnawaitedRequestResponseCallGreeter implements TestGreeter {
     const ctx = restate.useContext(this);
 
     const client = new TestGreeterClientImpl(ctx);
-    client.greet(TestRequest.create({ name: "Francesco" }))
+    client.greet(TestRequest.create({ name: "Francesco" }));
 
     return TestResponse.create({ greeting: `Hello` });
   }
@@ -874,11 +874,7 @@ describe("UnawaitedRequestResponseCallGreeter: if a call is replayed but uncompl
       [
         startMessage(2),
         inputMessage(greetRequest("Till")),
-        invokeMessage(
-          "test.TestGreeter",
-          "Greet",
-          greetRequest("Francesco")
-        ),
+        invokeMessage("test.TestGreeter", "Greet", greetRequest("Francesco")),
       ]
     ).run();
 


### PR DESCRIPTION
- Side effects without return value were stored as Empty.
- This failed upon replay because it was parsed with `JSON.parse(value.toString())`
- Fixed by storing it as a jsonified empty object {}
Fixes #79 