### PR TITLE
Add event handler

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: restatedev
     repository: proto
-    commit: 7c1d0063691147dab51a87fc7d2befa5
-    digest: shake256:41fb2128bd34a84f363d2b0cafbf0746b82d2b18c400cf85a1b3a94b28a2f4643fc17c9cf523cf98720b227b8d75b24fdc03fb87f8fa9a7ef75f788a5cbfe0c4
+    commit: 4c536701ef5348ecbf3cd1ef6cf825fc
+    digest: shake256:0fdebe27d9653dc31f9951623e0c8dc68a161d2b55146cc22c0501d2bccb22d49ab9b2b80c8f4de8827c4ba168119296f14d323eed5162ef63f128803cc64f47

--- a/examples/handler_example.ts
+++ b/examples/handler_example.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+/* eslint-disable no-console */
+
+/*
+ * A simple example program using the Restate's event handlers.
+ */
+
+import * as restate from "../src/public_api";
+
+const registration = async (ctx: restate.RpcContext, event: restate.Event) => {
+  // store in state the user's information as coming from the registeration event
+  const { name } = event.json<{ name: string }>();
+  ctx.set("name", name);
+};
+
+const email = async (ctx: restate.RpcContext, event: restate.Event) => {
+  // store in state the user's information as coming from the email event
+  const { email } = event.json<{ email: string }>();
+  ctx.set("email", email);
+};
+
+type UserProfile = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+const get = async (
+  ctx: restate.RpcContext,
+  id: string
+): Promise<UserProfile> => {
+  return {
+    id,
+    name: (await ctx.get<string>("name")) ?? "",
+    email: (await ctx.get<string>("email")) ?? "",
+  };
+};
+
+const profile = restate.keyedRouter({
+  registration: restate.keyedEventHandler(registration),
+  email: restate.keyedEventHandler(email),
+  get,
+});
+
+// restate server
+restate.createServer().bindKeyedRouter("profile", profile).listen(8080);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "verify": "npm run format -- --check && npm run test && npm run lint && npm run build",
     "release": "release-it",
     "example": "RESTATE_DEBUG_LOGGING=JOURNAL ts-node-dev --respawn --transpile-only ./examples/example.ts",
-    "grpcexample": "RESTATE_DEBUG_LOGGING=JOURNAL ts-node-dev --respawn --transpile-only ./examples/grpc_example.ts"
+    "grpcexample": "RESTATE_DEBUG_LOGGING=JOURNAL ts-node-dev --respawn --transpile-only ./examples/grpc_example.ts",
+    "handlerexample": "RESTATE_DEBUG_LOGGING=JOURNAL ts-node-dev --respawn --transpile-only ./examples/handler_example.ts"
   },
   "files": [
     "dist"

--- a/proto/dynrpc.proto
+++ b/proto/dynrpc.proto
@@ -12,13 +12,16 @@
 syntax = "proto3";
 
 import "dev/restate/ext.proto";
+import "dev/restate/events.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/empty.proto";
 
 service RpcEndpoint {
 	option (dev.restate.ext.service_type) = KEYED;
 
 	rpc call(RpcRequest) returns (RpcResponse) {};
 
+	rpc handle(dev.restate.StringKeyedEvent) returns (google.protobuf.Empty) {};
 }
 
 service UnkeyedRpcEndpoint {

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -19,8 +19,10 @@ export {
 export {
   router,
   keyedRouter,
+  keyedEventHandler,
   UnKeyedRouter,
   KeyedRouter,
+  KeyedEventHandler,
   Client,
   SendClient,
 } from "./types/router";
@@ -32,3 +34,4 @@ export {
 } from "./server/restate_lambda_handler";
 export * as RestateUtils from "./utils/public_utils";
 export { ErrorCodes, RestateError, TerminalError } from "./types/errors";
+export { Event } from "./types/types";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -120,3 +120,20 @@ export class Header {
     return res;
   }
 }
+
+export class Event {
+  constructor(
+    readonly key: string,
+    readonly payload: Buffer,
+    readonly source: string,
+    readonly attributes: Record<string, string>
+  ) {}
+
+  public json<T>(): T {
+    return JSON.parse(this.payload.toString("utf-8")) as T;
+  }
+
+  public body(): Uint8Array {
+    return this.payload;
+  }
+}


### PR DESCRIPTION
The following PR adds support for a `keyedEventHandler`.

The following usage example demonstrates a simple `join` between two different topics,
* a "registration" topic, that is keyed by a user id (string), and has `{ "name" : "the name of the user"} ` jsons,
* and a `email_verification` topic, that is keyed by the user id (string) and has `{ "email" : "the verified email"}` jsons.
This demonstrates how to structure a restate program that naturally preforms a keyed join. 

```ts
import * as restate from "../src/public_api";

const registration = async (ctx: restate.RpcContext, event: restate.Event) => {
  // store in state the user's information as coming from the registeration event
  const { name } = event.json<{ name: string }>();
  ctx.set("name", name);
};

const email = async (ctx: restate.RpcContext, event: restate.Event) => {
  // store in state the user's information as coming from the registeration event
  const { email } = event.json<{ email: string }>();
  ctx.set("email", email);
};

type UserProfile = {
  id: string;
  name: string;
  email: string;
};

const get = async (
  ctx: restate.RpcContext,
  id: string
): Promise<UserProfile> => {
  return {
    id,
    name: (await ctx.get<string>("name")) ?? "<no name yet>",
    email: (await ctx.get<string>("email")) ?? "<no email yet>",
  };
};

const profile = restate.keyedRouter({
  registration: restate.keyedEventHandler(registration),
  email: restate.keyedEventHandler(email),
  get,
});

// restate server
restate.createServer().bindKeyedRouter("profile", profile).listen(8080);


```