### PR TITLE
Remove the ServiceApi and ObjectApi abstractions

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -11,16 +11,16 @@
 
 import * as restate from "../src/public_api";
 
-const greeter = restate.service({
+const greeter = restate.service("greeter", {
   greet: async (ctx: restate.Context, name: string) => {
     // blocking RPC call to a keyed service (here supplying type and path separately)
-    const countSoFar = await ctx.object(counterApi, name).count();
+    const countSoFar = await ctx.object(Counter, name).count();
 
     const message = `Hello ${name}, for the ${countSoFar + 1}th time!`;
 
     // sending messages to ourselves, immediately and delayed
-    ctx.serviceSend(greeterApi).logger(message);
-    ctx.serviceSendDelayed(greeterApi, 100).logger("delayed " + message);
+    ctx.serviceSend(Greeter).logger(message);
+    ctx.serviceSendDelayed(Greeter, 100).logger("delayed " + message);
 
     return message;
   },
@@ -30,12 +30,16 @@ const greeter = restate.service({
   },
 });
 
+export type GreeterService = typeof greeter;
+const Greeter: GreeterService = { path: "greeter" };
+
 //
 // The stateful aux service that keeps the counts.
 // This could in principle be the same service as the greet service, we just separate
 // them here to have this multi-service setup for testing.
 //
-const counter = restate.object({
+
+const counter = restate.object("counter", {
   count: async (ctx: restate.ObjectContext): Promise<number> => {
     const seen = (await ctx.get<number>("seen")) ?? 0;
     ctx.set("seen", seen + 1);
@@ -43,13 +47,8 @@ const counter = restate.object({
   },
 });
 
-const greeterApi = restate.serviceApi("greeter", greeter);
-const counterApi = restate.objectApi("counter", counter);
-
+export type CounterObject = typeof counter;
+const Counter: CounterObject = { path: "counter" };
 // restate server
 
-restate
-  .endpoint()
-  .service(greeterApi.path, greeter)
-  .object(counterApi.path, counter)
-  .listen(9080);
+restate.endpoint().object(counter).service(greeter).listen(9080);

--- a/src/clients/workflow_client.ts
+++ b/src/clients/workflow_client.ts
@@ -74,8 +74,9 @@ export interface RestateClient {
     client: WorkflowClient<R, unknown>;
   }>;
 
-  submitWorkflow<R, T, U>(
-    workflowApi: restate.ServiceApi<
+  submitWorkflow<P extends string, R, T, U>(
+    workflowApi: restate.ServiceDefintion<
+      P,
       restate.workflow.WorkflowRestateRpcApi<R, T, U>
     >,
     workflowId: string,
@@ -93,8 +94,9 @@ export interface RestateClient {
     client: WorkflowClient<R, unknown>;
   }>;
 
-  connectToWorkflow<R, T, U>(
-    workflowApi: restate.ServiceApi<
+  connectToWorkflow<P extends string, R, T, U>(
+    workflowApi: restate.ServiceDefintion<
+      P,
       restate.workflow.WorkflowRestateRpcApi<R, T, U>
     >,
     workflowId: string
@@ -114,10 +116,13 @@ export interface RestateClient {
  */
 export function connect(restateUri: string): RestateClient {
   return {
-    submitWorkflow: async <R, T, U>(
+    submitWorkflow: async <P extends string, R, T, U>(
       pathOrApi:
         | string
-        | restate.ServiceApi<restate.workflow.WorkflowRestateRpcApi<R, T, U>>,
+        | restate.ServiceDefintion<
+            P,
+            restate.workflow.WorkflowRestateRpcApi<R, T, U>
+          >,
       workflowId: string,
       params: T
     ): Promise<{
@@ -142,10 +147,13 @@ export function connect(restateUri: string): RestateClient {
       };
     },
 
-    async connectToWorkflow<R, T, U>(
+    async connectToWorkflow<P extends string, R, T, U>(
       pathOrApi:
         | string
-        | restate.ServiceApi<restate.workflow.WorkflowRestateRpcApi<R, T, U>>,
+        | restate.ServiceDefintion<
+            P,
+            restate.workflow.WorkflowRestateRpcApi<R, T, U>
+          >,
       workflowId: string
     ): Promise<{
       status: restate.workflow.LifecycleStatus;

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,7 +10,12 @@
  */
 
 import { RetrySettings } from "./utils/public_utils";
-import { Client, SendClient } from "./types/rpc";
+import {
+  Client,
+  SendClient,
+  ServiceDefintion,
+  VirtualObjectDefintion,
+} from "./types/rpc";
 import { ContextImpl } from "./context_impl";
 
 /**
@@ -249,9 +254,12 @@ export interface Context {
    * const result2 = await ctx.rpc(myApi).anotherAction(1337);
    * ```
    */
-  service<M>(opts: ServiceApi<M>): Client<M>;
+  service<P extends string, M>(opts: ServiceDefintion<P, M>): Client<M>;
 
-  object<M>(opts: ObjectApi<M>, key: string): Client<M>;
+  object<P extends string, M>(
+    opts: VirtualObjectDefintion<P, M>,
+    key: string
+  ): Client<M>;
 
   /**
    * Makes a type-safe one-way RPC to the specified target service. This method effectively behaves
@@ -292,8 +300,11 @@ export interface Context {
    * ctx.send(myApi).anotherAction(1337);
    * ```
    */
-  objectSend<M>(opts: ObjectApi<M>, key: string): SendClient<M>;
-  serviceSend<M>(opts: ServiceApi<M>): SendClient<M>;
+  objectSend<P extends string, M>(
+    opts: VirtualObjectDefintion<P, M>,
+    key: string
+  ): SendClient<M>;
+  serviceSend<P extends string, M>(opts: ServiceDefintion<P, M>): SendClient<M>;
 
   /**
    * Makes a type-safe one-way RPC to the specified target service, after a delay specified by the
@@ -340,12 +351,15 @@ export interface Context {
    * ctx.sendDelayed(myApi, 60_000).anotherAction(1337);
    * ```
    */
-  objectSendDelayed<M>(
-    opts: ObjectApi<M>,
+  objectSendDelayed<P extends string, M>(
+    opts: VirtualObjectDefintion<P, M>,
     delay: number,
     key: string
   ): SendClient<M>;
-  serviceSendDelayed<M>(opts: ServiceApi<M>, delay: number): SendClient<M>;
+  serviceSendDelayed<P extends string, M>(
+    opts: ServiceDefintion<P, M>,
+    delay: number
+  ): SendClient<M>;
 }
 
 /**
@@ -495,52 +509,3 @@ export const CombineablePromise = {
  * @deprecated use {@link ObjectContext}.
  */
 export type RestateContext = ObjectContext;
-
-// ----------------------------------------------------------------------------
-//  types for the rpc-handler-based API
-// ----------------------------------------------------------------------------
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-/**
- * ServiceApi captures the type and parameters to make RPC calls and send messages to
- * a set of RPC handlers in a router.
- *
- * @example
- * **Service Side:**
- * ```ts
- * const router = restate.router({
- *   someAction:    async(ctx: restate.RpcContext, req: string) => { ... },
- *   anotherAction: async(ctx: restate.RpcContext, count: number) => { ... }
- * });
- *
- * export const myApi: restate.ServiceApi<typeof router> = { path : "myservice" };
- *
- * restate.createServer().bindRouter("myservice", router).listen(9080);
- * ```
- * **Client side:**
- * ```ts
- * ctx.rpc(myApi).someAction("hello!");
- * ```
- */
-export type ServiceApi<_M = unknown, _P extends string = string> = {
-  path: _P;
-};
-
-export const serviceApi = <_M = unknown, _P extends string = string>(
-  path: _P,
-  _m?: _M
-): ServiceApi<_M, _P> => {
-  return { path };
-};
-
-export type ObjectApi<_M = unknown, _P extends string = string> = {
-  path: _P;
-};
-
-export const objectApi = <_M = unknown, _P extends string = string>(
-  path: _P,
-  _m?: _M
-): ObjectApi<_M, _P> => {
-  return { path };
-};

--- a/src/context_impl.ts
+++ b/src/context_impl.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { CombineablePromise, ObjectContext, Rand, ServiceApi } from "./context";
+import { CombineablePromise, ObjectContext, Rand } from "./context";
 import { StateMachine } from "./state_machine";
 import {
   AwakeableEntryMessage,
@@ -56,7 +56,7 @@ import {
   EXPONENTIAL_BACKOFF,
   RetrySettings,
 } from "./utils/public_utils";
-import { Client, SendClient } from "./types/rpc";
+import { Client, SendClient, ServiceDefintion } from "./types/rpc";
 import { RandImpl } from "./utils/rand";
 import { newJournalEntryPromiseId } from "./promise_combinator_tracker";
 import { WrappedPromise } from "./utils/promises";
@@ -247,7 +247,7 @@ export class ContextImpl implements ObjectContext {
     return new Uint8Array();
   }
 
-  service<M>({ path }: ServiceApi<M>): Client<M> {
+  service<P extends string, M>({ path }: ServiceDefintion<P, M>): Client<M> {
     const clientProxy = new Proxy(
       {},
       {
@@ -266,7 +266,10 @@ export class ContextImpl implements ObjectContext {
     return clientProxy as Client<M>;
   }
 
-  object<M>({ path }: ServiceApi<M>, key: string): Client<M> {
+  object<P extends string, M>(
+    { path }: ServiceDefintion<P, M>,
+    key: string
+  ): Client<M> {
     const clientProxy = new Proxy(
       {},
       {
@@ -285,12 +288,14 @@ export class ContextImpl implements ObjectContext {
     return clientProxy as Client<M>;
   }
 
-  public serviceSend<M>(options: ServiceApi): SendClient<M> {
+  public serviceSend<P extends string, M>(
+    options: ServiceDefintion<P, M>
+  ): SendClient<M> {
     return this.serviceSendDelayed(options, 0);
   }
 
-  public serviceSendDelayed<M>(
-    { path }: ServiceApi,
+  public serviceSendDelayed<P extends string, M>(
+    { path }: ServiceDefintion<P, M>,
     delayMillis: number
   ): SendClient<M> {
     const clientProxy = new Proxy(
@@ -313,12 +318,15 @@ export class ContextImpl implements ObjectContext {
     return clientProxy as SendClient<M>;
   }
 
-  public objectSend<M>(options: ServiceApi, key: string): SendClient<M> {
+  public objectSend<P extends string, M>(
+    options: ServiceDefintion<P, M>,
+    key: string
+  ): SendClient<M> {
     return this.objectSendDelayed(options, 0, key);
   }
 
-  public objectSendDelayed<M>(
-    { path }: ServiceApi,
+  public objectSendDelayed<P extends string, M>(
+    { path }: ServiceDefintion<P, M>,
     delayMillis: number,
     key: string
   ): SendClient<M> {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { VirtualObject, Service } from "./types/rpc";
+import { VirtualObjectDefintion, ServiceDefintion } from "./types/rpc";
 import { Http2ServerRequest, Http2ServerResponse } from "http2";
 import { EndpointImpl } from "./endpoint/endpoint_impl";
 
@@ -75,7 +75,9 @@ export interface RestateEndpoint {
    * If the path is 'acme.myservice' and the router has '{ foo, bar }' as properties, the
    * Restate will expose the RPC paths '/acme.myservice/foo' and '/acme.myservice/bar'.
    */
-  service<M>(path: string, service: Service<M>): RestateEndpoint;
+  service<P extends string, M>(
+    service: ServiceDefintion<P, M>
+  ): RestateEndpoint;
 
   /**
    * Binds a new stateful keyed durable RPC service to the given path.
@@ -86,7 +88,9 @@ export interface RestateEndpoint {
    * If the path is 'acme.myservice' and the router has '{ foo, bar }' as properties, the
    * Restate will expose the RPC paths '/acme.myservice/foo' and '/acme.myservice/bar'.
    */
-  object<M>(path: string, virtualObject: VirtualObject<M>): RestateEndpoint;
+  object<P extends string, M>(
+    virtualObject: VirtualObjectDefintion<P, M>
+  ): RestateEndpoint;
 
   /**
    * Adds one or more services to this endpoint. This will call the

--- a/src/endpoint/endpoint_impl.ts
+++ b/src/endpoint/endpoint_impl.ts
@@ -12,7 +12,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { RestateEndpoint, ServiceBundle } from "../public_api";
-import { VirtualObject, Service } from "../types/rpc";
+import { ServiceDefintion, VirtualObjectDefintion } from "../types/rpc";
 import { rlog } from "../logger";
 import http2, { Http2ServerRequest, Http2ServerResponse } from "http2";
 import { Http2Handler } from "./http2_handler";
@@ -22,7 +22,7 @@ import {
   ServiceComponent,
   ServiceHandlerFunction,
   VirtualObjectHandlerFunction,
-  VritualObjectComponent as VritualObjectComponent,
+  VritualObjectComponent,
 } from "../types/components";
 
 import * as discovery from "../types/discovery";
@@ -38,13 +38,25 @@ export class EndpointImpl implements RestateEndpoint {
     this.components.set(component.name(), component);
   }
 
-  public service<M>(path: string, router: Service<M>): RestateEndpoint {
-    this.bindServiceComponent(path, router);
+  public service<P extends string, M>(
+    defintion: ServiceDefintion<P, M>
+  ): RestateEndpoint {
+    const { path, service } = defintion;
+    if (!service) {
+      throw new TypeError(`no service implemention found.`);
+    }
+    this.bindServiceComponent(path, service);
     return this;
   }
 
-  public object<M>(path: string, router: VirtualObject<M>): RestateEndpoint {
-    this.bindVirtualObjectComponent(path, router);
+  public object<P extends string, M>(
+    defintion: VirtualObjectDefintion<P, M>
+  ): RestateEndpoint {
+    const { path, object } = defintion;
+    if (!object) {
+      throw new TypeError(`no object implemention found.`);
+    }
+    this.bindVirtualObjectComponent(path, object);
     return this;
   }
 

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -13,10 +13,6 @@ export {
   RestateContext,
   Context,
   ObjectContext,
-  ServiceApi,
-  ObjectApi,
-  serviceApi,
-  objectApi,
   CombineablePromise,
   Rand,
 } from "./context";
@@ -24,7 +20,9 @@ export {
   service,
   object,
   Service,
+  ServiceDefintion,
   VirtualObject,
+  VirtualObjectDefintion,
   Client,
   SendClient,
 } from "./types/rpc";

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -56,11 +56,19 @@ export type Service<U> = {
     : never;
 };
 
-export const service = <M>(opts: ServiceOpts<M>): Service<M> => {
+export type ServiceDefintion<P extends string, M> = {
+  path: P;
+  service?: Service<M>;
+};
+
+export const service = <P extends string, M>(
+  path: P,
+  opts: ServiceOpts<M>
+): ServiceDefintion<P, Service<M>> => {
   if (opts === undefined || opts === null) {
     throw new Error("service must be defined");
   }
-  return opts as Service<M>;
+  return { path, service: opts as Service<M> };
 };
 
 // ----------- keyed handlers ----------------------------------------------
@@ -84,9 +92,17 @@ export type VirtualObject<U> = {
     : never;
 };
 
-export const object = <M>(opts: ObjectOpts<M>): VirtualObject<M> => {
+export type VirtualObjectDefintion<P extends string, M> = {
+  path: P;
+  object?: VirtualObject<M>;
+};
+
+export const object = <P extends string, M>(
+  path: P,
+  opts: ObjectOpts<M>
+): VirtualObjectDefintion<P, VirtualObject<M>> => {
   if (opts === undefined || opts === null) {
     throw new Error("object options must be defined");
   }
-  return opts as VirtualObject<M>;
+  return { path, object: opts as VirtualObject<M> };
 };

--- a/src/workflows/workflow_state_service.ts
+++ b/src/workflows/workflow_state_service.ts
@@ -24,7 +24,12 @@ export type ValueOrError<T> = {
   error?: string;
 };
 
-export const workflowStateService = restate.object({
+export type api<P extends string> = restate.VirtualObjectDefintion<
+  P,
+  restate.VirtualObject<typeof workflowStateService>
+>;
+
+export const workflowStateService = {
   startWorkflow: async (
     ctx: restate.ObjectContext
   ): Promise<WorkflowStartResult> => {
@@ -196,9 +201,7 @@ export const workflowStateService = restate.object({
   dispose: async (ctx: restate.ObjectContext): Promise<void> => {
     ctx.clearAll();
   },
-});
-
-export type api = typeof workflowStateService;
+};
 
 // ----------------------------------------------------------------------------
 

--- a/test/lambda.test.ts
+++ b/test/lambda.test.ts
@@ -227,8 +227,7 @@ function getTestHandler() {
   return restate
     .endpoint()
     .object(
-      "greeter",
-      restate.object({
+      restate.object("greeter", {
         // eslint-disable @typescript-eslint/no-unused-vars
         greet: (ctx: restate.ObjectContext) =>
           new LambdaGreeter().greet(ctx /*req*/),

--- a/test/testdriver.ts
+++ b/test/testdriver.ts
@@ -22,8 +22,8 @@ import { rlog } from "../src/logger";
 import { StateMachine } from "../src/state_machine";
 import { InvocationBuilder } from "../src/invocation";
 import { EndpointImpl } from "../src/endpoint/endpoint_impl";
-import { ObjectContext, ServiceApi } from "../src/context";
-import { object } from "../src/public_api";
+import { ObjectContext } from "../src/context";
+import { ServiceDefintion, object } from "../src/public_api";
 import { ProtocolMode } from "../src/types/discovery";
 
 export type TestRequest = {
@@ -42,7 +42,9 @@ export type GreetType = {
   greet: (key: string, arg: TestRequest) => Promise<TestResponse>;
 };
 
-export const GreeterApi: ServiceApi<GreetType> = { path: "greeter" };
+export const GreeterApi: ServiceDefintion<"greeter", GreetType> = {
+  path: "greeter",
+};
 
 export interface TestGreeter {
   greet(ctx: ObjectContext, message: TestRequest): Promise<TestResponse>;
@@ -62,13 +64,13 @@ export class TestDriver implements Connection {
   ) {
     this.restateServer = new TestRestateServer();
 
-    const svc = object({
+    const svc = object("greeter", {
       greet: async (ctx: ObjectContext, arg: TestRequest) => {
         return instance.greet(ctx, arg);
       },
     });
 
-    this.restateServer.object(GreeterApi.path, svc);
+    this.restateServer.object(svc);
 
     if (entries.length < 2) {
       throw new Error(


### PR DESCRIPTION
This commit removes the previously introduced `ServiceApi` and `ObjectApi` types. With this commit applied, we no longer need a special concept, but simply import the typeof the Service/Object.


`a.ts`:

```ts

const greeter = restate.service("greeter", {
  greet: async (ctx: restate.Context, name: string) => {
    return message;
  },

});

export type GreeterService = typeof greeter;

```

`b.ts`

```ts

import type {GreeterService} from 'a.ts';
...
const Greeter: GreeterService = { path: "greeter" };
ctx.service(Greeter).greet("hello");
...
```