### PR TITLE
Generalize release process and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,37 @@ curl -X POST http://localhost:9090/test.TestGreeter/Greet -H 'content-type: appl
 
 # Releasing the package
 
-Releasing a new npm package from this repo requires a GitHub personal access token in your environment as `NPM_TOKEN`.
+## Releasing via release-it
+
+Releasing a new npm package from this repo requires:
+
+* [SSH access configured for Github](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) in order to push commits and tags to GitHub
+* A GitHub personal access token with access to https://github.com/restatedev/sdk-typescript in your environment as `GITHUB_TOKEN` in order to create a Github release
+
+
 ```bash
-# using 1password (https://developer.1password.com/docs/cli/shell-plugins/github/)
-NPM_TOKEN="op://private/GitHub Personal Access Token/token" op run -- npm run release
+npm run release
 # now select what type of release you want to do and say yes to the rest of the options
 ```
-The actual `npm publish` is done by GitHub actions once a GitHub release is created.
+
+The actual `npm publish` is run by GitHub actions once a GitHub release is created.
+
+## Releasing manually
+
+1. Bump the version field in package.json to `X.Y.Z`
+2. Create and push a tag of the form `vX.Y.Z` to the upstream repository
+3. [Create a new GitHub release](https://github.com/restatedev/sdk-typescript/releases)
+
+Creating the GitHub release will trigger `npm publish` via GitHub actions.
+
+After having created a new SDK release, you need to:
+
+1. [Update and release the tour of Restate](https://github.com/restatedev/tour-of-restate-typescript#upgrading-typescript-sdk)
+2. [Update the Typescript SDK and Tour version and release the documentation](https://github.com/restatedev/documentation#upgrading-typescript-sdk-version)
+3. [Update and release the Node template generator](https://github.com/restatedev/node-template-generator#upgrading-typescript-sdk)
+4. Update the examples:
+   * [Ticket reservation example](https://github.com/restatedev/example-ticket-reservation-system#upgrading-typescript-sdk)
+   * [Food ordering example](https://github.com/restatedev/example-food-ordering#upgrading-typescript-sdk)
+   * [Shopping cart example](https://github.com/restatedev/example-shopping-cart-typescript#upgrading-typescript-sdk)
+   * [Lambda greeter example](https://github.com/restatedev/example-lambda-ts-greeter#upgrading-the-sdk)
+5. Update the e2e tests to point to the new SDK version.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "url": "git+https://github.com/restatedev/sdk-typescript.git"
   },
   "release-it": {
+    "git": {
+      "pushRepo": "https://github.com/restatedev/sdk-typescript.git"
+    },
     "github": {
       "release": true
     },


### PR DESCRIPTION
This commit fixes the remote repository to be
https://github.com/restatedev/sdk-typescript.git. That way we now support working on a fork of this repo and still be able to create releases. Moreover, it updates the release process description by listing the requirements.

This fixes #134.