### PR TITLE
Add service discovery and service protocol checks 

### DIFF
--- a/packages/restate-sdk/proto/discovery.proto
+++ b/packages/restate-sdk/proto/discovery.proto
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/service-protocol/blob/main/LICENSE
+
+syntax = "proto3";
+
+package dev.restate.service.discovery;
+
+option java_package = "dev.restate.generated.service.discovery";
+option go_package = "restate.dev/sdk-go/pb/service/discovery";
+
+// Service discovery protocol version.
+enum ServiceDiscoveryProtocolVersion {
+  SERVICE_DISCOVERY_PROTOCOL_VERSION_UNSPECIFIED = 0;
+  // initial service discovery protocol version using endpoint_manifest_schema.json
+  V1 = 1;
+}

--- a/packages/restate-sdk/proto/protocol.proto
+++ b/packages/restate-sdk/proto/protocol.proto
@@ -14,6 +14,13 @@ package dev.restate.service.protocol;
 option java_package = "dev.restate.generated.service.protocol";
 option go_package = "restate.dev/sdk-go/pb/service/protocol";
 
+// Service protocol version.
+enum ServiceProtocolVersion {
+  SERVICE_PROTOCOL_VERSION_UNSPECIFIED = 0;
+  // initial service protocol version
+  V1 = 1;
+}
+
 // --- Core frames ---
 
 // Type: 0x0000 + 0
