### PR TITLE
Denodeify

### DIFF
--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -55,7 +55,6 @@ import {
   PEEK_PROMISE_MESSAGE_TYPE,
   COMPLETE_PROMISE_MESSAGE_TYPE,
 } from "./types/protocol";
-import { AsyncLocalStorage } from "node:async_hooks";
 import {
   RetryableError,
   TerminalError,
@@ -82,33 +81,16 @@ import { WrappedPromise } from "./utils/promises";
 import { Buffer } from "node:buffer";
 import { deserializeJson, serializeJson } from "./utils/serde";
 
-export enum CallContextType {
-  None,
-  Run,
-}
-
-export interface CallContext {
-  type: CallContextType;
-  delay?: number;
-}
-
 export type InternalCombineablePromise<T> = CombineablePromise<T> & {
   journalIndex: number;
 };
 
 export class ContextImpl implements ObjectContext, WorkflowContext {
-  // here, we capture the context information for actions on the Restate context that
-  // are executed within other actions, such as
-  // ctx.oneWayCall( () => client.foo(bar) );
-  // we also use this information to ensure we check that only allowed operations are
-  // used. Within side-effects, no operations are allowed on the RestateContext.
-  // For example, this is illegal: 'ctx.sideEffect(() => {await ctx.get("my-state")})'
-  static callContext = new AsyncLocalStorage<CallContext>();
-
   // This is used to guard users against calling ctx.sideEffect without awaiting it.
   // See https://github.com/restatedev/sdk-typescript/issues/197 for more details.
   private executingRun = false;
   private readonly invocationRequest: Request;
+  public readonly rand: Rand;
 
   public readonly date: ContextDate = {
     now: (): Promise<number> => {
@@ -129,8 +111,7 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
     invocationHeaders: ReadonlyMap<string, string>,
     attemptHeaders: ReadonlyMap<string, string | string[] | undefined>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly stateMachine: StateMachine,
-    public readonly rand: Rand = new RandImpl(id)
+    readonly stateMachine: StateMachine
   ) {
     this.invocationRequest = {
       id,
@@ -138,7 +119,9 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
       attemptHeaders,
       body: invocationValue,
     };
+    this.rand = new RandImpl(id, this.checkState.bind(this));
   }
+
   workflowClient<D>(
     opts: WorkflowDefinitionFrom<D>,
     key: string
@@ -451,13 +434,9 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
     nameOrAction: string | RunAction<T>,
     actionSecondParameter?: RunAction<T>
   ): Promise<T> {
+    this.checkState("run");
+
     const { name, action } = unpack(nameOrAction, actionSecondParameter);
-    if (this.isInRun()) {
-      throw new TerminalError("Not possible to nest runs.", {
-        errorCode: INTERNAL_ERROR_CODE,
-      });
-    }
-    this.checkNotExecutingRun();
     this.executingRun = true;
 
     const executeRun = async () => {
@@ -472,10 +451,7 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
 
       let sideEffectResult: T;
       try {
-        sideEffectResult = await ContextImpl.callContext.run(
-          { type: CallContextType.Run },
-          () => action()
-        );
+        sideEffectResult = await action();
       } catch (e) {
         if (!(e instanceof TerminalError)) {
           ///non terminal errors are retirable.
@@ -679,15 +655,10 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
 
   // -- Various private methods
 
-  private isInRun(): boolean {
-    const context = ContextImpl.callContext.getStore();
-    return context?.type === CallContextType.Run;
-  }
-
-  private checkNotExecutingRun() {
+  private checkNotExecutingRun(callType: string) {
     if (this.executingRun) {
       throw new TerminalError(
-        `Invoked a RestateContext method while a run() is still executing.
+        `Invoked a RestateContext method (${callType}) while a run() is still executing.
           Make sure you await the ctx.run() call before using any other RestateContext method.`,
         { errorCode: INTERNAL_ERROR_CODE }
       );
@@ -695,18 +666,7 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
   }
 
   private checkState(callType: string): void {
-    const context = ContextImpl.callContext.getStore();
-    if (!context) {
-      this.checkNotExecutingRun();
-      return;
-    }
-
-    if (context.type === CallContextType.Run) {
-      throw new TerminalError(
-        `You cannot do ${callType} calls from within a run.`,
-        { errorCode: INTERNAL_ERROR_CODE }
-      );
-    }
+    this.checkNotExecutingRun(callType);
   }
 
   markCombineablePromise<T>(

--- a/packages/restate-sdk/src/io/decoder.ts
+++ b/packages/restate-sdk/src/io/decoder.ts
@@ -23,7 +23,6 @@
 import stream from "node:stream";
 import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
 import { Header, Message } from "../types/types";
-import assert from "node:assert";
 import { ensureError } from "../types/errors";
 import { Buffer } from "node:buffer";
 import { readBigUInt64BE } from "../utils/buffer";
@@ -158,4 +157,8 @@ export function decodeMessagesBuffer(buffer: Buffer): Message[] {
   }
 
   return decodedEntries;
+}
+
+function assert(value: boolean, msg?: string): asserts value {
+  if (!value) throw new Error(msg || "assertion error");
 }

--- a/packages/restate-sdk/src/io/decoder.ts
+++ b/packages/restate-sdk/src/io/decoder.ts
@@ -26,6 +26,7 @@ import { Header, Message } from "../types/types";
 import assert from "node:assert";
 import { ensureError } from "../types/errors";
 import { Buffer } from "node:buffer";
+import { readBigUInt64BE } from "../utils/buffer";
 
 type Output = { push(msg: Message): void };
 type DecoderState = { state: number; header: Header | undefined; buf: Buffer };
@@ -157,17 +158,4 @@ export function decodeMessagesBuffer(buffer: Buffer): Message[] {
   }
 
   return decodedEntries;
-}
-
-function readBigUInt64BE(buf: Buffer): bigint {
-  return (
-    (BigInt(buf.readUInt8(0)) << 56n) |
-    (BigInt(buf.readUInt8(1)) << 48n) |
-    (BigInt(buf.readUInt8(2)) << 40n) |
-    (BigInt(buf.readUInt8(3)) << 32n) |
-    (BigInt(buf.readUInt8(4)) << 24n) |
-    (BigInt(buf.readUInt8(5)) << 16n) |
-    (BigInt(buf.readUInt8(6)) << 8n) |
-    BigInt(buf.readUInt8(7))
-  );
 }

--- a/packages/restate-sdk/src/io/encoder.ts
+++ b/packages/restate-sdk/src/io/encoder.ts
@@ -13,6 +13,7 @@ import stream from "node:stream";
 import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
 import { Header, Message } from "../types/types";
 import { Buffer } from "node:buffer";
+import { writeBigUInt64BE } from "../utils/buffer";
 
 export function streamEncoder(): stream.Transform {
   return new stream.Transform({
@@ -59,15 +60,4 @@ export function encodeMessages(messages: Message[]): Uint8Array {
     chunks.push(buf);
   }
   return Buffer.concat(chunks);
-}
-
-function writeBigUInt64BE(value: bigint, buf: Buffer): void {
-  buf.writeUInt8(Number((value >> 56n) & 0xffn), 0);
-  buf.writeUInt8(Number((value >> 48n) & 0xffn), 1);
-  buf.writeUInt8(Number((value >> 40n) & 0xffn), 2);
-  buf.writeUInt8(Number((value >> 32n) & 0xffn), 3);
-  buf.writeUInt8(Number((value >> 24n) & 0xffn), 4);
-  buf.writeUInt8(Number((value >> 16n) & 0xffn), 5);
-  buf.writeUInt8(Number((value >> 8n) & 0xffn), 6);
-  buf.writeUInt8(Number(value & 0xffn), 7);
 }

--- a/packages/restate-sdk/src/utils/buffer.ts
+++ b/packages/restate-sdk/src/utils/buffer.ts
@@ -1,0 +1,66 @@
+// Functions adapted from https://github.com/nodejs/node/blob/main/lib/internal/buffer.js
+// MIT licensed
+// Copyright Node.js contributors
+
+export function readBigUInt64LE(buf: Uint8Array, offset = 0): bigint {
+  const first = buf[offset];
+  const last = buf[offset + 7];
+  if (first === undefined || last === undefined)
+    throw new Error("out of bounds");
+
+  const lo =
+    first +
+    buf[++offset] * 2 ** 8 +
+    buf[++offset] * 2 ** 16 +
+    buf[++offset] * 2 ** 24;
+
+  const hi =
+    buf[++offset] +
+    buf[++offset] * 2 ** 8 +
+    buf[++offset] * 2 ** 16 +
+    last * 2 ** 24;
+
+  return BigInt(lo) + (BigInt(hi) << 32n);
+}
+
+export function readBigUInt64BE(buf: Uint8Array, offset = 0): bigint {
+  const first = buf[offset];
+  const last = buf[offset + 7];
+  if (first === undefined || last === undefined)
+    throw new Error("out of bounds");
+  const hi =
+    first * 2 ** 24 +
+    buf[++offset] * 2 ** 16 +
+    buf[++offset] * 2 ** 8 +
+    buf[++offset];
+  const lo =
+    buf[++offset] * 2 ** 24 +
+    buf[++offset] * 2 ** 16 +
+    buf[++offset] * 2 ** 8 +
+    last;
+  return (BigInt(hi) << 32n) + BigInt(lo);
+}
+
+export function writeBigUInt64BE(
+  value: bigint,
+  buf: Buffer,
+  offset = 0
+): number {
+  let lo = Number(value & 0xffffffffn);
+  buf[offset + 7] = lo;
+  lo = lo >> 8;
+  buf[offset + 6] = lo;
+  lo = lo >> 8;
+  buf[offset + 5] = lo;
+  lo = lo >> 8;
+  buf[offset + 4] = lo;
+  let hi = Number((value >> 32n) & 0xffffffffn);
+  buf[offset + 3] = hi;
+  hi = hi >> 8;
+  buf[offset + 2] = hi;
+  hi = hi >> 8;
+  buf[offset + 1] = hi;
+  hi = hi >> 8;
+  buf[offset] = hi;
+  return offset + 8;
+}

--- a/packages/restate-sdk/src/utils/promises.ts
+++ b/packages/restate-sdk/src/utils/promises.ts
@@ -42,7 +42,8 @@ export function wrapDeeply<T>(
       | null
       | undefined
   ) => WrappedPromise<TResult1 | TResult2>;
-  if (Object.hasOwn(promise, "transform")) {
+  // Object.hasOwn doesn't have great support yet, but this has the same effect
+  if (Object.prototype.hasOwnProperty.call(promise, "transform")) {
     const wrappedPromise = promise as WrappedPromise<T>;
     transform = (onfulfilled, onrejected) =>
       wrapDeeply(wrappedPromise.transform(onfulfilled, onrejected), onThen);

--- a/packages/restate-sdk/src/utils/rand.ts
+++ b/packages/restate-sdk/src/utils/rand.ts
@@ -13,8 +13,6 @@
 //! License MIT
 
 import { Rand } from "../context";
-import { INTERNAL_ERROR_CODE, TerminalError } from "../types/errors";
-import { CallContextType, ContextImpl } from "../context_impl";
 import { createHash } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { readBigUInt64LE } from "./buffer";
@@ -22,7 +20,10 @@ import { readBigUInt64LE } from "./buffer";
 export class RandImpl implements Rand {
   private randstate256: [bigint, bigint, bigint, bigint];
 
-  constructor(id: Buffer | [bigint, bigint, bigint, bigint]) {
+  constructor(
+    id: Buffer | [bigint, bigint, bigint, bigint],
+    private readonly checkState: (state: string) => void = () => undefined
+  ) {
     if (id instanceof Buffer) {
       // hash the invocation ID, which is known to contain 74 bits of entropy
       const hash = createHash("sha256").update(id).digest();
@@ -69,20 +70,10 @@ export class RandImpl implements Rand {
     return ((x << k) & RandImpl.U64_MASK) | (x >> (64n - k));
   }
 
-  checkContext() {
-    const context = ContextImpl.callContext.getStore();
-    if (context && context.type === CallContextType.Run) {
-      throw new TerminalError(
-        `You may not call methods on Rand from within a run().`,
-        { errorCode: INTERNAL_ERROR_CODE }
-      );
-    }
-  }
-
   static U53_MASK = (1n << 53n) - 1n;
 
   public random(): number {
-    this.checkContext();
+    this.checkState("rand.random");
 
     // first generate a uint in range [0,2^53), which can be mapped 1:1 to a float64 in [0,1)
     const u53 = this.u64() & RandImpl.U53_MASK;
@@ -91,7 +82,7 @@ export class RandImpl implements Rand {
   }
 
   public uuidv4(): string {
-    this.checkContext();
+    this.checkState("rand.uuidv4");
 
     const buf = Buffer.alloc(16);
     buf.writeBigUInt64LE(this.u64(), 0);

--- a/packages/restate-sdk/src/utils/rand.ts
+++ b/packages/restate-sdk/src/utils/rand.ts
@@ -17,6 +17,7 @@ import { INTERNAL_ERROR_CODE, TerminalError } from "../types/errors";
 import { CallContextType, ContextImpl } from "../context_impl";
 import { createHash } from "node:crypto";
 import { Buffer } from "node:buffer";
+import { readBigUInt64LE } from "./buffer";
 
 export class RandImpl implements Rand {
   private randstate256: [bigint, bigint, bigint, bigint];
@@ -27,10 +28,10 @@ export class RandImpl implements Rand {
       const hash = createHash("sha256").update(id).digest();
 
       this.randstate256 = [
-        hash.readBigUInt64LE(0),
-        hash.readBigUInt64LE(8),
-        hash.readBigUInt64LE(16),
-        hash.readBigUInt64LE(24),
+        readBigUInt64LE(hash, 0),
+        readBigUInt64LE(hash, 8),
+        readBigUInt64LE(hash, 16),
+        readBigUInt64LE(hash, 24),
       ];
     } else {
       this.randstate256 = id;


### PR DESCRIPTION
1. Remove Object.hasOwn as LLRT doesn't implement it
2. Inline Node's implementations of the uint64 buffer functions as neither workers nor llrt supports it
3. Remove assert as neither workers nor llrt supports it (and its a single line :p)
4. Remove async_hooks as this is not standardised and cannot be polyfilled without runtime support. Fall back on the flag which says whether we are currently executing a run