### PR TITLE
Allow type narrowing on the service/object path when redeclared

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -523,24 +523,24 @@ export type RestateContext = ObjectContext;
  * ctx.rpc(myApi).someAction("hello!");
  * ```
  */
-export type ServiceApi<_M = unknown> = {
-  path: string;
+export type ServiceApi<_M = unknown, _P extends string = string> = {
+  path: _P;
 };
 
-export const serviceApi = <_M = unknown>(
-  path: string,
+export const serviceApi = <_M = unknown, _P extends string = string>(
+  path: _P,
   _m?: _M
-): ServiceApi<_M> => {
+): ServiceApi<_M, _P> => {
   return { path };
 };
 
-export const objectApi = <_M = unknown>(
-  path: string,
-  _m?: _M
-): ObjectApi<_M> => {
-  return { path };
+export type ObjectApi<_M = unknown, _P extends string = string> = {
+  path: _P;
 };
 
-export type ObjectApi<_M = unknown> = {
-  path: string;
+export const objectApi = <_M = unknown, _P extends string = string>(
+  path: _P,
+  _m?: _M
+): ObjectApi<_M, _P> => {
+  return { path };
 };


### PR DESCRIPTION
Current examples show how it's easy to import another serviceApi/objectApi (`{ path: 'some-path' }`) when another service/objects wants to send requests to it, e.g.
```ts
// serviceOne.ts
const serviceOne = restate.service({})
export const serviceOneApi = restate.serviceApi('one', serviceOne)

// serviceTwo.ts
import { serviceOneApi } from './serviceOne'

const serviceTwoHandler = async (cox: restate.Context) => {
  const serviceOne = ctx.service(serviceOneApi)
  // etc
}
```

However if serviceOne is not available (think Docker build contexts) when serviceTwo is being built, it won't be able to import the object and the transpiled code will be invalid. However, if it is still possible to import **_types_** at dev-time, then in this situation, a dev will likely reconstruct the object containing the path like so whilst retaining type inferences and it will compile and work correctly
```ts
// serviceOne.ts
const serviceOne = restate.service({})
export const serviceOneApi = restate.serviceApi('one', serviceOne)
export type ServiceOneApi = typeof serviceOneApi

// serviceTwo.ts
import { type ServiceOneApi } from '../../some-out-of-build-scope-path/serviceOne'

const serviceOneApi: ServiceOneApi = {
  path: 'one'
}

// etc
```

The only problem, is that the path string value can now literally be anything, and TS won't complain, you'll still see serviceOne's methods available to call, but it will fail at runtime because the path is incorrect

Therefore this PR supports type narrowing on the path that is provided in serviceOne so that the exported type `ServiceOneApi` enforces that the path MUST be `'one'` and will complain if you try and redeclare the string value as anything else

Keep point here is that concrete code imports are needed to exist at build/compile time, but type imports aren't

Hopefully this is all that is needed to support this change, I also did move the `ObjectApi` type declaration above the `objectApi` implementation to mimic the order that serviceApi has already

Used `_P` as already using `_M` syntax, P = path

Any feedback appreciated