### PR TITLE
Remove redundant buf setup action in testing workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Buf is anyways available as a dev dependency and works without any setup action.
(The release workflow doesn't have that action).