### PR TITLE
[protocol] Use the SideEffectMessage from the protocol

### DIFF
--- a/packages/restate-sdk/proto/javascript.proto
+++ b/packages/restate-sdk/proto/javascript.proto
@@ -15,23 +15,6 @@ package dev.restate.sdk.javascript;
 
 import "proto/protocol.proto";
 
-message FailureWithTerminal {
-  dev.restate.service.protocol.Failure failure = 1;
-  bool terminal = 2;
-}
-
-// Type: 0xFC00 + 1
-// Flag: RequiresRuntimeAck
-message SideEffectEntryMessage {
-  
-  string name = 1; 
-
-  oneof result {
-    bytes value = 100;
-    FailureWithTerminal failure = 101;
-  };
-}
-
 // Type: 0xFC00 + 2
 message CombinatorEntryMessage {
   int32 combinator_id = 1;

--- a/packages/restate-sdk/proto/protocol.proto
+++ b/packages/restate-sdk/proto/protocol.proto
@@ -75,6 +75,14 @@ message ErrorMessage {
   string message = 2;
   // Contains a verbose error description, e.g. the exception stacktrace.
   string description = 3;
+
+  // Entry that caused the failure. This may be outside the current stored journal size.
+  // If no specific entry caused the failure, the current replayed/processed entry can be used.
+  uint32 related_entry_index = 4;
+  // Name of the entry that caused the failure. Empty if no name was set.
+  string related_entry_name = 5;
+  // Entry type. 0 if unknown.
+  uint32 related_entry_type = 6;
 }
 
 // Type: 0x0000 + 4
@@ -90,13 +98,16 @@ message EndMessage {
 // --- Journal Entries ---
 
 // Every Completable JournalEntry has a result field, filled only and only if the entry is in DONE state.
-// Depending on the semantics of the corresponding syscall, the entry can represent the result field with any of these three types:
+//
+// For every journal entry, fields 12, 13, 14 and 15 are reserved.
+//
+// The field 12 is used for name. The name is used by introspection/observability tools.
+//
+// Depending on the semantics of the corresponding syscall, the entry can represent the completion result field with any of these three types:
 //
 //   * google.protobuf.Empty empty = 13 for cases when we need to propagate to user code the distinction between default value or no value.
 //   * bytes value = 14 for carrying the result value
 //   * Failure failure = 15 for carrying a failure
-//
-// The tag numbers 13, 14 and 15 are reserved and shouldn't be used for other fields.
 
 // ------ Input and output ------
 
@@ -107,6 +118,9 @@ message InputEntryMessage {
   repeated Header headers = 1;
 
   bytes value = 14;
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: No
@@ -117,6 +131,9 @@ message OutputEntryMessage {
     bytes value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
 }
 
 // ------ State access ------
@@ -132,6 +149,9 @@ message GetStateEntryMessage {
     bytes value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: No
@@ -140,6 +160,9 @@ message GetStateEntryMessage {
 message SetStateEntryMessage {
   bytes key = 1;
   bytes value = 3;
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: No
@@ -147,12 +170,17 @@ message SetStateEntryMessage {
 // Type: 0x0800 + 2
 message ClearStateEntryMessage {
   bytes key = 1;
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: No
 // Fallible: No
 // Type: 0x0800 + 3
 message ClearAllStateEntryMessage {
+  // Entry name
+  string name = 12;
 }
 
 // Completable: Yes
@@ -167,6 +195,9 @@ message GetStateKeysEntryMessage {
     StateKeys value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
 }
 
 // ------ Syscalls ------
@@ -183,6 +214,9 @@ message SleepEntryMessage {
     Empty empty = 13;
     Failure failure = 15;
   }
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: Yes
@@ -203,6 +237,9 @@ message InvokeEntryMessage {
     bytes value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: No
@@ -224,6 +261,9 @@ message BackgroundInvokeEntryMessage {
 
   // If this invocation has a key associated (e.g. for objects and workflows), then this key is filled in. Empty otherwise.
   string key = 6;
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: Yes
@@ -235,6 +275,9 @@ message AwakeableEntryMessage {
     bytes value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
 }
 
 // Completable: No
@@ -245,9 +288,26 @@ message CompleteAwakeableEntryMessage {
   string id = 1;
 
   oneof result {
-    bytes value = 5;
-    Failure failure = 6;
+    bytes value = 14;
+    Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: No
+// Fallible: No
+// Type: 0x0C00 + 5
+// Flag: RequiresRuntimeAck
+message SideEffectEntryMessage {
+  oneof result {
+    bytes value = 14;
+    dev.restate.service.protocol.Failure failure = 15;
+  };
+
+  // Entry name
+  string name = 12;
 }
 
 // --- Nested messages

--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -28,6 +28,7 @@ import {
   GetStateKeysEntryMessage,
   GetStateKeysEntryMessage_StateKeys,
   InvokeEntryMessage,
+  SideEffectEntryMessage,
   SleepEntryMessage,
 } from "./generated/proto/protocol_pb";
 import {
@@ -44,16 +45,15 @@ import {
   SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
   SLEEP_ENTRY_MESSAGE_TYPE,
 } from "./types/protocol";
-import { SideEffectEntryMessage } from "./generated/proto/javascript_pb";
 import { AsyncLocalStorage } from "async_hooks";
 import {
   RetryableError,
   TerminalError,
   ensureError,
-  errorToFailureWithTerminal,
   TimeoutError,
   INTERNAL_ERROR_CODE,
   UNKNOWN_ERROR_CODE,
+  errorToFailure,
 } from "./types/errors";
 import { jsonSerialize, jsonDeserialize } from "./utils/utils";
 import { PartialMessage, protoInt64 } from "@bufbuild/protobuf";
@@ -417,7 +417,7 @@ export class ContextImpl implements ObjectContext {
         // the function. that way, any catching by the user and reacting to it will be
         // deterministic on replay
         const error = ensureError(e);
-        const failure = errorToFailureWithTerminal(error);
+        const failure = errorToFailure(error);
         const sideEffectMsg = new SideEffectEntryMessage({
           name,
           result: { case: "failure", value: failure },

--- a/packages/restate-sdk/src/journal.ts
+++ b/packages/restate-sdk/src/journal.ts
@@ -13,6 +13,7 @@ import * as p from "./types/protocol";
 import {
   Failure,
   GetStateKeysEntryMessage_StateKeys,
+  SideEffectEntryMessage,
 } from "./generated/proto/protocol_pb";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
@@ -43,7 +44,6 @@ import {
 } from "./types/protocol";
 import { equalityCheckers, jsonDeserialize } from "./utils/utils";
 import { Message } from "./types/types";
-import { SideEffectEntryMessage } from "./generated/proto/javascript_pb";
 import { Invocation } from "./invocation";
 import { failureToError, RetryableError } from "./types/errors";
 import { CompletablePromise } from "./utils/promises";
@@ -343,8 +343,8 @@ export class Journal {
             journalIndex,
             journalEntry,
             undefined,
-            sideEffectMsg.result.value.failure,
-            sideEffectMsg.result.value.terminal
+            sideEffectMsg.result.value,
+            true
           );
         } else {
           // A side effect can have a void return type

--- a/packages/restate-sdk/src/types/errors.ts
+++ b/packages/restate-sdk/src/types/errors.ts
@@ -13,7 +13,6 @@
 
 import { ErrorMessage, Failure } from "../generated/proto/protocol_pb";
 import { formatMessageAsJson } from "../utils/utils";
-import { FailureWithTerminal } from "../generated/proto/javascript_pb";
 import * as p from "./protocol";
 
 export const INTERNAL_ERROR_CODE = 500;
@@ -124,14 +123,6 @@ export function errorToFailure(err: Error): Failure {
         code: INTERNAL_ERROR_CODE,
         message: err.message,
       });
-}
-
-export function errorToFailureWithTerminal(err: Error): FailureWithTerminal {
-  const failure = errorToFailure(err);
-  return new FailureWithTerminal({
-    failure,
-    terminal: err instanceof TerminalError,
-  });
 }
 
 export function failureToTerminalError(failure: Failure): TerminalError {

--- a/packages/restate-sdk/src/types/protocol.ts
+++ b/packages/restate-sdk/src/types/protocol.ts
@@ -10,10 +10,7 @@
  */
 
 import { Message } from "@bufbuild/protobuf";
-import {
-  SideEffectEntryMessage,
-  CombinatorEntryMessage,
-} from "../generated/proto/javascript_pb";
+import { CombinatorEntryMessage } from "../generated/proto/javascript_pb";
 import {
   AwakeableEntryMessage,
   BackgroundInvokeEntryMessage,
@@ -33,6 +30,7 @@ import {
   SleepEntryMessage,
   StartMessage,
   SuspensionMessage,
+  SideEffectEntryMessage,
 } from "../generated/proto/protocol_pb";
 
 // Re-export the protobuf messages.
@@ -79,9 +77,10 @@ export const COMPLETE_AWAKEABLE_ENTRY_MESSAGE_TYPE = 0x0c04n;
 
 export const AWAKEABLE_IDENTIFIER_PREFIX = "prom_1";
 
+export const SIDE_EFFECT_ENTRY_MESSAGE_TYPE = 0x0c00n + 5n;
+
 // Export the custom message types
 // Side effects are custom messages because the runtime does not need to inspect them
-export const SIDE_EFFECT_ENTRY_MESSAGE_TYPE = 0xfc01n;
 export const COMBINATOR_ENTRY_MESSAGE = 0xfc02n;
 
 // Restate DuplexStream

--- a/packages/restate-sdk/test/protoutils.ts
+++ b/packages/restate-sdk/test/protoutils.ts
@@ -53,13 +53,10 @@ import {
   GetStateKeysEntryMessage,
 } from "../src/types/protocol";
 import { Message } from "../src/types/types";
-import {
-  CombinatorEntryMessage,
-  FailureWithTerminal,
-  SideEffectEntryMessage,
-} from "../src/generated/proto/javascript_pb";
+import { CombinatorEntryMessage } from "../src/generated/proto/javascript_pb";
 import {
   Failure,
+  SideEffectEntryMessage,
   StartMessage_StateEntry,
 } from "../src/generated/proto/protocol_pb";
 import { expect } from "@jest/globals";
@@ -408,7 +405,7 @@ export function backgroundInvokeMessage(
 
 export function sideEffectMessage<T>(
   value?: T,
-  failure?: FailureWithTerminal,
+  failure?: Failure,
   name?: string
 ): Message {
   if (value !== undefined) {
@@ -520,17 +517,6 @@ export function failure(
   code: number = INTERNAL_ERROR_CODE
 ): Failure {
   return new Failure({ code: code, message: msg });
-}
-
-export function failureWithTerminal(
-  terminal: boolean,
-  msg: string,
-  code: number = INTERNAL_ERROR_CODE
-): FailureWithTerminal {
-  return new FailureWithTerminal({
-    terminal,
-    failure: new Failure({ code: code, message: msg }),
-  });
 }
 
 export function greetRequest(myName: string): Uint8Array {

--- a/packages/restate-sdk/test/side_effect.test.ts
+++ b/packages/restate-sdk/test/side_effect.test.ts
@@ -13,8 +13,6 @@ import { describe, expect } from "@jest/globals";
 import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
 import {
   END_MESSAGE,
-  failure,
-  failureWithTerminal,
   errorMessage,
   greetRequest,
   inputMessage,
@@ -23,6 +21,7 @@ import {
   startMessage,
   suspensionMessage,
   greetResponse,
+  failure,
 } from "./protoutils";
 import { ObjectContext } from "../src/context";
 import { TerminalError } from "../src/public_api";
@@ -114,27 +113,24 @@ describe("Greeter", () => {
       inputMessage(greetRequest("Pete")),
     ]).run();
 
-    const failure = failureWithTerminal(true, "oh no");
+    const f = failure("oh no");
 
     expect(result).toStrictEqual([
-      sideEffectMessage(undefined, failure),
+      sideEffectMessage(undefined, f),
       suspensionMessage([1]),
     ]);
   });
 
   it("After a terminal exception is acknowledge, the execution ends", async () => {
-    const failure = failureWithTerminal(true, "oh no");
+    const f = failure("oh no");
 
     const result = await new TestDriver(new GreeterThrowsTerm(), [
       startMessage({ knownEntries: 3, key: "Pete" }),
       inputMessage(greetRequest("Pete")),
-      sideEffectMessage(undefined, failure),
+      sideEffectMessage(undefined, f),
     ]).run();
 
-    expect(result).toStrictEqual([
-      outputMessage(undefined, failure.failure),
-      END_MESSAGE,
-    ]);
+    expect(result).toStrictEqual([outputMessage(undefined, f), END_MESSAGE]);
   });
 
   it("A non terminal exception (1) does not record the sideEffect in the journal. (2) ends the current attempt", async () => {


### PR DESCRIPTION
This PR use the `SideEffectMessageEntry` from the protocol And populate the name field of the run() field.
By reusing a SideEffectMessageEntry, common tools like the cli and the ui can introspect and display the side effect message across the sdks.

Note: e2e should not pass, before the runtime changes has landed.