### PR TITLE
[api] Add shared handlers

### DIFF
--- a/packages/restate-sdk-examples/src/example.ts
+++ b/packages/restate-sdk-examples/src/example.ts
@@ -47,11 +47,17 @@ const Greeter: GreeterService = { name: "greeter" };
 const counter = restate.object({
   name: "counter",
   handlers: {
-    count: async (ctx: restate.ObjectContext): Promise<number> => {
+    count: async (ctx: restate.ObjectContext) => {
       const seen = (await ctx.get<number>("seen")) ?? 0;
       ctx.set("seen", seen + 1);
       return seen;
     },
+
+    get: restate.handlers.shared(
+      async (ctx: restate.ObjectSharedContext): Promise<number> => {
+        return (await ctx.get("count")) ?? 0;
+      }
+    ),
   },
 });
 

--- a/packages/restate-sdk/src/context.ts
+++ b/packages/restate-sdk/src/context.ts
@@ -416,6 +416,36 @@ export interface ObjectContext extends Context, KeyValueStore {
   key: string;
 }
 
+/**
+ * The context that gives access to all Restate-backed operations, for example
+ *   - sending reliable messages / RPC through Restate
+ *   - execute non-deterministic closures and memoize their result
+ *   - sleeps and delayed calls
+ *   - awakeables
+ *   - ...
+ *
+ * This context can be used only within a shared virtual objects.
+ *
+ */
+export interface ObjectSharedContext extends Context {
+  key: string;
+
+  /**
+   * Get/retrieve state from the Restate runtime.
+   * Note that state objects are serialized with `Buffer.from(JSON.stringify(theObject))`
+   * and deserialized with `JSON.parse(value.toString()) as T`.
+   *
+   * @param name key of the state to retrieve
+   * @returns a Promise that is resolved with the value of the state key
+   *
+   * @example
+   * const state = await ctx.get<string>("STATE");
+   */
+  get<T>(name: string): Promise<T | null>;
+
+  stateKeys(): Promise<Array<string>>;
+}
+
 export interface Rand {
   /**
    * Equivalent of JS `Math.random()` but deterministic; seeded by the invocation ID of the current invocation,

--- a/packages/restate-sdk/src/public_api.ts
+++ b/packages/restate-sdk/src/public_api.ts
@@ -9,7 +9,13 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-export { Context, ObjectContext, CombineablePromise, Rand } from "./context";
+export {
+  Context,
+  ObjectContext,
+  ObjectSharedContext,
+  CombineablePromise,
+  Rand,
+} from "./context";
 export {
   service,
   object,
@@ -19,6 +25,7 @@ export {
   VirtualObjectDefinition,
   Client,
   SendClient,
+  handlers,
 } from "./types/rpc";
 
 export { endpoint, ServiceBundle, RestateEndpoint } from "./endpoint";

--- a/packages/restate-sdk/src/types/discovery.ts
+++ b/packages/restate-sdk/src/types/discovery.ts
@@ -26,7 +26,7 @@ export enum ServiceHandlerType {
 
 type InputPayload = {
   contentType: string;
-  empty: "ALLOW" | "DISALLOW" | "REQUIRE";
+  required: boolean;
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   jsonSchema?: any; // You should specify the type of jsonSchema if known

--- a/packages/restate-sdk/src/types/rpc.ts
+++ b/packages/restate-sdk/src/types/rpc.ts
@@ -10,8 +10,20 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { CombineablePromise, Context, ObjectContext } from "../context";
+/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/ban-types */
+import {
+  CombineablePromise,
+  Context,
+  ObjectContext,
+  ObjectSharedContext,
+} from "../context";
+import {
+  deserializeJson,
+  deserializeNoop,
+  serializeJson,
+  serializeNoop,
+} from "../utils/serde";
 
 // ----------- generics -------------------------------------------------------
 
@@ -73,10 +85,35 @@ export const service = <P extends string, M>(service: {
   if (!service.handlers) {
     throw new Error("service must be defined");
   }
-  return { name: service.name, service: service.handlers as Service<M> };
+  const handlers = Object.entries(service.handlers).map(([name, handler]) => {
+    if (handler instanceof HandlerWrapper) {
+      return [name, handler.transpose()];
+    }
+    if (handler instanceof Function) {
+      return [
+        name,
+        new HandlerWrapper(HandlerKind.SERVICE, handler).transpose(),
+      ];
+    }
+    throw new TypeError(`Unexpected handler type ${name}`);
+  });
+
+  return {
+    name: service.name,
+    service: Object.fromEntries(handlers) as Service<M>,
+  };
 };
 
 // ----------- keyed handlers ----------------------------------------------
+
+export type ObjectSharedHandler<F> = F extends (
+  ctx: ObjectSharedContext,
+  param: any
+) => Promise<any>
+  ? F
+  : F extends (ctx: ObjectSharedContext) => Promise<any>
+  ? F
+  : never;
 
 export type ObjectHandler<F> = F extends (
   ctx: ObjectContext,
@@ -86,6 +123,229 @@ export type ObjectHandler<F> = F extends (
   : F extends (ctx: ObjectContext) => Promise<any>
   ? F
   : never;
+
+export type ObjectHandlerOpts = {
+  accept?: string;
+  contentType?: string;
+};
+
+export type ServiceHandlerOpts = {
+  accept?: string;
+  contentType?: string;
+};
+
+export enum HandlerKind {
+  EXCLUSIVE,
+  SHARED,
+  WORKFLOW,
+  SERVICE,
+}
+
+const JSON_CONTENT_TYPE = "application/json";
+
+export class HandlerWrapper {
+  private readonly serializer: (input: unknown) => Uint8Array;
+  private readonly deserializer: (input: Uint8Array) => unknown;
+
+  constructor(
+    public readonly kind: HandlerKind,
+    private handler: Function,
+    public readonly accept?: string,
+    public readonly contentType?: string
+  ) {
+    const input = accept ?? JSON_CONTENT_TYPE;
+    if (input.toLocaleLowerCase() == JSON_CONTENT_TYPE) {
+      this.serializer = serializeJson;
+    } else {
+      this.serializer = serializeNoop;
+    }
+    const output = contentType ?? JSON_CONTENT_TYPE;
+    if (output.toLocaleLowerCase() == JSON_CONTENT_TYPE) {
+      this.deserializer = deserializeJson;
+    } else {
+      this.deserializer = deserializeNoop;
+    }
+  }
+
+  bindInstance(t: unknown) {
+    this.handler = this.handler.bind(t);
+  }
+
+  async invoke(context: unknown, input: Uint8Array) {
+    const req = this.deserializer(input);
+    const res = await this.handler(context, req);
+    return this.serializer(res);
+  }
+
+  /**
+   * Instead of a HandlerWrapper with a handler property,
+   * return the original handler with a HandlerWrapper property.
+   * This is needed to keep the appearance of regular functions
+   * bound to an object, so that for example, `this.foo(ctx, arg)` would
+   * work.
+   */
+  transpose<F>(): F {
+    const h = this.handler;
+    defineProperty(h, HANDLER_SYMBOL, this);
+    return h as F;
+  }
+
+  public static fromHandler(handler: any): HandlerWrapper {
+    const wrapper = handler[HANDLER_SYMBOL];
+    if (wrapper instanceof HandlerWrapper) {
+      return wrapper;
+    }
+    throw new TypeError(`Not a wrapped handler`);
+  }
+}
+
+// wraps defineProperty such that it informs tsc of the correct type of its output
+function defineProperty<Obj extends object, Key extends PropertyKey, T>(
+  obj: Obj,
+  prop: Key,
+  value: T
+): asserts obj is Obj & Readonly<Record<Key, T>> {
+  Object.defineProperty(obj, prop, { value });
+}
+const HANDLER_SYMBOL = Symbol("Handler");
+
+export namespace handlers {
+  /**
+   * Create a service handler.
+   *
+   * @param opts additional configuration
+   * @param fn the actual handler code to execute
+   */
+  export function handler<F>(
+    opts: ServiceHandlerOpts,
+    fn: ServiceHandler<F>
+  ): F {
+    return new HandlerWrapper(
+      HandlerKind.SERVICE,
+      fn,
+      opts.accept,
+      opts.contentType
+    ) as F;
+  }
+
+  /**
+   * Creates an exclusive handler for a virtual Object.
+   *
+   * note : This applies only to a virtual object.
+   *
+   * @param opts additional configurations
+   * @param fn the handler to execute
+   */
+  export function exclusive<F>(
+    opts: ObjectHandlerOpts,
+    fn: ObjectHandler<F>
+  ): F;
+
+  /**
+   * Creates an exclusive handler for a virtual Object.
+   *
+   *
+   * note 1: This applies only to a virtual object.
+   * note 2: This is the default for virtual objects, so if no
+   *         additional reconfiguration is needed, you can simply
+   *         use the handler directly (no need to use exclusive).
+   *         This variant here is only for symmetry/convenance.
+   *
+   * @param fn the handler to execute
+   */
+  export function exclusive<F>(fn: ObjectHandler<F>): F;
+
+  /**
+   * Creates an exclusive handler for a virtual Object.
+   *
+   *
+   * note 1: This applies only to a virtual object.
+   * note 2: This is the default for virtual objects, so if no
+   *         additional reconfiguration is needed, you can simply
+   *         use the handler directly (no need to use exclusive).
+   *         This variant here is only for symmetry/convenance.
+   *
+   * @param opts additional configurations
+   * @param fn the handler to execute
+   */
+  export function exclusive<F>(
+    optsOrFn: ObjectHandlerOpts | ObjectHandler<F>,
+    fn?: ObjectHandler<F>
+  ): F {
+    if (typeof optsOrFn == "function") {
+      return new HandlerWrapper(HandlerKind.EXCLUSIVE, optsOrFn) as F;
+    }
+    const opts = optsOrFn satisfies ObjectHandlerOpts;
+    if (typeof fn !== "function") {
+      throw new TypeError("The second argument must be a function");
+    }
+    return new HandlerWrapper(
+      HandlerKind.EXCLUSIVE,
+      fn,
+      opts.accept,
+      opts.contentType
+    ) as F;
+  }
+
+  /**
+   * Creates a shared handler for a virtual Object.
+   *
+   * A shared handler allows a read-only concurrent execution
+   * for a given key.
+   *
+   * note: This applies only to a virtual object.
+   *
+   * @param opts additional configurations
+   * @param fn the handler to execute
+   */
+  export function shared<F>(
+    opts: ObjectHandlerOpts,
+    fn: ObjectSharedHandler<F>
+  ): F;
+
+  /**
+   * Creates a shared handler for a virtual Object.
+   *
+   * A shared handler allows a read-only concurrent execution
+   * for a given key.
+   *
+   * note: This applies only to a virtual object.
+   *
+   * @param opts additional configurations
+   * @param fn the handler to execute
+   */
+  export function shared<F>(fn: ObjectSharedHandler<F>): F;
+
+  /**
+   * Creates a shared handler for a virtual Object.
+   *
+   * A shared handler allows a read-only concurrent execution
+   * for a given key.
+   *
+   * note: This applies only to a virtual object.
+   *
+   * @param opts additional configurations
+   * @param fn the handler to execute
+   */
+  export function shared<F>(
+    optsOrFn: ObjectHandlerOpts | ObjectSharedHandler<F>,
+    fn?: ObjectSharedHandler<F>
+  ): F {
+    if (typeof optsOrFn == "function") {
+      return new HandlerWrapper(HandlerKind.SHARED, optsOrFn) as F;
+    }
+    const opts = optsOrFn satisfies ObjectHandlerOpts;
+    if (typeof fn !== "function") {
+      throw new TypeError("The second argument must be a function");
+    }
+    return new HandlerWrapper(
+      HandlerKind.SHARED,
+      fn,
+      opts.accept,
+      opts.contentType
+    ) as F;
+  }
+}
 
 export type ObjectOpts<U> = {
   [K in keyof U]: U[K] extends ObjectHandler<U[K]> ? U[K] : never;
@@ -114,5 +374,22 @@ export const object = <P extends string, M>(object: {
   if (!object.handlers) {
     throw new Error("object options must be defined");
   }
-  return { name: object.name, object: object.handlers as VirtualObject<M> };
+
+  const handlers = Object.entries(object.handlers).map(([name, handler]) => {
+    if (handler instanceof HandlerWrapper) {
+      return [name, handler.transpose()];
+    }
+    if (handler instanceof Function) {
+      return [
+        name,
+        new HandlerWrapper(HandlerKind.EXCLUSIVE, handler).transpose(),
+      ];
+    }
+    throw new TypeError(`Unexpected handler type ${name}`);
+  });
+
+  return {
+    name: object.name,
+    object: Object.fromEntries(handlers) as VirtualObject<M>,
+  };
 };

--- a/packages/restate-sdk/src/utils/serde.ts
+++ b/packages/restate-sdk/src/utils/serde.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { TerminalError } from "../types/errors";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function serializeJson(item: any | undefined): Uint8Array {
@@ -17,4 +18,17 @@ export function deserializeJson(buf: Uint8Array): any | undefined {
   const b = Buffer.from(buf);
   const str = b.toString("utf8");
   return JSON.parse(str);
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function serializeNoop(item: any | undefined): Uint8Array {
+  if (!(item instanceof Uint8Array)) {
+    throw new TerminalError(`Return value must be an instance of a Uint8Array`);
+  }
+  return item;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function deserializeNoop(buf: Uint8Array): any | undefined {
+  return buf;
 }

--- a/packages/restate-sdk/test/service_bind.test.ts
+++ b/packages/restate-sdk/test/service_bind.test.ts
@@ -29,9 +29,30 @@ const greeter: TestGreeter = {
   },
 };
 
+const greeterFoo = {
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  greet(ctx: restate.ObjectContext, req: TestRequest): Promise<TestResponse> {
+    return this.foo(ctx, req);
+  },
+
+  async foo(
+    ctx: restate.ObjectContext,
+    req: TestRequest
+  ): Promise<TestResponse> {
+    return TestResponse.create({ greeting: `Hello` });
+  },
+};
+
 describe("BindService", () => {
   it("should bind object literals", async () => {
     await new TestDriver(greeter, [
+      startMessage({ knownEntries: 1 }),
+      inputMessage(greetRequest("Pete")),
+    ]).run();
+  });
+
+  it("should bind and preserve `this`", async () => {
+    await new TestDriver(greeterFoo, [
       startMessage({ knownEntries: 1 }),
       inputMessage(greetRequest("Pete")),
     ]).run();


### PR DESCRIPTION
This PR adds shared handlers for virtual objects With this commit and runtime >= 0.9, it is possible to define handlers as shared.
A shared handler allows concurrent invocations for a given key, but it does not allow any state modification (only retrieval) This is useful to retrieve state keys for locked objects.