### PR TITLE
[context] Use function overloading for ctx.run()

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -143,13 +143,7 @@ export interface ContextDate {
   toJSON(): Promise<string>;
 }
 
-/**
- * Additional configuration to be used
- * when running a durable action via ctx.run().
- */
-export interface RunOptions {
-  name?: string;
-}
+export type RunAction<T> = (() => Promise<T>) | (() => T);
 
 /**
  * The context that gives access to all Restate-backed operations, for example
@@ -216,15 +210,21 @@ export interface Context {
    *   }
    * }
    * const paymentAccepted: boolean =
-   *   await ctx.run(paymentAction, "paymentAction");
+   *   await ctx.run("paymentAction", paymentAction);
    *
    * @param action The function to run.
    * @param nameOrOptions the operation's name or a run configuration
    */
-  run<T>(
-    action: () => Promise<T> | T,
-    nameOrOptions?: string | RunOptions
-  ): Promise<T>;
+  run<T>(action: RunAction<T>): Promise<T>;
+
+  /**
+   * Run an operation and store the result in Restate. The operation will thus not
+   * be re-run during a later replay, but take the durable result from Restate.
+   *
+   * @param name the action's name
+   * @param action the action to run.
+   */
+  run<T>(name: string, action: RunAction<T>): Promise<T>;
 
   /**
    * Register an awakeable and pause the processing until the awakeable ID (and optional payload) have been returned to the service

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -14,7 +14,6 @@ export {
   Context,
   ObjectContext,
   CombineablePromise,
-  RunOptions,
   Rand,
 } from "./context";
 export {

--- a/src/workflows/workflow_wrapper_service.ts
+++ b/src/workflows/workflow_wrapper_service.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { ContextDate, Request, RunOptions, SendOptions } from "../context";
+import { ContextDate, Request, RunAction, SendOptions } from "../context";
 import * as restate from "../public_api";
 import * as wf from "./workflow";
 import * as wss from "./workflow_state_service";
@@ -140,11 +140,14 @@ class ExclusiveContextImpl<P extends string>
     this.ctx.objectSendClient(this.stateServiceApi, this.wfId).clearAllState();
   }
 
-  run<T>(
-    fn: () => Promise<T> | T,
-    nameOrOptions?: string | RunOptions
-  ): Promise<T> {
-    return this.ctx.run(fn, nameOrOptions);
+  run<T>(name: string | RunAction<T>, action?: RunAction<T>): Promise<T> {
+    if (typeof name == "string" && typeof action == "function") {
+      return this.ctx.run(name, action);
+    } else if (typeof name == "function" && typeof action == "undefined") {
+      return this.ctx.run(name);
+    } else {
+      throw new TypeError(`Unexpected arguments to run ${name} and ${action}`);
+    }
   }
 
   awakeable<T>(): { id: string; promise: restate.CombineablePromise<T> } {

--- a/test/protoutils.ts
+++ b/test/protoutils.ts
@@ -408,12 +408,14 @@ export function backgroundInvokeMessage(
 
 export function sideEffectMessage<T>(
   value?: T,
-  failure?: FailureWithTerminal
+  failure?: FailureWithTerminal,
+  name?: string
 ): Message {
   if (value !== undefined) {
     return new Message(
       SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
       new SideEffectEntryMessage({
+        name,
         result: { case: "value", value: Buffer.from(JSON.stringify(value)) },
       }),
       false,
@@ -424,6 +426,7 @@ export function sideEffectMessage<T>(
     return new Message(
       SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
       new SideEffectEntryMessage({
+        name,
         result: { case: "failure", value: failure },
       }),
       false,
@@ -433,7 +436,7 @@ export function sideEffectMessage<T>(
   } else {
     return new Message(
       SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
-      new SideEffectEntryMessage({}),
+      new SideEffectEntryMessage({ name }),
       false,
       undefined,
       true


### PR DESCRIPTION
This PR uses overloaded function in `ctx.run()`
Now we can:
1. ctx.run("name", action)
2. ctx.run(action) // without the name
