### PR TITLE
Add `src/` directory to the restate-sdk package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "main": "dist/public_api.js",
   "types": "dist/public_api.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "proto": "npx buf mod update && npx buf generate",


### PR DESCRIPTION
This PR adds the `src/` directory to the list of files to be included in the `restate-sdk` package.

Running `npm pack` creates a tarball with the ./src directory included.

Note that, with this change, the bundle size is: 3,1M	
