### PR TITLE
Catch send/send delayed failed promises

### DIFF
--- a/src/endpoint/http2_handler.ts
+++ b/src/endpoint/http2_handler.ts
@@ -48,7 +48,7 @@ export class Http2Handler {
     });
   }
 
-  private handleConnection(
+  private async handleConnection(
     url: Url,
     stream: http2.ServerHttp2Stream
   ): Promise<void> {
@@ -76,7 +76,8 @@ export class Http2Handler {
       ":status": 200,
     });
     const restateStream = RestateHttp2Connection.from(stream);
-    return handleInvocation(handler, restateStream);
+    await handleInvocation(handler, restateStream);
+    return;
   }
 }
 

--- a/src/state_machine.ts
+++ b/src/state_machine.ts
@@ -623,6 +623,15 @@ export class StateMachine implements RestateStreamConsumer {
     this.unhandledError(e);
   }
 
+  public handleDanglingPromiseError(e: Error): void {
+    this.console.info(
+      "Aborting function execution and closing state machine due to an error: " +
+        e.message
+    );
+
+    this.unhandledError(e);
+  }
+
   public nextEntryWillBeReplayed() {
     return this.journal.nextEntryWillBeReplayed();
   }


### PR DESCRIPTION
Send/send delayed are `void` methods on our  API, but the reality is that these operations produce a promise, and this promise can actually fail. For example due to a non determinism errors. This commit makes sure to propagate errors happening in these promises back to the state machine.
See the e2e test called `test_non-determinism` in the e2e repo.