@@ -195,6 +202,60 @@ message GetStateKeysEntryMessage {
     StateKeys value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: Yes
+// Fallible: No
+// Type: 0x0800 + 8
+message GetPromiseEntryMessage {
+  string key = 1;
+
+  oneof result {
+    bytes value = 14;
+    Failure failure = 15;
+  };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: Yes
+// Fallible: No
+// Type: 0x0800 + 9
+message PeekPromiseEntryMessage {
+  string key = 1;
+
+  oneof result {
+    Empty empty = 13;
+    bytes value = 14;
+    Failure failure = 15;
+  };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: Yes
+// Fallible: No
+// Type: 0x0800 + A
+message CompletePromiseEntryMessage {
+  string key = 1;
+
+  // The value to use to complete the promise
+  oneof completion {
+    bytes completion_value = 2;
+    Failure completion_failure = 3;
+  };
+
+  oneof result {
+    // Returns empty if value was set successfully
+    Empty empty = 13;
+    // Returns a failure if the promise was already completed
+    Failure failure = 15;
+  }
 
   // Entry name
   string name = 12;

--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -439,7 +439,6 @@ export class ContextImpl implements ObjectContext {
           SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
           sideEffectMsg,
           false,
-          undefined,
           true
         );
 
@@ -475,7 +474,6 @@ export class ContextImpl implements ObjectContext {
         SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
         sideEffectMsg,
         false,
-        undefined,
         true
       );
 

--- a/packages/restate-sdk/src/io/decoder.ts
+++ b/packages/restate-sdk/src/io/decoder.ts
@@ -33,8 +33,6 @@ type DecoderState = { state: number; header: Header | undefined; buf: Buffer };
 const WAITING_FOR_HEADER = 0;
 const WAITING_FOR_BODY = 1;
 
-export const SUPPORTED_PROTOCOL_VERSION = 2;
-
 function initalDecoderState(buf: Buffer): DecoderState {
   return {
     state: WAITING_FOR_HEADER,
@@ -64,16 +62,6 @@ function decodeMessages(decoderState: DecoderState, out: Output): DecoderState {
         decoderState.header = materializedHeader;
         decoderState.state = WAITING_FOR_BODY;
 
-        // Check protocol version
-        if (
-          materializedHeader.protocolVersion !== undefined &&
-          materializedHeader.protocolVersion !== SUPPORTED_PROTOCOL_VERSION
-        ) {
-          throw new Error(
-            `Unsupported protocol version ${materializedHeader.protocolVersion}, only version ${SUPPORTED_PROTOCOL_VERSION} is supported`
-          );
-        }
-
         break;
       }
       case WAITING_FOR_BODY: {
@@ -100,7 +88,6 @@ function decodeMessages(decoderState: DecoderState, out: Output): DecoderState {
               header.messageType,
               message,
               header.completedFlag,
-              header.protocolVersion,
               header.requiresAckFlag
             )
           );

--- a/packages/restate-sdk/src/io/encoder.ts
+++ b/packages/restate-sdk/src/io/encoder.ts
@@ -49,7 +49,6 @@ export function encodeMessages(messages: Message[]): Uint8Array {
       BigInt(message.messageType),
       buf.length,
       message.completed,
-      message.protocolVersion, // only set for incoming start message
       message.requiresAck
     );
     const header64 = header.toU64be();

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -155,7 +155,6 @@ export class StateMachine implements RestateStreamConsumer {
     messageType: bigint,
     message: p.ProtocolMessage,
     completedFlag?: boolean,
-    protocolVersion?: number,
     requiresAckFlag?: boolean
   ): WrappedPromise<T | void> {
     // if the state machine is already closed, return a promise that never
@@ -176,13 +175,7 @@ export class StateMachine implements RestateStreamConsumer {
       );
 
       this.send(
-        new Message(
-          messageType,
-          message,
-          completedFlag,
-          protocolVersion,
-          requiresAckFlag
-        )
+        new Message(messageType, message, completedFlag, requiresAckFlag)
       );
     } else {
       this.console.debugJournalMessage(
@@ -290,7 +283,6 @@ export class StateMachine implements RestateStreamConsumer {
         new Message(
           COMBINATOR_ENTRY_MESSAGE,
           combinatorMessage,
-          undefined,
           undefined,
           true
         )

--- a/packages/restate-sdk/test/message_coders.test.ts
+++ b/packages/restate-sdk/test/message_coders.test.ts
@@ -10,15 +10,10 @@
  */
 
 import { describe, expect } from "@jest/globals";
-import {
-  decodeMessagesBuffer,
-  streamDecoder,
-  SUPPORTED_PROTOCOL_VERSION,
-} from "../src/io/decoder";
+import { streamDecoder } from "../src/io/decoder";
 import { Message } from "../src/types/types";
 import { backgroundInvokeMessage } from "./protoutils";
 import { encodeMessage } from "../src/io/encoder";
-import { START_MESSAGE_TYPE, StartMessage } from "../src/types/protocol";
 
 describe("The stream decoder", () => {
   it("should handle decoding of messages across chunks", () => {
@@ -48,27 +43,5 @@ describe("The stream decoder", () => {
     expect(result.length).toStrictEqual(1);
     expect(result[0]).toStrictEqual(largeMessage);
     expect(callbackCounter).toStrictEqual(2);
-  });
-
-  it("should fail when unsupported protocol version", () => {
-    const startMessage = encodeMessage(
-      new Message(
-        START_MESSAGE_TYPE,
-        new StartMessage({
-          id: Buffer.from(
-            "f311f1fdcb9863f0018bd3400ecd7d69b547204e776218b2",
-            "hex"
-          ),
-          debugId: "8xHx_cuYY_AAYvTQA7NfWm1RyBOd2IYsg",
-        }),
-        undefined,
-        SUPPORTED_PROTOCOL_VERSION + 1,
-        undefined
-      )
-    );
-
-    expect(() => decodeMessagesBuffer(Buffer.from(startMessage))).toThrow(
-      "Unsupported protocol version"
-    );
   });
 });

--- a/packages/restate-sdk/test/protocol_stream.test.ts
+++ b/packages/restate-sdk/test/protocol_stream.test.ts
@@ -23,7 +23,6 @@ import { Header, Message } from "../src/types/types";
 import stream from "stream";
 import { setTimeout } from "timers/promises";
 import { CompletablePromise } from "../src/utils/promises";
-import { SUPPORTED_PROTOCOL_VERSION } from "../src/io/decoder";
 
 // The following test suite is taken from headers.rs
 describe("Header", () => {
@@ -34,7 +33,7 @@ describe("Header", () => {
     expect(b).toStrictEqual(a);
   });
 
-  it("invoke_test", () => roundtripTest(newStart(1, 25)));
+  it("invoke_test", () => roundtripTest(newStart(25)));
 
   it("completion_test", () =>
     roundtripTest(newHeader(COMPLETION_MESSAGE_TYPE, 22)));
@@ -53,7 +52,7 @@ describe("Header", () => {
   it("custom_entry", () => roundtripTest(newHeader(0xfc00n, 10341)));
 
   it("custom_entry_with_requires_ack", () =>
-    roundtripTest(new Header(0xfc00n, 10341, undefined, undefined, true)));
+    roundtripTest(new Header(0xfc00n, 10341, undefined, true)));
 });
 
 describe("Restate Streaming Connection", () => {
@@ -91,8 +90,7 @@ describe("Restate Streaming Connection", () => {
           debugId: "abcd",
           knownEntries: 1337,
         }),
-        undefined,
-        SUPPORTED_PROTOCOL_VERSION
+        undefined
       )
     );
 
@@ -186,14 +184,8 @@ function newHeader(messageTypeId: bigint, length: number): Header {
   return new Header(messageTypeId, length);
 }
 
-function newStart(protocolVersion: number, length: number): Header {
-  return new Header(
-    START_MESSAGE_TYPE,
-    length,
-    undefined,
-    protocolVersion,
-    undefined
-  );
+function newStart(length: number): Header {
+  return new Header(START_MESSAGE_TYPE, length, undefined, undefined);
 }
 
 function newCompletableEntry(
@@ -248,7 +240,6 @@ function roundtripTest(a: Header) {
   const b = Header.fromU64be(a.toU64be());
   expect(b.messageType).toStrictEqual(a.messageType);
   expect(b.frameLength).toStrictEqual(a.frameLength);
-  expect(b.protocolVersion).toStrictEqual(a.protocolVersion);
   sameTruthness(a.completedFlag, b.completedFlag);
   sameTruthness(a.requiresAckFlag, b.requiresAckFlag);
   sameTruthness(a.partialStateFlag, b.partialStateFlag);

--- a/packages/restate-sdk/test/protoutils.ts
+++ b/packages/restate-sdk/test/protoutils.ts
@@ -68,7 +68,6 @@ import {
   RestateErrorCodes,
   UNKNOWN_ERROR_CODE,
 } from "../src/types/errors";
-import { SUPPORTED_PROTOCOL_VERSION } from "../src/io/decoder";
 
 export type StartMessageOpts = {
   knownEntries?: number;
@@ -97,7 +96,6 @@ export function startMessage({
       key: key ?? "Till",
     }),
     undefined,
-    SUPPORTED_PROTOCOL_VERSION,
     undefined
   );
 }
@@ -417,7 +415,6 @@ export function sideEffectMessage<T>(
         result: { case: "value", value: Buffer.from(JSON.stringify(value)) },
       }),
       false,
-      undefined,
       true
     );
   } else if (failure !== undefined) {
@@ -428,7 +425,6 @@ export function sideEffectMessage<T>(
         result: { case: "failure", value: failure },
       }),
       false,
-      undefined,
       true
     );
   } else {
@@ -436,7 +432,6 @@ export function sideEffectMessage<T>(
       SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
       new RunEntryMessage({ name }),
       false,
-      undefined,
       true
     );
   }
@@ -507,7 +502,6 @@ export function combinatorEntryMessage(
       combinatorId,
       journalEntriesOrder,
     }),
-    undefined,
     undefined,
     true
   );

--- a/packages/restate-sdk/test/testdriver.ts
+++ b/packages/restate-sdk/test/testdriver.ts
@@ -113,7 +113,6 @@ export class TestDriver implements Connection {
         key: startEntry.key,
       }),
       msg.completed,
-      msg.protocolVersion,
       msg.requiresAck
     );
 


### PR DESCRIPTION
This commits add support for verifying the service discovery protocol and
the service protocol which are now communicated via HTTP headers.

This fixes https://github.com/restatedev/sdk-typescript/issues/356.