### PR TITLE
Properly pass RetrySettings parameter in the functional rpc API.

### DIFF
--- a/src/restate_context_impl.ts
+++ b/src/restate_context_impl.ts
@@ -596,8 +596,11 @@ export class RpcContextImpl implements RpcContext {
   public clear(name: string): void {
     this.ctx.clear(name);
   }
-  public sideEffect<T>(fn: () => Promise<T>): Promise<T> {
-    return this.ctx.sideEffect(fn);
+  public sideEffect<T>(
+    fn: () => Promise<T>,
+    retryPolicy?: RetrySettings
+  ): Promise<T> {
+    return this.ctx.sideEffect(fn, retryPolicy);
   }
   public awakeable<T>(): { id: string; promise: Promise<T> } {
     return this.ctx.awakeable();


### PR DESCRIPTION
Currently, the RPC handler API does not respect the `RetrySettings`, because it forgets to pass that optional parameter down to the underlying context.