### PR TITLE
[examples] Add back the examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9421,7 +9421,7 @@
     },
     "packages/restate-sdk-examples": {
       "name": "@restatedev/restate-sdk-examples",
-      "version": "0.8.0",
+      "version": "0.0.0-SNAPSHOT-20240418194215",
       "license": "MIT",
       "dependencies": {
         "@restatedev/restate-sdk": "^0.8.0",

--- a/packages/restate-sdk-examples/.eslintignore
+++ b/packages/restate-sdk-examples/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+src/generated

--- a/packages/restate-sdk-examples/jest.config.js
+++ b/packages/restate-sdk-examples/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  roots: ["<rootDir>"],
+  testMatch: ["**/test/?(*.)+(spec|test).+(ts|tsx|js)"],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/packages/restate-sdk-examples/package.json
+++ b/packages/restate-sdk-examples/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@restatedev/restate-sdk-examples",
+  "version": "0.8.0",
+  "description": "Typescript SDK examples",
+  "private": true,
+  "author": "Restate Developers",
+  "license": "MIT",
+  "email": "code@restate.dev",
+  "homepage": "https://github.com/restatedev/sdk-typescript#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/restatedev/sdk-typescript.git"
+  },
+  "bugs": {
+    "url": "https://github.com/restatedev/sdk-typescript/issues"
+  },
+  "type": "commonjs",
+  "main": "./dist/src/public_api.js",
+  "types": "./dist/src/public_api.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
+    "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
+    "format-check": "prettier --ignore-path .eslintignore --check \"**/*.+(js|ts|json)\"",
+    "test": "jest --silent --maxWorkers=1",
+    "verify": "npm run format-check && npm run lint && npm run build",
+    "release": "",
+    "example": "RESTATE_DEBUG_LOGGING=OFF ts-node-dev --transpile-only ./src/example.ts",
+    "workflowexample": "RESTATE_DEBUG_LOGGING=OFF ts-node-dev --transpile-only ./src/workflow_example.ts",
+    "ingress": "RESTATE_DEBUG_LOGGING=OFF ts-node-dev --transpile-only ./src/ingress.ts"
+  },
+  "dependencies": {
+    "@restatedev/restate-sdk": "^0.8.0",
+    "@restatedev/restate-sdk-clients": "^0.8.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.115",
+    "@types/jest": "^29.4.0",
+    "@types/node": "^20.10.4",
+    "@typescript-eslint/eslint-plugin": "^5.53.0",
+    "@typescript-eslint/parser": "^5.53.0",
+    "eslint": "^8.35.0",
+    "prettier": "^2.8.4",
+    "ts-jest": "^29.0.5",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^4.9.5"
+  },
+  "engines": {
+    "node": ">= 18"
+  }
+}

--- a/packages/restate-sdk-examples/src/example.ts
+++ b/packages/restate-sdk-examples/src/example.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-2024 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import * as restate from "@restatedev/restate-sdk";
+
+const greeter = restate.service({
+  name: "greeter",
+  handlers: {
+    greet: async (ctx: restate.Context, name: string) => {
+      // blocking RPC call to a keyed service (here supplying type and path separately)
+      const countSoFar = await ctx.objectClient(Counter, name).count();
+
+      const message = `Hello ${name}, for the ${countSoFar + 1}th time!`;
+
+      // sending messages to ourselves, immediately and delayed
+      ctx.serviceSendClient(Greeter).logger(message);
+      ctx
+        .serviceSendClient(Greeter, { delay: 100 })
+        .logger("delayed " + message);
+
+      return message;
+    },
+
+    logger: async (ctx: restate.Context, msg: string) => {
+      ctx.console.log(" HEEEELLLLOOOOO! " + msg);
+    },
+  },
+});
+
+export type GreeterService = typeof greeter;
+const Greeter: GreeterService = { name: "greeter" };
+
+//
+// The stateful aux service that keeps the counts.
+// This could in principle be the same service as the greet service, we just separate
+// them here to have this multi-service setup for testing.
+//
+
+const counter = restate.object({
+  name: "counter",
+  handlers: {
+    count: async (ctx: restate.ObjectContext): Promise<number> => {
+      const seen = (await ctx.get<number>("seen")) ?? 0;
+      ctx.set("seen", seen + 1);
+      return seen;
+    },
+  },
+});
+
+export type CounterObject = typeof counter;
+const Counter: CounterObject = { name: "counter" };
+// restate server
+
+restate.endpoint().bind(counter).bind(greeter).listen(9080);

