### PR TITLE
Add context.date 

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -96,6 +96,17 @@ export interface KeyValueStore {
   clearAll(): void;
 }
 
+export interface ContextDate {
+  /** Returns the number of milliseconds elapsed since midnight, January 1, 1970 Universal Coordinated Time (UTC).
+   *  This is equivalent to Date.now()
+   */
+  now(): Promise<number>;
+  /** Returns the JSON represention of the current date.
+   * This is equivalent to new Date().toJSON()
+   **/
+  toJSON(): Promise<string>;
+}
+
 /**
  * The context that gives access to all Restate-backed operations, for example
  *   - sending reliable messages / RPC through Restate
@@ -124,6 +135,11 @@ export interface Context {
    * such as invoked service method and invocation id, and automatically excludes logs during replay.
    */
   console: Console;
+
+  /**
+   * Deterministic date.
+   */
+  date: ContextDate;
 
   /**
    * Execute a side effect and store the result in Restate. The side effect will thus not

--- a/src/context_impl.ts
+++ b/src/context_impl.ts
@@ -9,7 +9,13 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { CombineablePromise, ObjectContext, Rand, Request } from "./context";
+import {
+  CombineablePromise,
+  ContextDate,
+  ObjectContext,
+  Rand,
+  Request,
+} from "./context";
 import { StateMachine } from "./state_machine";
 import {
   AwakeableEntryMessage,
@@ -92,6 +98,16 @@ export class ContextImpl implements ObjectContext {
   // See https://github.com/restatedev/sdk-typescript/issues/197 for more details.
   private executingSideEffect = false;
   private readonly invocationRequest: Request;
+
+  public readonly date: ContextDate = {
+    now: (): Promise<number> => {
+      return this.sideEffect(async () => Date.now());
+    },
+
+    toJSON: (): Promise<string> => {
+      return this.sideEffect(async () => new Date().toJSON());
+    },
+  };
 
   constructor(
     id: Buffer,

--- a/src/workflows/workflow_wrapper_service.ts
+++ b/src/workflows/workflow_wrapper_service.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { Request } from "../context";
+import { ContextDate, Request } from "../context";
 import * as restate from "../public_api";
 import * as wf from "./workflow";
 import * as wss from "./workflow_state_service";
@@ -97,12 +97,15 @@ class ExclusiveContextImpl<P extends string>
 {
   public readonly rand: restate.Rand;
   public readonly console: Console;
+  public readonly date: ContextDate;
 
   constructor(ctx: restate.Context, wfId: string, stateServiceApi: wss.api<P>) {
     super(ctx, wfId, stateServiceApi);
     this.rand = ctx.rand;
     this.console = ctx.console;
+    this.date = ctx.date;
   }
+
   request(): Request {
     return this.ctx.request();
   }


### PR DESCRIPTION
This PR adds a new deterministic date to the context.

```ts
ctx.date.now() -> is the unix epoch time

ctx.date.toJSON() -> is the JSON representation of the current time 

```