### PR TITLE
Fix definition typo

### DIFF
--- a/src/clients/ingress.ts
+++ b/src/clients/ingress.ts
@@ -9,23 +9,23 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { ServiceDefintion, VirtualObjectDefintion } from "../public_api";
+import { ServiceDefinition, VirtualObjectDefinition } from "../public_api";
 import { deserializeJson, serializeJson } from "../utils/serde";
 
 export interface Ingress {
   serviceClient<P extends string, M>(
-    opts: ServiceDefintion<P, M>
+    opts: ServiceDefinition<P, M>
   ): IngressClient<M>;
   objectClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     key: string
   ): IngressClient<M>;
   objectSendClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     key: string
   ): IngressSendClient<M>;
   serviceSendClient<P extends string, M>(
-    opts: ServiceDefintion<P, M>
+    opts: ServiceDefinition<P, M>
   ): IngressSendClient<M>;
 
   /**
@@ -228,27 +228,27 @@ export class HttpIngress implements Ingress {
   }
 
   serviceClient<P extends string, M>(
-    opts: ServiceDefintion<P, M>
+    opts: ServiceDefinition<P, M>
   ): IngressClient<M> {
     return this.proxy(opts.name) as IngressClient<M>;
   }
 
   objectClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     key: string
   ): IngressClient<M> {
     return this.proxy(opts.name, key) as IngressClient<M>;
   }
 
   objectSendClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     key: string
   ): IngressSendClient<M> {
     return this.proxy(opts.name, key, true) as IngressSendClient<M>;
   }
 
   serviceSendClient<P extends string, M>(
-    opts: ServiceDefintion<P, M>
+    opts: ServiceDefinition<P, M>
   ): IngressSendClient<M> {
     return this.proxy(opts.name, undefined, true) as IngressSendClient<M>;
   }

--- a/src/clients/workflow_client.ts
+++ b/src/clients/workflow_client.ts
@@ -75,7 +75,7 @@ export interface RestateClient {
   }>;
 
   submitWorkflow<P extends string, R, T, U>(
-    workflowApi: restate.ServiceDefintion<
+    workflowApi: restate.ServiceDefinition<
       P,
       restate.workflow.WorkflowRestateRpcApi<R, T, U>
     >,
@@ -95,7 +95,7 @@ export interface RestateClient {
   }>;
 
   connectToWorkflow<P extends string, R, T, U>(
-    workflowApi: restate.ServiceDefintion<
+    workflowApi: restate.ServiceDefinition<
       P,
       restate.workflow.WorkflowRestateRpcApi<R, T, U>
     >,
@@ -119,7 +119,7 @@ export function connect(restateUri: string): RestateClient {
     submitWorkflow: async <P extends string, R, T, U>(
       pathOrApi:
         | string
-        | restate.ServiceDefintion<
+        | restate.ServiceDefinition<
             P,
             restate.workflow.WorkflowRestateRpcApi<R, T, U>
           >,
@@ -150,7 +150,7 @@ export function connect(restateUri: string): RestateClient {
     async connectToWorkflow<P extends string, R, T, U>(
       pathOrApi:
         | string
-        | restate.ServiceDefintion<
+        | restate.ServiceDefinition<
             P,
             restate.workflow.WorkflowRestateRpcApi<R, T, U>
           >,

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,8 +12,8 @@
 import {
   Client,
   SendClient,
-  ServiceDefintion,
-  VirtualObjectDefintion,
+  ServiceDefinition,
+  VirtualObjectDefinition,
 } from "./types/rpc";
 import { ContextImpl } from "./context_impl";
 
@@ -276,10 +276,10 @@ export interface Context {
    * const result2 = await ctx.rpc(myApi).anotherAction(1337);
    * ```
    */
-  serviceClient<P extends string, M>(opts: ServiceDefintion<P, M>): Client<M>;
+  serviceClient<P extends string, M>(opts: ServiceDefinition<P, M>): Client<M>;
 
   objectClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     key: string
   ): Client<M>;
 
