### PR TITLE
Support custom/raw input output serializers

### DIFF
--- a/packages/restate-sdk/src/endpoint/endpoint_impl.ts
+++ b/packages/restate-sdk/src/endpoint/endpoint_impl.ts
@@ -191,6 +191,9 @@ export class EndpointImpl implements RestateEndpoint {
 
     for (const [route, handler] of Object.entries(router)) {
       const wrapper = HandlerWrapper.fromHandler(handler);
+      if (!wrapper) {
+        throw new TypeError(`${route} is not a restate handler.`);
+      }
       wrapper.bindInstance(router);
       component.add(route, wrapper);
     }
@@ -206,10 +209,12 @@ export class EndpointImpl implements RestateEndpoint {
 
     for (const [route, handler] of Object.entries(router)) {
       const wrapper = HandlerWrapper.fromHandler(handler);
+      if (!wrapper) {
+        throw new TypeError(`${route} is not a restate handler.`);
+      }
       wrapper.bindInstance(router);
       component.add(route, wrapper);
     }
-
     this.addComponent(component);
   }
 }


### PR DESCRIPTION
This PR adds a way to configure  an handler, by:
* specify a different expected/returned content-type  
* pass in custom serializer/deserializer functions

This is useful for:
* raw payloads coming out of Kafka
* non JSON arguments like Protobuf for example.


Here is an example of how to invoke an handler with a Protobuf argument:

```ts
service({
   name : "GreeterService",
   handlers: {
      
         "DoGreet" : restate.handlers.handler({
              accept: "application/proto",
              contentType : "application/proto",
              inputDeserializer : GreetRequestMessage.decode,
              outputSerializer: GreetResponseMessage.encode
         }, 
        async (ctx, greet: GreetRequestMessage): Promise<GreetResponseMessage> => { .... }
  )
})
```

note that the `opts` part can be reused/abstracted to reduce the boilerplate, for example:

```ts
protobufHandler(messageType, theHandler) => restate.handlers.handler( { .. }, theHandler);
```

* Another example, simply receive raw binary payloads from Kafka

```ts
service( {
  ..
  signup: restate.handlers.handler( { 
     accept : "application/octet-stream",
     content-type: "application/octet-stream" },
     async (ctx, input: Uint8Array) => { ... }
 )
)
```

```
 