### PR TITLE
Avoid transform after invoke, which appears to break CombineablePromise

### DIFF
--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -74,10 +74,9 @@ export interface CallContext {
   delay?: number;
 }
 
-export type InternalCombineablePromise<T> = CombineablePromise<T> &
-  WrappedPromise<T> & {
-    journalIndex: number;
-  };
+export type InternalCombineablePromise<T> = CombineablePromise<T> & {
+  journalIndex: number;
+};
 
 export class ContextImpl implements ObjectContext {
   // here, we capture the context information for actions on the Restate context that
@@ -667,18 +666,21 @@ export class ContextImpl implements ObjectContext {
       ]) as Promise<T>;
     };
 
-    return Object.defineProperties(p, {
-      [RESTATE_CTX_SYMBOL]: {
-        value: this,
-      },
-      journalIndex: {
-        value: journalIndex,
-      },
-      orTimeout: {
-        value: orTimeout.bind(this),
-      },
-    }) as InternalCombineablePromise<T>;
+    defineProperty(p, RESTATE_CTX_SYMBOL, this);
+    defineProperty(p, "journalIndex", journalIndex);
+    defineProperty(p, "orTimeout", orTimeout.bind(this));
+
+    return p;
   }
+}
+
+// wraps defineProperty such that it informs tsc of the correct type of its output
+function defineProperty<Obj extends object, Key extends PropertyKey, T>(
+  obj: Obj,
+  prop: Key,
+  value: T
+): asserts obj is Obj & Readonly<Record<Key, T>> {
+  Object.defineProperty(obj, prop, { value });
 }
 
 function unpack<T>(

--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -229,7 +229,8 @@ export class ContextImpl implements ObjectContext {
     method: string,
     data: Uint8Array,
     key?: string
-  ): InternalCombineablePromise<Uint8Array> {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  ): InternalCombineablePromise<any> {
     this.checkState("invoke");
 
     const msg = new CallEntryMessage({
@@ -241,7 +242,7 @@ export class ContextImpl implements ObjectContext {
     return this.markCombineablePromise(
       this.stateMachine
         .handleUserCodeMessage(INVOKE_ENTRY_MESSAGE_TYPE, msg)
-        .transform((v) => v as Uint8Array)
+        .transform((v) => deserializeJson(v as Uint8Array))
     );
   }
 
@@ -280,9 +281,7 @@ export class ContextImpl implements ObjectContext {
           const route = prop as string;
           return (...args: unknown[]) => {
             const requestBytes = serializeJson(args.shift());
-            return this.invoke(name, route, requestBytes).transform(
-              (responseBytes) => deserializeJson(responseBytes)
-            );
+            return this.invoke(name, route, requestBytes);
           };
         },
       }
@@ -302,9 +301,7 @@ export class ContextImpl implements ObjectContext {
           const route = prop as string;
           return (...args: unknown[]) => {
             const requestBytes = serializeJson(args.shift());
-            return this.invoke(name, route, requestBytes, key).transform(
-              (responseBytes) => deserializeJson(responseBytes)
-            );
+            return this.invoke(name, route, requestBytes, key);
           };
         },
       }

--- a/packages/restate-sdk/test/testdriver.ts
+++ b/packages/restate-sdk/test/testdriver.ts
@@ -23,7 +23,11 @@ import { StateMachine } from "../src/state_machine";
 import { InvocationBuilder } from "../src/invocation";
 import { EndpointImpl } from "../src/endpoint/endpoint_impl";
 import { ObjectContext } from "../src/context";
-import { ServiceDefinition, object } from "../src/public_api";
+import {
+  object,
+  VirtualObjectDefinition,
+  VirtualObject,
+} from "../src/public_api";
 import { ProtocolMode } from "../src/types/discovery";
 
 export type TestRequest = {
@@ -38,11 +42,10 @@ export const TestResponse = {
   create: (test: TestResponse): TestResponse => test,
 };
 
-export type GreetType = {
-  greet: (key: string, arg: TestRequest) => Promise<TestResponse>;
-};
-
-export const GreeterApi: ServiceDefinition<"greeter", GreetType> = {
+export const GreeterApi: VirtualObjectDefinition<
+  "greeter",
+  VirtualObject<TestGreeter>
+> = {
   name: "greeter",
 };
 
@@ -188,7 +191,7 @@ export class TestDriver implements Connection {
     rlog.debug(
       `Adding result to the result array. Message type: ${
         msg.messageType
-      }, message: 
+      }, message:
         ${
           msg.message instanceof Uint8Array
             ? (msg.message as Uint8Array).toString()


### PR DESCRIPTION
This is a hotfix, a more meaningful fix would be to implement 'transform' for combineable promises so that they stay combineable