### PR TITLE
Update SDK to use latest Restate service protocol

### DIFF
--- a/proto/protocol.proto
+++ b/proto/protocol.proto
@@ -60,7 +60,17 @@ message SuspensionMessage {
 
 // Type: 0x0000 + 3
 message ErrorMessage {
-  Failure failure = 15;
+  // The code can be:
+  // * Any of the error codes defined by OutputStreamEntry.failure (see Failure message)
+  // * JOURNAL_MISMATCH = 32, that is when the SDK cannot replay a journal due to the mismatch between the journal and the actual code.
+  // * PROTOCOL_VIOLATION = 33, that is when the SDK receives an unexpected message or an expected message variant, given its state.
+  //
+  // If 16 < code < 32, or code > 33, the runtime will interpret it as code 2 (UNKNOWN).
+  uint32 code = 1;
+  // Contains a concise error message, e.g. Throwable#getMessage() in Java.
+  string message = 2;
+  // Contains a verbose error description, e.g. the exception stacktrace.
+  string description = 3;
 }
 
 // --- Journal Entries ---
@@ -122,8 +132,9 @@ message ClearStateEntryMessage {
 // Kind: Completable JournalEntry
 // Type: 0x0C00 + 0
 message SleepEntryMessage {
-  // Duration since UNIX Epoch
-  int64 wake_up_time = 1;
+  // Wake up time.
+  // The time is set as duration since UNIX Epoch.
+  uint64 wake_up_time = 1;
 
   google.protobuf.Empty result = 13;
 }
@@ -154,7 +165,7 @@ message BackgroundInvokeEntryMessage {
   // The time is set as duration since UNIX Epoch.
   // If this value is not set, equal to 0, or past in time,
   // the runtime will execute this BackgroundInvoke as soon as possible.
-  int64 invoke_time = 4;
+  uint64 invoke_time = 4;
 }
 
 // Kind: Completable JournalEntry
@@ -179,8 +190,14 @@ message CompleteAwakeableEntryMessage {
 
 // --- Nested messages
 
+// This failure object carries user visible errors,
+// e.g. invocation failure return value or failure result of an InvokeEntryMessage.
 message Failure {
-  // Same error space of gRPC, as defined here: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
-  int32 code = 1;
+  // The code should be any of the gRPC error codes,
+  // as defined here: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
+  //
+  // If code > 16, the runtime will interpret it as code 2 (UNKNOWN).
+  uint32 code = 1;
+  // Contains a concise error message, e.g. Throwable#getMessage() in Java.
   string message = 2;
 }

--- a/src/state_machine.ts
+++ b/src/state_machine.ts
@@ -25,14 +25,13 @@ import {
   SUSPENSION_MESSAGE_TYPE,
   SuspensionMessage,
 } from "./types/protocol";
-import { ErrorMessage } from "./generated/proto/protocol";
 import { Journal } from "./journal";
 import { Invocation } from "./invocation";
 import {
   ensureError,
   TerminalError,
   RetryableError,
-  errorToFailure,
+  errorToErrorMessage,
 } from "./types/errors";
 import { LocalStateStore } from "./local_state_store";
 
@@ -304,9 +303,7 @@ export class StateMachine<I, O> implements RestateStreamConsumer {
   private sendRetryableError(e: Error) {
     const msg = new Message(
       ERROR_MESSAGE_TYPE,
-      ErrorMessage.create({
-        failure: errorToFailure(e),
-      })
+      errorToErrorMessage(e)
     );
     rlog.debugJournalMessage(
       this.invocation.logPrefix,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Failure } from "../generated/proto/protocol";
+import { ErrorMessage, Failure } from "../generated/proto/protocol";
 import { printMessageAsJson } from "../utils/utils";
 import { Message } from "./types";
 import { JournalEntry } from "../journal";
@@ -128,4 +128,15 @@ export function failureToError(
   return terminalError
     ? new TerminalError(errorMessage, { errorCode })
     : new RestateError(errorMessage, { errorCode });
+}
+
+export function errorToErrorMessage(err: Error): ErrorMessage {
+  const code = err instanceof RestateError
+    ? err.code
+    : ErrorCodes.INTERNAL;
+
+  return ErrorMessage.create({
+    code: code,
+    message: err.message
+  });
 }

--- a/test/protoutils.ts
+++ b/test/protoutils.ts
@@ -431,18 +431,18 @@ export function checkError(
   code: number = ErrorCodes.INTERNAL
 ) {
   expect(outputMsg.messageType).toEqual(ERROR_MESSAGE_TYPE);
-  expect((outputMsg.message as ErrorMessage).failure?.code).toStrictEqual(code);
-  expect((outputMsg.message as ErrorMessage).failure?.message).toContain(
+  expect((outputMsg.message as ErrorMessage).code).toStrictEqual(code);
+  expect((outputMsg.message as ErrorMessage).message).toContain(
     errorMessage
   );
 }
 
 export function checkJournalMismatchError(outputMsg: Message) {
   expect(outputMsg.messageType).toEqual(ERROR_MESSAGE_TYPE);
-  expect((outputMsg.message as ErrorMessage).failure?.code).toStrictEqual(
+  expect((outputMsg.message as ErrorMessage).code).toStrictEqual(
     ErrorCodes.JOURNAL_MISMATCH
   );
-  expect((outputMsg.message as ErrorMessage).failure?.message).toContain(
+  expect((outputMsg.message as ErrorMessage).message).toContain(
     "Journal mismatch: Replayed journal entries did not correspond to the user code. The user code has to be deterministic!"
   );
 }


### PR DESCRIPTION
The new service protocol has a different ErrorMessage which this commit makes use of. A potential follow-up is to use the description field to expose more information about the stack trace of the retryable error and/or causes.

This fixes #139.