### PR TITLE
[endpoint] Return a promise that resolves/reject on listen().

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -111,8 +111,9 @@ export interface RestateEndpoint {
    * If you need to manually control the server lifecycle, we suggest to manually instantiate the http2 server and use {@link http2Handler}.
    *
    * @param port The port to listen at. May be undefined (see above).
+   * @returns a Promise that resolves with the bound port, or rejects with a failure otherwise.
    */
-  listen(port?: number): Promise<void>;
+  listen(port?: number): Promise<number>;
 
   /**
    * Returns an http2 server handler. See {@link listen} for more details.

--- a/src/endpoint/endpoint_impl.ts
+++ b/src/endpoint/endpoint_impl.ts
@@ -93,7 +93,7 @@ export class EndpointImpl implements RestateEndpoint {
     return handler.handleRequest.bind(handler);
   }
 
-  listen(port?: number): Promise<void> {
+  listen(port?: number): Promise<number> {
     const actualPort = port ?? parseInt(process.env.PORT ?? "9080");
     rlog.info(`Listening on ${actualPort}...`);
 
@@ -106,8 +106,18 @@ export class EndpointImpl implements RestateEndpoint {
         reject(e);
       });
       server.listen(actualPort, () => {
-        if (!failed) {
-          resolve();
+        if (failed) {
+          return;
+        }
+        const address = server.address();
+        if (address === null || typeof address === "string") {
+          reject(
+            new TypeError(
+              "endpoint.listen() currently supports only binding to a PORT"
+            )
+          );
+        } else {
+          resolve(address.port);
         }
       });
     });


### PR DESCRIPTION
This PR makes sure that the returned promise from endpoint.listen() resolves whenever the server is successfully listening on the provided port. Otherwise reject with the first error.