@@ -323,11 +323,11 @@ export interface Context {
    * ```
    */
   objectSendClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     key: string
   ): SendClient<M>;
   serviceSendClient<P extends string, M>(
-    opts: ServiceDefintion<P, M>
+    opts: ServiceDefinition<P, M>
   ): SendClient<M>;
 
   /**
@@ -376,13 +376,13 @@ export interface Context {
    * ```
    */
   objectSendDelayedClient<P extends string, M>(
-    opts: VirtualObjectDefintion<P, M>,
+    opts: VirtualObjectDefinition<P, M>,
     delay: number,
     key: string
   ): SendClient<M>;
 
   serviceSendDelayedClient<P extends string, M>(
-    opts: ServiceDefintion<P, M>,
+    opts: ServiceDefinition<P, M>,
     delay: number
   ): SendClient<M>;
 

--- a/src/context_impl.ts
+++ b/src/context_impl.ts
@@ -55,7 +55,7 @@ import {
 } from "./types/errors";
 import { jsonSerialize, jsonDeserialize } from "./utils/utils";
 import { PartialMessage, protoInt64 } from "@bufbuild/protobuf";
-import { Client, SendClient, ServiceDefintion } from "./types/rpc";
+import { Client, SendClient, ServiceDefinition } from "./types/rpc";
 import { RandImpl } from "./utils/rand";
 import { newJournalEntryPromiseId } from "./promise_combinator_tracker";
 import { WrappedPromise } from "./utils/promises";
@@ -271,7 +271,7 @@ export class ContextImpl implements ObjectContext {
 
   serviceClient<P extends string, M>({
     name,
-  }: ServiceDefintion<P, M>): Client<M> {
+  }: ServiceDefinition<P, M>): Client<M> {
     const clientProxy = new Proxy(
       {},
       {
@@ -291,7 +291,7 @@ export class ContextImpl implements ObjectContext {
   }
 
   objectClient<P extends string, M>(
-    { name }: ServiceDefintion<P, M>,
+    { name }: ServiceDefinition<P, M>,
     key: string
   ): Client<M> {
     const clientProxy = new Proxy(
@@ -313,13 +313,13 @@ export class ContextImpl implements ObjectContext {
   }
 
   public serviceSendClient<P extends string, M>(
-    options: ServiceDefintion<P, M>
+    options: ServiceDefinition<P, M>
   ): SendClient<M> {
     return this.serviceSendDelayedClient(options, 0);
   }
 
   public serviceSendDelayedClient<P extends string, M>(
-    { name }: ServiceDefintion<P, M>,
+    { name }: ServiceDefinition<P, M>,
     delayMillis: number
   ): SendClient<M> {
     const clientProxy = new Proxy(
@@ -343,14 +343,14 @@ export class ContextImpl implements ObjectContext {
   }
 
   public objectSendClient<P extends string, M>(
-    options: ServiceDefintion<P, M>,
+    options: ServiceDefinition<P, M>,
     key: string
   ): SendClient<M> {
     return this.objectSendDelayedClient(options, 0, key);
   }
 
   public objectSendDelayedClient<P extends string, M>(
-    { name }: ServiceDefintion<P, M>,
+    { name }: ServiceDefinition<P, M>,
     delayMillis: number,
     key: string
   ): SendClient<M> {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { VirtualObjectDefintion, ServiceDefintion } from "./types/rpc";
+import { VirtualObjectDefinition, ServiceDefinition } from "./types/rpc";
 import { Http2ServerRequest, Http2ServerResponse } from "http2";
 import { EndpointImpl } from "./endpoint/endpoint_impl";
 
@@ -71,7 +71,7 @@ export interface RestateEndpoint {
    * Binds a new durable RPC service / virtual object.
    **/
   bind<P extends string, M>(
-    service: ServiceDefintion<P, M> | VirtualObjectDefintion<P, M>
+    service: ServiceDefinition<P, M> | VirtualObjectDefinition<P, M>
   ): RestateEndpoint;
 
   /**

--- a/src/endpoint/endpoint_impl.ts
+++ b/src/endpoint/endpoint_impl.ts
@@ -13,7 +13,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { RestateEndpoint, ServiceBundle } from "../public_api";
-import { ServiceDefintion, VirtualObjectDefintion } from "../types/rpc";
+import { ServiceDefinition, VirtualObjectDefinition } from "../types/rpc";
 import { rlog } from "../logger";
 import http2, { Http2ServerRequest, Http2ServerResponse } from "http2";
 import { Http2Handler } from "./http2_handler";
@@ -28,15 +28,15 @@ import {
 
 import * as discovery from "../types/discovery";
 
-function isServiceDefintion<P extends string, M>(
+function isServiceDefinition<P extends string, M>(
   m: any
-): m is ServiceDefintion<P, M> {
+): m is ServiceDefinition<P, M> {
   return m && m.service;
 }
 
-function isObjectDefintion<P extends string, M>(
+function isObjectDefinition<P extends string, M>(
   m: any
-): m is VirtualObjectDefintion<P, M> {
+): m is VirtualObjectDefinition<P, M> {
   return m && m.object;
 }
 
@@ -57,16 +57,16 @@ export class EndpointImpl implements RestateEndpoint {
   }
 
   public bind<P extends string, M>(
-    defintion: ServiceDefintion<P, M> | VirtualObjectDefintion<P, M>
+    definition: ServiceDefinition<P, M> | VirtualObjectDefinition<P, M>
   ): RestateEndpoint {
-    if (isServiceDefintion(defintion)) {
-      const { name, service } = defintion;
+    if (isServiceDefinition(definition)) {
+      const { name, service } = definition;
       if (!service) {
         throw new TypeError(`no service implemention found.`);
       }
       this.bindServiceComponent(name, service);
-    } else if (isObjectDefintion(defintion)) {
-      const { name, object } = defintion;
+    } else if (isObjectDefinition(definition)) {
+      const { name, object } = definition;
       if (!object) {
         throw new TypeError(`no object implemention found.`);
       }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -20,9 +20,9 @@ export {
   service,
   object,
   Service,
-  ServiceDefintion,
+  ServiceDefinition,
   VirtualObject,
-  VirtualObjectDefintion,
+  VirtualObjectDefinition,
   Client,
   SendClient,
 } from "./types/rpc";

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -56,7 +56,7 @@ export type Service<U> = {
     : never;
 };
 
-export type ServiceDefintion<P extends string, M> = {
+export type ServiceDefinition<P extends string, M> = {
   name: P;
   service?: Service<M>;
 };
@@ -64,7 +64,7 @@ export type ServiceDefintion<P extends string, M> = {
 export const service = <P extends string, M>(service: {
   name: P;
   handlers: ServiceOpts<M>;
-}): ServiceDefintion<P, Service<M>> => {
+}): ServiceDefinition<P, Service<M>> => {
   if (!service.handlers) {
     throw new Error("service must be defined");
   }
@@ -92,7 +92,7 @@ export type VirtualObject<U> = {
     : never;
 };
 
-export type VirtualObjectDefintion<P extends string, M> = {
+export type VirtualObjectDefinition<P extends string, M> = {
   name: P;
   object?: VirtualObject<M>;
 };
@@ -100,7 +100,7 @@ export type VirtualObjectDefintion<P extends string, M> = {
 export const object = <P extends string, M>(object: {
   name: P;
   handlers: ObjectOpts<M>;
-}): VirtualObjectDefintion<P, VirtualObject<M>> => {
+}): VirtualObjectDefinition<P, VirtualObject<M>> => {
   if (!object.handlers) {
     throw new Error("object options must be defined");
   }

--- a/src/workflows/workflow.ts
+++ b/src/workflows/workflow.ts
@@ -47,7 +47,7 @@ export function workflow<P extends string, R, T, U>(
   );
 
   return {
-    api: { name } as restate.ServiceDefintion<
+    api: { name } as restate.ServiceDefinition<
       P,
       WorkflowRestateRpcApi<R, T, U>
     >,
@@ -99,7 +99,7 @@ type WorkflowMethods<R, T, U> = {
  */
 export interface WorkflowServices<P extends string, R, T, U>
   extends restate.ServiceBundle {
-  readonly api: restate.ServiceDefintion<P, WorkflowRestateRpcApi<R, T, U>>;
+  readonly api: restate.ServiceDefinition<P, WorkflowRestateRpcApi<R, T, U>>;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/workflows/workflow_state_service.ts
+++ b/src/workflows/workflow_state_service.ts
@@ -24,7 +24,7 @@ export type ValueOrError<T> = {
   error?: string;
 };
 
-export type api<P extends string> = restate.VirtualObjectDefintion<
+export type api<P extends string> = restate.VirtualObjectDefinition<
   P,
   restate.VirtualObject<typeof workflowStateService>
 >;

--- a/src/workflows/workflow_wrapper_service.ts
+++ b/src/workflows/workflow_wrapper_service.ts
@@ -164,36 +164,36 @@ class ExclusiveContextImpl<P extends string>
   }
 
   serviceClient<P extends string, M>(
-    opts: restate.ServiceDefintion<P, M>
+    opts: restate.ServiceDefinition<P, M>
   ): restate.Client<M> {
     return this.ctx.serviceClient(opts);
   }
   objectClient<P extends string, M>(
-    opts: restate.ServiceDefintion<P, M>,
+    opts: restate.ServiceDefinition<P, M>,
     key: string
   ): restate.Client<M> {
     return this.ctx.objectClient(opts, key);
   }
   objectSendClient<P extends string, M>(
-    opts: restate.ServiceDefintion<P, M>,
+    opts: restate.ServiceDefinition<P, M>,
     key: string
   ): restate.SendClient<M> {
     return this.ctx.objectSendClient(opts, key);
   }
   serviceSendClient<P extends string, M>(
-    opts: restate.ServiceDefintion<P, M>
+    opts: restate.ServiceDefinition<P, M>
   ): restate.SendClient<M> {
     return this.ctx.serviceSendClient(opts);
   }
   objectSendDelayedClient<P extends string, M>(
-    opts: restate.ServiceDefintion<P, M>,
+    opts: restate.ServiceDefinition<P, M>,
     delay: number,
     key: string
   ): restate.SendClient<M> {
     return this.ctx.objectSendDelayedClient(opts, delay, key);
   }
   serviceSendDelayedClient<P extends string, M>(
-    opts: restate.ServiceDefintion<P, M>,
+    opts: restate.ServiceDefinition<P, M>,
     delay: number
   ): restate.SendClient<M> {
     return this.ctx.serviceSendDelayedClient(opts, delay);

--- a/test/testdriver.ts
+++ b/test/testdriver.ts
@@ -23,7 +23,7 @@ import { StateMachine } from "../src/state_machine";
 import { InvocationBuilder } from "../src/invocation";
 import { EndpointImpl } from "../src/endpoint/endpoint_impl";
 import { ObjectContext } from "../src/context";
-import { ServiceDefintion, object } from "../src/public_api";
+import { ServiceDefinition, object } from "../src/public_api";
 import { ProtocolMode } from "../src/types/discovery";
 
 export type TestRequest = {
@@ -42,7 +42,7 @@ export type GreetType = {
   greet: (key: string, arg: TestRequest) => Promise<TestResponse>;
 };
 
-export const GreeterApi: ServiceDefintion<"greeter", GreetType> = {
+export const GreeterApi: ServiceDefinition<"greeter", GreetType> = {
   name: "greeter",
 };
 


### PR DESCRIPTION
Noticed this minor typo whilst checking some TS type implementations

Resolved with a case-sensitive find and replace on both `defintion` and `Defintion`