### PR TITLE
Augment the protocol ErrorMessage with additional journal context

### DIFF
--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -410,7 +410,11 @@ export class ContextImpl implements ObjectContext {
           // Before we can propagate this error to the user, we must let the state machine know that this attempt
           // is finished with an error, and it should not append anything else to the journal from now on.
           const error = ensureError(e);
-          await this.stateMachine.sendErrorAndFinish(error);
+          const additionalContext = {
+            relatedEntryName: name,
+            relatedEntryType: SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
+          };
+          await this.stateMachine.sendErrorAndFinish(error, additionalContext);
           throw e;
         }
         // we commit a terminal error from the side effect to the journal, and re-throw it into

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -37,6 +37,7 @@ import {
   TerminalError,
   RetryableError,
   errorToErrorMessage,
+  JournalErrorContext,
 } from "./types/errors";
 import { LocalStateStore } from "./local_state_store";
 import { createRestateConsole, LoggerContext } from "./logger";
@@ -422,18 +423,18 @@ export class StateMachine implements RestateStreamConsumer {
     return this.invocationComplete.promise;
   }
 
-  public async sendErrorAndFinish(e: Error) {
+  public async sendErrorAndFinish(e: Error, ctx?: JournalErrorContext) {
     if (e instanceof TerminalError) {
       this.sendTerminalError(e);
     } else {
-      this.sendRetryableError(e);
+      this.sendRetryableError(e, ctx);
     }
 
     await this.finish();
   }
 
-  private sendRetryableError(e: Error) {
-    const msg = new Message(ERROR_MESSAGE_TYPE, errorToErrorMessage(e));
+  private sendRetryableError(e: Error, ctx?: JournalErrorContext) {
+    const msg = new Message(ERROR_MESSAGE_TYPE, errorToErrorMessage(e, ctx));
     this.console.debugJournalMessage(
       "Invocation ended with retryable error.",
       msg.messageType,

--- a/packages/restate-sdk/src/types/errors.ts
+++ b/packages/restate-sdk/src/types/errors.ts
@@ -24,6 +24,12 @@ export enum RestateErrorCodes {
   PROTOCOL_VIOLATION = 571,
 }
 
+export type JournalErrorContext = {
+  relatedEntryName?: string;
+  relatedEntryIndex?: number;
+  relatedEntryType?: bigint;
+};
+
 export function ensureError(e: unknown): Error {
   if (e instanceof Error) {
     return e;
@@ -141,11 +147,19 @@ export function failureToError(
     : new RestateError(errorMessage, { errorCode });
 }
 
-export function errorToErrorMessage(err: Error): ErrorMessage {
+export function errorToErrorMessage(
+  err: Error,
+  additionalContext?: JournalErrorContext
+): ErrorMessage {
   const code = err instanceof RestateError ? err.code : INTERNAL_ERROR_CODE;
+
+  const ty = additionalContext?.relatedEntryType;
 
   return new ErrorMessage({
     code: code,
     message: err.message,
+    relatedEntryName: additionalContext?.relatedEntryName,
+    relatedEntryIndex: additionalContext?.relatedEntryIndex,
+    relatedEntryType: ty !== undefined ? Number(ty) : undefined,
   });
 }

--- a/packages/restate-sdk/test/protoutils.ts
+++ b/packages/restate-sdk/test/protoutils.ts
@@ -64,6 +64,7 @@ import { jsonSerialize, formatMessageAsJson } from "../src/utils/utils";
 import { rlog } from "../src/logger";
 import {
   INTERNAL_ERROR_CODE,
+  JournalErrorContext,
   RestateErrorCodes,
   UNKNOWN_ERROR_CODE,
 } from "../src/types/errors";
@@ -529,12 +530,20 @@ export function greetResponse(myGreeting: string): Uint8Array {
   return Buffer.from(str);
 }
 
-export function errorMessage(failure: Failure): Message {
+export function errorMessage(
+  failure: Failure,
+  ctx?: JournalErrorContext
+): Message {
   return new Message(
     ERROR_MESSAGE_TYPE,
     new ErrorMessage({
       message: failure.message,
       code: failure.code,
+      relatedEntryIndex: ctx?.relatedEntryIndex,
+      relatedEntryType: ctx?.relatedEntryType
+        ? Number(ctx.relatedEntryType)
+        : undefined,
+      relatedEntryName: ctx?.relatedEntryName,
     })
   );
 }


### PR DESCRIPTION
This PR adds an additional journal context to the ErrorMessage, such as the journal entry type and name that caused this error. This is useful for observability and introspection, especially when using named runs, i.e. `ctx.run("foo", () => ...)`.