### PR TITLE
Add license headers to all files.

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 /* eslint-disable no-console */
 
 /*

--- a/examples/grpc_example.ts
+++ b/examples/grpc_example.ts
@@ -1,4 +1,15 @@
 /*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+/*
  * A simple example program using the Restate gRPC-based API.
  *
  * This example primarily exists to make it simple to test the code against

--- a/proto/discovery.proto
+++ b/proto/discovery.proto
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+ 
 syntax = "proto3";
 
 package dev.restate.service.discovery;

--- a/proto/dynrpc.proto
+++ b/proto/dynrpc.proto
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 syntax = "proto3";
 
 import "dev/restate/ext.proto";

--- a/proto/javascript.proto
+++ b/proto/javascript.proto
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+ 
 syntax = "proto3";
 
 package dev.restate.sdk.javascript;

--- a/proto/protocol.proto
+++ b/proto/protocol.proto
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 syntax = "proto3";
 
 package dev.restate.service.protocol;

--- a/proto/test.proto
+++ b/proto/test.proto
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 syntax = "proto3";
 
 package test;

--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import { Message } from "../types/types";
 

--- a/src/connection/http_connection.ts
+++ b/src/connection/http_connection.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import stream from "stream";
 import { encodeMessage } from "../io/encoder";

--- a/src/connection/lambda_connection.ts
+++ b/src/connection/lambda_connection.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import { Connection } from "./connection";
 import { encodeMessage } from "../io/encoder";

--- a/src/invocation.ts
+++ b/src/invocation.ts
@@ -1,4 +1,14 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 /*eslint-disable @typescript-eslint/no-non-null-assertion*/
 
 import { Message } from "./types/types";

--- a/src/io/decoder.ts
+++ b/src/io/decoder.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 // This is a NodeJs stream transformer. It is used to convert a chunked stream of bytes to
 // a stream of JavaScript objects of the form { header: .. , message: ..} where:
@@ -10,6 +19,7 @@
 // let decodedStream = stream.pipe(streamDecoder());
 //
 // at this point the decodedStream is a high level stream of objects {header, message}
+
 import stream from "stream";
 import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
 import { Header, Message } from "../types/types";

--- a/src/io/encoder.ts
+++ b/src/io/encoder.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import stream from "stream";
 import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import * as p from "./types/protocol";
 import { Failure } from "./generated/proto/protocol";

--- a/src/local_state_store.ts
+++ b/src/local_state_store.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import {
   ClearStateEntryMessage,

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 export {
   RestateContext,
   RestateGrpcContext,

--- a/src/restate_context.ts
+++ b/src/restate_context.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 // Use our prefixed logger instead of default console logging
 import "./utils/logger";

--- a/src/restate_context_impl.ts
+++ b/src/restate_context_impl.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { RestateGrpcContext, RpcContext, ServiceApi } from "./restate_context";
 import { StateMachine } from "./state_machine";
 import {

--- a/src/server/base_restate_server.ts
+++ b/src/server/base_restate_server.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 /* eslint-disable @typescript-eslint/ban-types */
 

--- a/src/server/restate_lambda_handler.ts
+++ b/src/server/restate_lambda_handler.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import { rlog } from "../utils/logger";
 import {

--- a/src/server/restate_server.ts
+++ b/src/server/restate_server.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import { on } from "events";
 import stream from "stream";

--- a/src/state_machine.ts
+++ b/src/state_machine.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import * as p from "./types/protocol";
 import { RestateGrpcContextImpl } from "./restate_context_impl";

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/src/types/grpc.ts
+++ b/src/types/grpc.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import { RestateContext, setContext } from "../restate_context";
 import { FileDescriptorProto } from "ts-proto-descriptors";

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import { SideEffectEntryMessage } from "../generated/proto/javascript";
 import {

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { RpcContext } from "../restate_context";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,

--- a/src/utils/assumpsions.ts
+++ b/src/utils/assumpsions.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { RpcRequest } from "../generated/proto/dynrpc";
 
 const ASSUME_UNKEYED_SINCE_FIRST_PARAM_NOT_STRING = 1;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
 

--- a/src/utils/public_utils.ts
+++ b/src/utils/public_utils.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 /**
  * Retry policy that decides how to delay between retries.
  */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,13 @@
-"use strict";
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/test/awakeable.test.ts
+++ b/test/awakeable.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import { TestDriver } from "./testdriver";

--- a/test/complete_awakeable.test.ts
+++ b/test/complete_awakeable.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { TestGreeter, TestResponse } from "../src/generated/proto/test";
 import * as restate from "../src/public_api";
 import {

--- a/test/eager_state.test.ts
+++ b/test/eager_state.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import {
   TestGreeter,
   TestRequest,

--- a/test/get_and_set_state.test.ts
+++ b/test/get_and_set_state.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import { TestDriver } from "./testdriver";

--- a/test/get_state.test.ts
+++ b/test/get_state.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import { TestDriver } from "./testdriver";

--- a/test/lambda.test.ts
+++ b/test/lambda.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import {

--- a/test/message_coders.test.ts
+++ b/test/message_coders.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import { streamDecoder } from "../src/io/decoder";
 import { Message } from "../src/types/types";

--- a/test/protocol_stream.test.ts
+++ b/test/protocol_stream.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import {
   START_MESSAGE_TYPE,

--- a/test/protoutils.ts
+++ b/test/protoutils.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 /* istanbul ignore file */
 import { Empty } from "../src/generated/google/protobuf/empty";
 import {

--- a/test/send_request.test.ts
+++ b/test/send_request.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import { TestDriver } from "./testdriver";

--- a/test/side_effect.test.ts
+++ b/test/side_effect.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import { TestDriver } from "./testdriver";

--- a/test/sleep.test.ts
+++ b/test/sleep.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import * as restate from "../src/public_api";
 import { TestDriver } from "./testdriver";

--- a/test/state_machine.test.ts
+++ b/test/state_machine.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { TestGreeter, TestResponse } from "../src/generated/proto/test";
 import * as restate from "../src/public_api";
 import { describe, expect } from "@jest/globals";

--- a/test/testdriver.ts
+++ b/test/testdriver.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import {
   COMPLETION_MESSAGE_TYPE,
   START_MESSAGE_TYPE,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
 import { describe, expect } from "@jest/globals";
 import {
   jsonDeserialize,


### PR DESCRIPTION
This also removes the "use strict" found in some files, which is redundant, because it is implied by the typescript compiler under our configuration.