--- a/packages/restate-sdk-examples/src/ingress.ts
+++ b/packages/restate-sdk-examples/src/ingress.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023-2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+/* eslint-disable no-console */
+
+import * as restate from "@restatedev/restate-sdk-clients";
+
+import type { CounterObject, GreeterService } from "./example";
+
+const Greeter: GreeterService = { name: "greeter" };
+const Counter: CounterObject = { name: "counter" };
+
+const ingress = restate.connect({ url: "http://localhost:8080" });
+
+const simpleCall = async (name: string) => {
+  const greeter = ingress.serviceClient(Greeter);
+  const greeting = await greeter.greet(name);
+
+  console.log(greeting);
+};
+
+const objectCall = async (name: string) => {
+  const counter = ingress.objectClient(Counter, name);
+  const count = await counter.count();
+
+  console.log(`The count for ${name} is ${count}`);
+};
+
+const idempotentCall = async (name: string, idempotencyKey: string) => {
+  const greeter = ingress.serviceClient(Greeter);
+
+  // send the request with the idempotent key, and ask restate
+  // to remember that key for 3 seconds.
+  const greeting = await greeter.greet(
+    name,
+    restate.Opts.from({ idempotencyKey })
+  );
+
+  console.log(greeting);
+};
+
+const customHeadersCall = async (name: string) => {
+  const greeter = ingress.serviceClient(Greeter);
+
+  const greeting = await greeter.greet(
+    name,
+    restate.Opts.from({ headers: { "x-bob": "1234" } })
+  );
+
+  console.log(greeting);
+};
+
+const globalCustomHeaders = async (name: string) => {
+  const ingress = restate.connect({
+    url: "http://localhost:8080",
+    headers: { Authorization: "Bearer mytoken123" },
+  });
+
+  const greeting = await ingress.serviceClient(Greeter).greet(name);
+
+  console.log(greeting);
+};
+
+const delayedCall = async (name: string) => {
+  const ingress = restate.connect({
+    url: "http://localhost:8080",
+  });
+
+  const greeting = await ingress
+    .serviceSendClient(Greeter)
+    .greet(name, restate.SendOpts.from({ delay: 1000 }));
+
+  console.log(greeting);
+};
+
+// Before running this example, make sure
+// to run and register `greeter` and `counter` services.
+//
+// to run them, run:
+//
+// 1. npm run example
+// 2. make sure that restate is running
+// 3. restate deployment add localhost:9080
+
+Promise.resolve()
+  .then(() => simpleCall("bob"))
+  .then(() => objectCall("bob"))
+  .then(() => objectCall("mop"))
+  .then(() => idempotentCall("joe", "idemp-1"))
+  .then(() => idempotentCall("joe", "idemp-1"))
+  .then(() => customHeadersCall("bob"))
+  .then(() => globalCustomHeaders("bob"))
+  .then(() => delayedCall("bob"))
+  .catch((e) => console.error(e));

