### PR TITLE
Minor logging changes

### DIFF
--- a/src/server/base_restate_server.ts
+++ b/src/server/base_restate_server.ts
@@ -150,7 +150,7 @@ export abstract class BaseRestateServer {
       );
       // note that this log will not print all the keys.
       rlog.info(
-        `Registering: ${url}  -> ${JSON.stringify(method, null, "\t")}`
+        `Binding: ${url}  -> ${JSON.stringify(method, null, "\t")}`
       );
     }
   }
@@ -264,7 +264,7 @@ export abstract class BaseRestateServer {
       ) as HostedGrpcServiceMethod<unknown, unknown>;
 
       rlog.info(
-        `Registering: ${url}  -> ${JSON.stringify(
+        `Binding: ${url}  -> ${JSON.stringify(
           registration.method,
           null,
           "\t"

--- a/src/server/restate_lambda_handler.ts
+++ b/src/server/restate_lambda_handler.ts
@@ -259,7 +259,7 @@ export class LambdaRestateServer extends BaseRestateServer {
   private handleDiscovery(): APIGatewayProxyResult | APIGatewayProxyResultV2 {
     // return discovery information
     rlog.info(
-      "Answering discovery request. Registering these services: " +
+      "Answering discovery request. Announcing services: " +
         JSON.stringify(this.discovery.services)
     );
     return {

--- a/src/server/restate_server.ts
+++ b/src/server/restate_server.ts
@@ -177,7 +177,7 @@ export class RestateServer extends BaseRestateServer {
     // no method under that name. might be a discovery request
     if (url.path == "/discover") {
       rlog.info(
-        "Answering discovery request. Registering these services: " +
+        "Answering discovery request. Announcing services: " +
           JSON.stringify(this.discovery.services)
       );
       await respondDiscovery(this.discovery, stream);


### PR DESCRIPTION
Minor logging changes

A few small logging changes to align better with how the server interacts with the SDK in some cases. The most notable is that when we discover services we don't always "register" them (in dry-run mode) so that SDK should just log that it's announcing those services instead. Additionally. Using the word "registering" in logs might confuse users as it's not registering those services to restate server but rather just binding those services on the open port.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/sdk-typescript/pull/225).
* #226
* __->__ #225