### PR TITLE
Make failure to serialize/deserialize JSON a TerminalError

### DIFF
--- a/packages/restate-sdk/src/utils/serde.ts
+++ b/packages/restate-sdk/src/utils/serde.ts
@@ -6,8 +6,12 @@ export function serializeJson(item: any | undefined): Uint8Array {
   if (item === undefined) {
     return Buffer.alloc(0);
   }
-  const str = JSON.stringify(item);
-  return Buffer.from(str);
+  try {
+    const str = JSON.stringify(item);
+    return Buffer.from(str);
+  } catch (e) {
+    throw new TerminalError(`Failed to serialize JSON: ${e}`);
+  }
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -17,7 +21,11 @@ export function deserializeJson(buf: Uint8Array): any | undefined {
   }
   const b = Buffer.from(buf);
   const str = b.toString("utf8");
-  return JSON.parse(str);
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    throw new TerminalError(`Failed to parse JSON: ${e}`);
+  }
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
With this PR


```
[restate] [2024-06-03T16:46:13.475Z] INFO:  Listening on 9080...
[restate] [greeter/greet][inv_1j2SK8rbeE2M2ZmmjJuXLDxQfQsmtjEwzT][2024-06-03T16:46:25.508Z] INFO:  Invoking function.
[restate] [greeter/greet][inv_1j2SK8rbeE2M2ZmmjJuXLDxQfQsmtjEwzT][2024-06-03T16:46:25.510Z] WARN:  Function completed with an error.
 TerminalError: Failed to parse JSON: SyntaxError: Unexpected token 'b', "b"" is not valid JSON
    at HandlerWrapper.deserializeJson [as deserializer] (/home/igal/work/sdk-typescript/packages/restate-sdk/dist/src/utils/serde.js:31:15)
    at HandlerWrapper.invoke (/home/igal/work/sdk-typescript/packages/restate-sdk/dist/src/types/rpc.js:66:26)
    at ServiceHandler.invoke (/home/igal/work/sdk-typescript/packages/restate-sdk/dist/src/types/components.js:95:36)
    at StateMachine.invoke (/home/igal/work/sdk-typescript/packages/restate-sdk/dist/src/state_machine.js:224:14)
    at handleInvocation (/home/igal/work/sdk-typescript/packages/restate-sdk/dist/src/endpoint/http2_handler.js:179:28)
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 500,
  [cause]: undefined
}
```