--- a/packages/restate-sdk-examples/src/workflow_example.ts
+++ b/packages/restate-sdk-examples/src/workflow_example.ts
@@ -1,0 +1,162 @@
+import * as restate from "@restatedev/restate-sdk";
+import { randomUUID } from "crypto";
+
+/* eslint-disable no-console */
+
+// ------------- NOTE !!! ------------------
+// unlike the other dev samples, this one includes a client and interaction
+// with the workflow, so it needs a running Restate runtime.
+// The protocol switched to a new version some days ago, so one needs the
+// latest nightly runtime build to run the current SDK main branch.
+//
+// start that via:
+// docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway ghcr.io/restatedev/restate:main
+
+const restateIngressUrl = process.argv[2] || "http://localhost:8080";
+const restateAdminUrl = process.argv[3] || "http://localhost:9070";
+const serviceHost = process.argv[4] || "host.docker.internal";
+
+//
+// (1) Definition of the workflow
+//
+const myworkflow = restate.workflow.workflow("acme.myworkflow", {
+  //
+  // Each workflow must have exactly one run() function, which defines
+  // the life cycle. This function isn't directly started, but indirectly
+  // via the synthetic start() function.
+  //
+  run: async (ctx: restate.workflow.WfContext, params: { name: string }) => {
+    if (!params?.name) {
+      throw new restate.TerminalError("Missing parameter 'name'");
+    }
+
+    ctx.console.log(">>>>>>>>>>> Starting workflow for " + params.name);
+
+    // workflow state can be accessed from other methods. the state becomes
+    // eventually visible, there is no linearizability for this state
+    ctx.set("name", params.name);
+
+    // to publish state in a way that other method calls can access it with
+    // guarantees (await until visible), use promises
+    ctx.promise<string>("name_promise").resolve(params.name);
+
+    // to listen to signals, also use promises
+    const signal = ctx.promise<string>("thesignal");
+    const message = await signal;
+
+    const result = `${message} my dear ${params.name}`;
+    ctx.console.log(">>>>>>>>>>> Finishing workflow with: " + result);
+    return result;
+  },
+
+  //
+  // Workflows may have an arbitrary number of other functions that take
+  // a 'SharedWfContext' and have shared access to state and promises
+  //
+
+  signal: async (
+    ctx: restate.workflow.SharedWfContext,
+    req: { signal: string }
+  ) => {
+    ctx.promise<string>("thesignal").resolve(req.signal);
+  },
+
+  getName: async (ctx: restate.workflow.SharedWfContext): Promise<string> => {
+    return (await ctx.get("name")) ?? "(not yet set)";
+  },
+
+  awaitName: async (ctx: restate.workflow.SharedWfContext): Promise<string> => {
+    return ctx.promise<string>("name_promise");
+  },
+});
+
+// typed API similar to how other Restate RPC services work
+const workflowApi = myworkflow.api;
+
+restate.endpoint().bindBundle(myworkflow).listen(9080);
+
+//
+// (2) Code to interact with the workflow using an external client
+//
+// This submits a workflow and sends signals / queries to the workflow.
+//
+async function startWorkflowAndInteract(restateUrl: string) {
+  const restateServer = restate.clients.connect(restateUrl);
+
+  const args = { name: "Restatearius" };
+  const workflowId = randomUUID();
+
+  // Option a) we can create clients either with just the workflow service path
+  const submit1 = await restateServer.submitWorkflow(
+    "acme.myworkflow",
+    workflowId,
+    args
+  );
+  console.log("Submitted workflow with result: " + submit1.status);
+
+  // Option b) we can supply the API signature and get a typed interface for all the methods
+  // Because the submit is idempotent, this call here will effectively attach to the
+  // previous workflow
+  const submit2 = await restateServer.submitWorkflow(
+    workflowApi,
+    workflowId,
+    args
+  );
+  console.log("Submitted workflow with result: " + submit2.status);
+  const client = submit2.client;
+
+  // check the status (should be RUNNING)
+  const status = await client.status();
+  console.log("Workflow status: " + status);
+
+  // call method that reads the 'name' state
+  const get_name = await client.workflowInterface().getName();
+  console.log("Workflow getName() (snapshot read): " + get_name);
+
+  // call method that awaits the 'name' promise
+  const await_name = await client.workflowInterface().awaitName();
+  console.log("Workflow awaitName() (promise): " + await_name);
+
+  // send a signal
+  client.workflowInterface().signal({ signal: "hey ho!" });
+
+  // wait until everything is done
+  const result = await client.result();
+  console.log("Workflow result: " + result);
+}
+
+//
+// (3) To make this example work end-to-end, with the external client below,
+// we issue a registration here
+//
+registerDeployment(restateAdminUrl, 9080)
+  .then(() => startWorkflowAndInteract(restateIngressUrl))
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(-1);
+  });
+
+// --------------------- utils -----------------
+
+async function registerDeployment(restateAdminAddress: string, port: number) {
+  const serviceEndpoint = `http://${serviceHost}:${port}`;
+  const httpResponse = await fetch(restateAdminAddress + "/deployments", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      uri: serviceEndpoint,
+    }),
+  });
+
+  const responseText = await httpResponse.text();
+  if (!httpResponse.ok) {
+    throw new Error(
+      `Registration failed: STATUS ${httpResponse.status} ; ${responseText}`
+    );
+  } else {
+    return `Registration succeeded: STATUS ${httpResponse.status} ; ${responseText}`;
+  }
+}

--- a/packages/restate-sdk-examples/test/hello.test.ts
+++ b/packages/restate-sdk-examples/test/hello.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023-2024 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import * as restate from "@restatedev/restate-sdk";
+
+describe("HelloGreeter", () => {
+  it("Demonstrates how to write a simple services", async () => {
+    const myservice = restate.service({
+      name: "myservice",
+      handlers: {
+        greet: async (ctx: restate.Context) => {
+          return await ctx.run("greet", () => "hi there!");
+        },
+      },
+    });
+
+    restate.endpoint().bind(myservice);
+    //---> 	.listen();
+  });
+});

--- a/packages/restate-sdk-examples/tsconfig.json
+++ b/packages/restate-sdk-examples/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../restate-sdk" },
+    { "path": "../restate-sdk-clients" }
+  ]
+}


### PR DESCRIPTION
Now that we can publish the new sdk-clients packages, we can re-add the examples.