### PR TITLE
Fix parsing of partial state flag

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -94,7 +94,7 @@ export class Header {
         : undefined;
     const partialStateFlag =
       MessageType.hasPartialStateFlag(messageType) &&
-      (value && PARTIAL_STATE_MASK) !== 0n
+      (value & PARTIAL_STATE_MASK) !== 0n
         ? true
         : undefined;
     const frameLength = Number(value & 0xffffffffn);

--- a/test/protocol_stream.test.ts
+++ b/test/protocol_stream.test.ts
@@ -21,6 +21,9 @@ describe("Header", () => {
 
   it("invoke_test", () => roundtripTest(newStart(1, 25)));
 
+  it("invoke_test_partial_state", () => roundtripTest(newStart(1, 25, true)));
+  it("invoke_test_complete_state", () => roundtripTest(newStart(1, 25, undefined)));
+
   it("completion_test", () =>
     roundtripTest(newHeader(COMPLETION_MESSAGE_TYPE, 22)));
 
@@ -93,8 +96,8 @@ function newHeader(messageTypeId: bigint, length: number): Header {
   return new Header(messageTypeId, length);
 }
 
-function newStart(protocolVersion: number, length: number): Header {
-  return new Header(START_MESSAGE_TYPE, length, undefined, protocolVersion);
+function newStart(protocolVersion: number, length: number, partialStateFlag?: boolean): Header {
+  return new Header(START_MESSAGE_TYPE, length, undefined, protocolVersion, undefined, partialStateFlag);
 }
 
 function newCompletableEntry(
@@ -120,6 +123,7 @@ function roundtripTest(a: Header) {
   expect(b.protocolVersion).toStrictEqual(a.protocolVersion);
   sameTruthness(a.completedFlag, b.completedFlag);
   sameTruthness(a.requiresAckFlag, b.requiresAckFlag);
+  sameTruthness(a.partialStateFlag, b.partialStateFlag);
 }
 
 function mockHttp2DuplexStream() {


### PR DESCRIPTION
This solves https://github.com/restatedev/sdk-typescript/issues/113

- Fixed parsing error for partial state flag
- Added unit tests 