### PR TITLE
[ingress] SendClient now returns a Promise of an invocationId

### DIFF
--- a/src/clients/ingress.ts
+++ b/src/clients/ingress.ts
@@ -83,7 +83,7 @@ export type IngressSendClient<M> = {
   [K in keyof M as M[K] extends never ? never : K]: M[K] extends (
     ...args: infer P
   ) => unknown
-    ? (...args: [...P, ...[opts?: Opts]]) => void
+    ? (...args: [...P, ...[opts?: Opts]]) => Promise<{ invocationId: string }>
     : never;
 };
 


### PR DESCRIPTION
This PR changes the return signature of the `IngressSendClient` to:
a. be a Promise instead of a void. Unlike the internal `SendClient`, the ingress is doing a blocking operation.
b. return the `invocationId` to the user, to further inspect/interact with the request.