### PR TITLE
Awakeable identifiers following the new ID scheme

### DIFF
--- a/src/restate_context_impl.ts
+++ b/src/restate_context_impl.ts
@@ -28,6 +28,7 @@ import {
 } from "./generated/proto/protocol";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
+  AWAKEABLE_IDENTIFIER_PREFIX,
   BACKGROUND_INVOKE_ENTRY_MESSAGE_TYPE,
   CLEAR_STATE_ENTRY_MESSAGE_TYPE,
   COMPLETE_AWAKEABLE_ENTRY_MESSAGE_TYPE,
@@ -59,7 +60,7 @@ import {
 import { rlog } from "./utils/logger";
 import { Client, SendClient } from "./types/router";
 import { RpcRequest, RpcResponse } from "./generated/proto/dynrpc";
-import { requestFromArgs } from "./utils/assumpsions";
+import { requestFromArgs } from "./utils/assumptions";
 import { RandImpl } from "./utils/rand";
 
 export enum CallContexType {
@@ -364,7 +365,7 @@ export class RestateGrpcContextImpl implements RestateGrpcContext {
     );
 
     return {
-      id: Buffer.concat([this.id, encodedEntryIndex]).toString("base64url"),
+      id: AWAKEABLE_IDENTIFIER_PREFIX + Buffer.concat([this.id, encodedEntryIndex]).toString("base64url"),
       promise: promise,
     };
   }

--- a/src/server/base_restate_server.ts
+++ b/src/server/base_restate_server.ts
@@ -46,7 +46,7 @@ import {
 } from "../generated/proto/dynrpc";
 import { RestateContext, useContext } from "../restate_context";
 import { RpcContextImpl } from "../restate_context_impl";
-import { verifyAssumptions } from "../utils/assumpsions";
+import { verifyAssumptions } from "../utils/assumptions";
 import { TerminalError } from "../public_api";
 import { isEventHandler } from "../types/router";
 import { jsonSafeAny } from "../utils/utils";

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -67,6 +67,8 @@ export const BACKGROUND_INVOKE_ENTRY_MESSAGE_TYPE = 0x0c02n;
 export const AWAKEABLE_ENTRY_MESSAGE_TYPE = 0x0c03n;
 export const COMPLETE_AWAKEABLE_ENTRY_MESSAGE_TYPE = 0x0c04n;
 
+export const AWAKEABLE_IDENTIFIER_PREFIX = "prom_1";
+
 // Export the custom message types
 // Side effects are custom messages because the runtime does not need to inspect them
 export const SIDE_EFFECT_ENTRY_MESSAGE_TYPE = 0xfc01n;

--- a/src/utils/assumptions.ts
+++ b/src/utils/assumptions.ts
@@ -76,8 +76,8 @@ export const verifyAssumptions = (
   isKeyed: boolean,
   request: RpcRequest
 ): { key?: string; request?: JsType } => {
-  const assumpsion = request.senderAssumes ?? 0;
-  switch (assumpsion) {
+  const assumption = request.senderAssumes ?? 0;
+  switch (assumption) {
     case 0: {
       // no assumption: this comes from an ingress.
       const hasKeyProperty =
@@ -124,7 +124,7 @@ export const verifyAssumptions = (
     }
     default: {
       throw new TerminalError(
-        `Unknown assumption id ${assumpsion}. This indicates an incorrect (or involuntary) setting of the assumption property at the ingress request, or an SDK bug.`
+        `Unknown assumption id ${assumption}. This indicates an incorrect (or involuntary) setting of the assumption property at the ingress request, or an SDK bug.`
       );
     }
   }

--- a/test/protoutils.ts
+++ b/test/protoutils.ts
@@ -45,6 +45,7 @@ import {
   EntryAckMessage,
   END_MESSAGE_TYPE,
   EndMessage,
+  AWAKEABLE_IDENTIFIER_PREFIX,
 } from "../src/types/protocol";
 import { Message } from "../src/types/types";
 import { TestRequest, TestResponse } from "../src/generated/proto/test";
@@ -487,7 +488,7 @@ export function getAwakeableId(entryIndex: number): string {
   const encodedEntryIndex = Buffer.alloc(4 /* Size of u32 */);
   encodedEntryIndex.writeUInt32BE(entryIndex);
 
-  return Buffer.concat([
+  return AWAKEABLE_IDENTIFIER_PREFIX + Buffer.concat([
     Buffer.from("f311f1fdcb9863f0018bd3400ecd7d69b547204e776218b2", "hex"),
     encodedEntryIndex,
   ]).toString("base64url");


### PR DESCRIPTION
Awakeable identifiers following the new ID scheme


Bonus: `s/assumpsions/assumptions/`

Server side in https://github.com/restatedev/restate/pull/1120 

Test Plan:

Using sample code to generate an awakeable and resolved it with
```
curl localhost:8080/dev.restate.Awakeables/Resolve -H 'content-type: application/json' -d '{"id": "prom_1NMyOAvDK2CcBjUH4Rmb7eGBp0DNNDnmsAAAAAQ", "json_result": ""}'
```

```
[restate] [2024-01-25T18:54:01.682Z] DEBUG: [CheckoutProcess/checkout] [inv_13q6r7rhzaG85fs0bfyqW8cubIUYJFjvBT] : Resuming (replaying) function.
Awakeable is:  prom_1NMyOAvDK2CcBjUH4Rmb7eGBp0DNNDnmsAAAAAQ
Awakeable COMPLETED  prom_1NMyOAvDK2CcBjUH4Rmb7eGBp0DNNDnmsAAAAAQ
```
