### PR TITLE
Fix keyed router type to wrongly identifies keyed handlers

### DIFF
--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -71,7 +71,7 @@ export type KeyedHandler<F> = F extends (ctx: RpcContext) => Promise<any>
   : never;
 
 export type KeyedRouterOpts<U> = {
-  [K in keyof U]: U[K] extends KeyedHandler<any> | KeyedEventHandler<U[K]>
+  [K in keyof U]: U[K] extends KeyedHandler<U[K]> | KeyedEventHandler<U[K]>
     ? U[K]
     : never;
 };
@@ -93,10 +93,11 @@ export const keyedRouter = <M>(opts: KeyedRouterOpts<M>): KeyedRouter<M> => {
 
 // ----------- event handlers ----------------------------------------------
 
-export type KeyedEventHandler<U> = U extends (
-  ctx: RpcContext,
-  event: Event
-) => Promise<void>
+export type KeyedEventHandler<U> = U extends () => Promise<void>
+  ? never
+  : U extends (ctx: RpcContext) => Promise<void>
+  ? never
+  : U extends (ctx: RpcContext, event: Event) => Promise<void>
   ? U
   : never;
 


### PR DESCRIPTION
### What 

Before this PR:
- `KeyedEventHandler< () => Promise<void> >` 
- `KeyedEventHandler< (ctx) => Promise<void> >` 
would typecheck successfully, (to them self instead of `never`)

While the expected behavior is that it would only type check for
`KeyedEventHandler< (ctx, event) => Promise<void> >`

This PR fixes this issue.

### Note 
This was detected by a compilation failure in the examples repository, as a followup, we'd look into connecting the examples and the sdk in the CI.