### PR TITLE
Use eslint to require import and export type statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "no-console": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/restrict-template-expressions": [
       "error",
       {

--- a/packages/restate-sdk/src/connection/buffered_connection.ts
+++ b/packages/restate-sdk/src/connection/buffered_connection.ts
@@ -1,6 +1,6 @@
 import { encodeMessages } from "../io/encoder";
-import { Message } from "../types/types";
-import { Buffer } from "node:buffer";
+import type { Message } from "../types/types";
+import type { Buffer } from "node:buffer";
 
 export class BufferedConnection {
   private queue: Message[] = [];

--- a/packages/restate-sdk/src/connection/connection.ts
+++ b/packages/restate-sdk/src/connection/connection.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { Message } from "../types/types";
+import type { Message } from "../types/types";
 
 /**
  * A connection from the service/SDK to Restate.

--- a/packages/restate-sdk/src/connection/http_connection.ts
+++ b/packages/restate-sdk/src/connection/http_connection.ts
@@ -9,14 +9,14 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import stream from "node:stream";
+import type stream from "node:stream";
 import { streamDecoder } from "../io/decoder";
-import { Connection, RestateStreamConsumer } from "./connection";
-import { Message } from "../types/types";
+import type { Connection, RestateStreamConsumer } from "./connection";
+import type { Message } from "../types/types";
 import { rlog } from "../logger";
 import { finished } from "node:stream/promises";
 import { BufferedConnection } from "./buffered_connection";
-import { Http2ServerRequest, IncomingHttpHeaders } from "node:http2";
+import type { Http2ServerRequest, IncomingHttpHeaders } from "node:http2";
 
 // utility promise, for cases where we want to save allocation of an extra promise
 const RESOLVED: Promise<void> = Promise.resolve();

--- a/packages/restate-sdk/src/connection/lambda_connection.ts
+++ b/packages/restate-sdk/src/connection/lambda_connection.ts
@@ -9,14 +9,14 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { Connection } from "./connection";
+import type { Connection } from "./connection";
 import { encodeMessage } from "../io/encoder";
 import {
   ERROR_MESSAGE_TYPE,
   OUTPUT_ENTRY_MESSAGE_TYPE,
   SUSPENSION_MESSAGE_TYPE,
 } from "../types/protocol";
-import { Message } from "../types/types";
+import type { Message } from "../types/types";
 import { rlog } from "../logger";
 import { Buffer } from "node:buffer";
 

--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {
+import type {
   CombineablePromise,
   ContextDate,
   DurablePromise,
@@ -22,7 +22,8 @@ import {
   SendOptions,
   WorkflowContext,
 } from "./context";
-import { StateMachine } from "./state_machine";
+import type { StateMachine } from "./state_machine";
+import type { GetStateKeysEntryMessage_StateKeys } from "./generated/proto/protocol_pb";
 import {
   AwakeableEntryMessage,
   OneWayCallEntryMessage,
@@ -30,7 +31,6 @@ import {
   Empty,
   GetStateEntryMessage,
   GetStateKeysEntryMessage,
-  GetStateKeysEntryMessage_StateKeys,
   CallEntryMessage,
   RunEntryMessage,
   SleepEntryMessage,
@@ -65,8 +65,10 @@ import {
   errorToFailure,
 } from "./types/errors";
 import { jsonSerialize, jsonDeserialize } from "./utils/utils";
-import { PartialMessage, protoInt64 } from "@bufbuild/protobuf";
-import { Client, HandlerKind, SendClient } from "./types/rpc";
+import type { PartialMessage } from "@bufbuild/protobuf";
+import { protoInt64 } from "@bufbuild/protobuf";
+import type { Client, SendClient } from "./types/rpc";
+import { HandlerKind } from "./types/rpc";
 import type {
   Service,
   ServiceDefinitionFrom,
@@ -77,7 +79,7 @@ import type {
 } from "@restatedev/restate-sdk-core";
 import { RandImpl } from "./utils/rand";
 import { newJournalEntryPromiseId } from "./promise_combinator_tracker";
-import { WrappedPromise } from "./utils/promises";
+import type { WrappedPromise } from "./utils/promises";
 import { Buffer } from "node:buffer";
 import { deserializeJson, serializeJson } from "./utils/serde";
 

--- a/packages/restate-sdk/src/endpoint/cloudflare_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/cloudflare_endpoint.ts
@@ -15,7 +15,7 @@ import type {
 } from "@restatedev/restate-sdk-core";
 
 import { rlog } from "../logger";
-import { Component } from "../types/components";
+import type { Component } from "../types/components";
 
 import type { KeySetV1 } from "./request_signing/v1";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";

--- a/packages/restate-sdk/src/endpoint/endpoint_builder.ts
+++ b/packages/restate-sdk/src/endpoint/endpoint_builder.ts
@@ -18,16 +18,17 @@ import type {
 } from "@restatedev/restate-sdk-core";
 
 import { HandlerWrapper } from "../types/rpc";
+import type { Component } from "../types/components";
 import {
-  Component,
   ServiceComponent,
   VirtualObjectComponent,
   WorkflowComponent,
 } from "../types/components";
 
-import * as discovery from "../types/discovery";
-import { KeySetV1, parseKeySetV1 } from "./request_signing/v1";
-import { WorkflowDefinition } from "@restatedev/restate-sdk-core";
+import type * as discovery from "../types/discovery";
+import type { KeySetV1 } from "./request_signing/v1";
+import { parseKeySetV1 } from "./request_signing/v1";
+import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";
 
 function isServiceDefinition<P extends string, M>(
   m: Record<string, any>

--- a/packages/restate-sdk/src/endpoint/handlers/cloudflare.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/cloudflare.ts
@@ -9,8 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { ExportedHandler, Request, Response } from "@cloudflare/workers-types";
-import { GenericHandler, RestateRequest } from "./generic";
+import type { ExportedHandler, Request } from "@cloudflare/workers-types";
+import { Response } from "@cloudflare/workers-types";
+import type { GenericHandler, RestateRequest } from "./generic";
 
 export class CloudflareHandler implements ExportedHandler {
   constructor(private readonly handler: GenericHandler) {}

--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -13,7 +13,7 @@ import { rlog } from "../../logger";
 import { LambdaConnection } from "../../connection/lambda_connection";
 import { InvocationBuilder } from "../../invocation";
 import { decodeMessagesBuffer } from "../../io/decoder";
-import { Message } from "../../types/types";
+import type { Message } from "../../types/types";
 import { StateMachine } from "../../state_machine";
 import { ensureError } from "../../types/errors";
 import {
@@ -25,13 +25,14 @@ import {
   serviceProtocolVersionToHeaderValue,
 } from "../../types/protocol";
 import { ProtocolMode } from "../../types/discovery";
-import { ComponentHandler, parseUrlComponents } from "../../types/components";
+import type { ComponentHandler } from "../../types/components";
+import { parseUrlComponents } from "../../types/components";
 import { validateRequestSignature } from "../request_signing/validate";
 import { X_RESTATE_SERVER } from "../../user_agent";
 import { Buffer } from "node:buffer";
 import { ServiceDiscoveryProtocolVersion } from "../../generated/proto/discovery_pb";
-import { ServiceProtocolVersion } from "../../generated/proto/protocol_pb";
-import { EndpointBuilder } from "../endpoint_builder";
+import type { ServiceProtocolVersion } from "../../generated/proto/protocol_pb";
+import type { EndpointBuilder } from "../endpoint_builder";
 
 export interface Headers {
   [name: string]: string | string[] | undefined;

--- a/packages/restate-sdk/src/endpoint/handlers/lambda.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/lambda.ts
@@ -17,7 +17,7 @@ import type {
   Context,
 } from "aws-lambda";
 import { Buffer } from "node:buffer";
-import { GenericHandler, RestateRequest } from "./generic";
+import type { GenericHandler, RestateRequest } from "./generic";
 
 export class LambdaHandler {
   constructor(private readonly handler: GenericHandler) {}

--- a/packages/restate-sdk/src/endpoint/handlers/node.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/node.ts
@@ -11,16 +11,19 @@
 
 import stream from "node:stream";
 import { pipeline, finished } from "node:stream/promises";
-import http2, { Http2ServerRequest, Http2ServerResponse } from "http2";
+import type { Http2ServerRequest, Http2ServerResponse } from "http2";
+import type http2 from "http2";
 import { RestateHttp2Connection } from "../../connection/http_connection";
 import { ensureError } from "../../types/errors";
 import { InvocationBuilder } from "../../invocation";
 import { StateMachine } from "../../state_machine";
 import { rlog } from "../../logger";
-import { ComponentHandler, parseUrlComponents } from "../../types/components";
-import { Endpoint, ProtocolMode } from "../../types/discovery";
+import type { ComponentHandler } from "../../types/components";
+import { parseUrlComponents } from "../../types/components";
+import type { Endpoint } from "../../types/discovery";
+import { ProtocolMode } from "../../types/discovery";
 import { validateRequestSignature } from "../request_signing/validate";
-import { ServerHttp2Stream } from "node:http2";
+import type { ServerHttp2Stream } from "node:http2";
 import { X_RESTATE_SERVER } from "../../user_agent";
 import {
   isServiceProtocolVersionSupported,
@@ -30,7 +33,7 @@ import {
   serviceProtocolVersionToHeaderValue,
 } from "../../types/protocol";
 import { ServiceDiscoveryProtocolVersion } from "../../generated/proto/discovery_pb";
-import { EndpointBuilder } from "../endpoint_builder";
+import type { EndpointBuilder } from "../endpoint_builder";
 
 export class Http2Handler {
   constructor(private readonly endpoint: EndpointBuilder) {}

--- a/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
@@ -15,12 +15,12 @@ import type {
 } from "@restatedev/restate-sdk-core";
 
 import { rlog } from "../logger";
-import { Component } from "../types/components";
+import type { Component } from "../types/components";
 
 import type { KeySetV1 } from "./request_signing/v1";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";
 import { EndpointBuilder } from "./endpoint_builder";
-import {
+import type {
   RestateEndpoint,
   RestateEndpointBase,
   ServiceBundle,

--- a/packages/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/node_endpoint.ts
@@ -12,7 +12,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { RestateEndpoint, ServiceBundle } from "../public_api";
+import type { RestateEndpoint, ServiceBundle } from "../public_api";
 import type {
   ServiceDefinition,
   VirtualObjectDefinition,
@@ -23,7 +23,7 @@ import type { Http2ServerRequest, Http2ServerResponse } from "http2";
 import * as http2 from "http2";
 import { Http2Handler } from "./handlers/node";
 import { LambdaHandler } from "./handlers/lambda";
-import { Component } from "../types/components";
+import type { Component } from "../types/components";
 
 import type { KeySetV1 } from "./request_signing/v1";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";

--- a/packages/restate-sdk/src/endpoint/request_signing/ed25519.ts
+++ b/packages/restate-sdk/src/endpoint/request_signing/ed25519.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { Buffer } from "node:buffer";
+import type { Buffer } from "node:buffer";
 import { webcrypto } from "node:crypto";
 import * as crypto from "node:crypto";
 

--- a/packages/restate-sdk/src/endpoint/request_signing/v1.ts
+++ b/packages/restate-sdk/src/endpoint/request_signing/v1.ts
@@ -10,8 +10,10 @@
  */
 
 import { Buffer } from "node:buffer";
-import { headerValue, ValidateResponse, ValidateSuccess } from "./validate";
-import { importKey, Key, verify } from "./ed25519";
+import type { ValidateResponse, ValidateSuccess } from "./validate";
+import { headerValue } from "./validate";
+import type { Key } from "./ed25519";
+import { importKey, verify } from "./ed25519";
 import base from "./basex";
 
 const JWT_HEADER = "x-restate-jwt-v1";

--- a/packages/restate-sdk/src/endpoint/request_signing/validate.ts
+++ b/packages/restate-sdk/src/endpoint/request_signing/validate.ts
@@ -9,7 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { KeySetV1, SCHEME_V1, validateV1 } from "./v1";
+import type { KeySetV1 } from "./v1";
+import { SCHEME_V1, validateV1 } from "./v1";
 
 const SIGNATURE_SCHEME_HEADER = "x-restate-signature-scheme";
 

--- a/packages/restate-sdk/src/invocation.ts
+++ b/packages/restate-sdk/src/invocation.ts
@@ -11,16 +11,19 @@
 
 /*eslint-disable @typescript-eslint/no-non-null-assertion*/
 
-import { Message } from "./types/types";
-import { InputEntryMessage, StartMessage } from "./generated/proto/protocol_pb";
+import type { Message } from "./types/types";
+import type {
+  InputEntryMessage,
+  StartMessage,
+} from "./generated/proto/protocol_pb";
 import { formatMessageAsJson } from "./utils/utils";
 import { INPUT_ENTRY_MESSAGE_TYPE, START_MESSAGE_TYPE } from "./types/protocol";
-import { RestateStreamConsumer } from "./connection/connection";
+import type { RestateStreamConsumer } from "./connection/connection";
 import { LocalStateStore } from "./local_state_store";
 import { ensureError } from "./types/errors";
 import { LoggerContext } from "./logger";
 import { CompletablePromise } from "./utils/promises";
-import { ComponentHandler } from "./types/components";
+import type { ComponentHandler } from "./types/components";
 import { Buffer } from "node:buffer";
 
 enum State {

--- a/packages/restate-sdk/src/io/decoder.ts
+++ b/packages/restate-sdk/src/io/decoder.ts
@@ -23,7 +23,7 @@
 import stream from "node:stream";
 import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
 import { Header, Message } from "../types/types";
-import { AnyMessage } from "@bufbuild/protobuf";
+import type { AnyMessage } from "@bufbuild/protobuf";
 import { ensureError } from "../types/errors";
 import { Buffer } from "node:buffer";
 import { readBigUInt64BE } from "../utils/buffer";

--- a/packages/restate-sdk/src/io/encoder.ts
+++ b/packages/restate-sdk/src/io/encoder.ts
@@ -11,7 +11,8 @@
 
 import stream from "node:stream";
 import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
-import { Header, Message } from "../types/types";
+import type { Message } from "../types/types";
+import { Header } from "../types/types";
 import { Buffer } from "node:buffer";
 import { writeBigUInt64BE } from "../utils/buffer";
 

--- a/packages/restate-sdk/src/journal.ts
+++ b/packages/restate-sdk/src/journal.ts
@@ -10,41 +10,40 @@
  */
 
 import * as p from "./types/protocol";
-import {
-  Failure,
-  GetStateKeysEntryMessage_StateKeys,
-  RunEntryMessage,
-} from "./generated/proto/protocol_pb";
+import type { Failure, RunEntryMessage } from "./generated/proto/protocol_pb";
+import { GetStateKeysEntryMessage_StateKeys } from "./generated/proto/protocol_pb";
+import type {
+  AwakeableEntryMessage,
+  CompletionMessage,
+  EntryAckMessage,
+  GetStateEntryMessage,
+  GetStateKeysEntryMessage,
+  CallEntryMessage,
+  OutputEntryMessage,
+  InputEntryMessage,
+  SleepEntryMessage,
+  SuspensionMessage,
+} from "./types/protocol";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
-  AwakeableEntryMessage,
   BACKGROUND_INVOKE_ENTRY_MESSAGE_TYPE,
   CLEAR_ALL_STATE_ENTRY_MESSAGE_TYPE,
   CLEAR_STATE_ENTRY_MESSAGE_TYPE,
   COMBINATOR_ENTRY_MESSAGE,
   COMPLETE_AWAKEABLE_ENTRY_MESSAGE_TYPE,
-  CompletionMessage,
-  EntryAckMessage,
   GET_STATE_ENTRY_MESSAGE_TYPE,
   GET_STATE_KEYS_ENTRY_MESSAGE_TYPE,
-  GetStateEntryMessage,
-  GetStateKeysEntryMessage,
   INVOKE_ENTRY_MESSAGE_TYPE,
-  CallEntryMessage,
   OUTPUT_ENTRY_MESSAGE_TYPE,
-  OutputEntryMessage,
   INPUT_ENTRY_MESSAGE_TYPE,
-  InputEntryMessage,
   SET_STATE_ENTRY_MESSAGE_TYPE,
   SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
   SLEEP_ENTRY_MESSAGE_TYPE,
-  SleepEntryMessage,
   SUSPENSION_MESSAGE_TYPE,
-  SuspensionMessage,
 } from "./types/protocol";
 import { equalityCheckers, jsonDeserialize } from "./utils/utils";
 import { Message } from "./types/types";
-import { Invocation } from "./invocation";
+import type { Invocation } from "./invocation";
 import { failureToError, RetryableError } from "./types/errors";
 import { CompletablePromise } from "./utils/promises";
 import { Buffer } from "node:buffer";

--- a/packages/restate-sdk/src/local_state_store.ts
+++ b/packages/restate-sdk/src/local_state_store.ts
@@ -9,15 +9,17 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
+import type {
+  GetStateEntryMessage,
+  GetStateKeysEntryMessage,
+  StartMessage_StateEntry,
+} from "./generated/proto/protocol_pb";
 import {
   ClearAllStateEntryMessage,
   ClearStateEntryMessage,
   Empty,
-  GetStateEntryMessage,
-  GetStateKeysEntryMessage,
   GetStateKeysEntryMessage_StateKeys,
   SetStateEntryMessage,
-  StartMessage_StateEntry,
 } from "./generated/proto/protocol_pb";
 import { jsonSerialize } from "./utils/utils";
 import { Buffer } from "node:buffer";

--- a/packages/restate-sdk/src/promise_combinator_tracker.ts
+++ b/packages/restate-sdk/src/promise_combinator_tracker.ts
@@ -1,8 +1,5 @@
-import {
-  CompletablePromise,
-  wrapDeeply,
-  WrappedPromise,
-} from "./utils/promises";
+import type { WrappedPromise } from "./utils/promises";
+import { CompletablePromise, wrapDeeply } from "./utils/promises";
 
 export enum PromiseType {
   JournalEntry,

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -11,12 +11,13 @@
 
 import * as p from "./types/protocol";
 import { ContextImpl } from "./context_impl";
-import { Connection, RestateStreamConsumer } from "./connection/connection";
+import type {
+  Connection,
+  RestateStreamConsumer,
+} from "./connection/connection";
 import { Message } from "./types/types";
-import {
-  createStateMachineConsole,
-  StateMachineConsole,
-} from "./utils/message_logger";
+import type { StateMachineConsole } from "./utils/message_logger";
+import { createStateMachineConsole } from "./utils/message_logger";
 import {
   COMBINATOR_ENTRY_MESSAGE,
   COMPLETION_MESSAGE_TYPE,
@@ -30,31 +31,32 @@ import {
   SuspensionMessage,
 } from "./types/protocol";
 import { Journal } from "./journal";
-import { Invocation } from "./invocation";
+import type { Invocation } from "./invocation";
+import type { JournalErrorContext } from "./types/errors";
 import {
   ensureError,
   TerminalError,
   RetryableError,
   errorToErrorMessage,
-  JournalErrorContext,
 } from "./types/errors";
-import { LocalStateStore } from "./local_state_store";
-import { createRestateConsole, LoggerContext } from "./logger";
+import type { LocalStateStore } from "./local_state_store";
+import type { LoggerContext } from "./logger";
+import { createRestateConsole } from "./logger";
+import type { WrappedPromise } from "./utils/promises";
 import {
   CompletablePromise,
   wrapDeeply,
   WRAPPED_PROMISE_PENDING,
-  WrappedPromise,
 } from "./utils/promises";
+import type { PromiseId } from "./promise_combinator_tracker";
 import {
   PromiseCombinatorTracker,
-  PromiseId,
   PromiseType,
 } from "./promise_combinator_tracker";
 import { CombinatorEntryMessage } from "./generated/proto/javascript_pb";
 import { ProtocolMode } from "./types/discovery";
 import { Buffer } from "node:buffer";
-import { HandlerKind } from "./types/rpc";
+import type { HandlerKind } from "./types/rpc";
 
 export class StateMachine implements RestateStreamConsumer {
   private journal: Journal;

--- a/packages/restate-sdk/src/types/components.ts
+++ b/packages/restate-sdk/src/types/components.ts
@@ -13,8 +13,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as d from "./discovery";
-import { ContextImpl } from "../context_impl";
-import { HandlerKind, HandlerWrapper } from "./rpc";
+import type { ContextImpl } from "../context_impl";
+import type { HandlerWrapper } from "./rpc";
+import { HandlerKind } from "./rpc";
 
 //
 // Interfaces

--- a/packages/restate-sdk/src/types/errors.ts
+++ b/packages/restate-sdk/src/types/errors.ts
@@ -13,7 +13,7 @@
 
 import { ErrorMessage, Failure } from "../generated/proto/protocol_pb";
 import { formatMessageAsJson } from "../utils/utils";
-import * as p from "./protocol";
+import type * as p from "./protocol";
 
 export const INTERNAL_ERROR_CODE = 500;
 export const TIMEOUT_ERROR_CODE = 408;

--- a/packages/restate-sdk/src/types/protocol.ts
+++ b/packages/restate-sdk/src/types/protocol.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { Message } from "@bufbuild/protobuf";
+import type { Message } from "@bufbuild/protobuf";
 import { CombinatorEntryMessage } from "../generated/proto/javascript_pb";
 import {
   AwakeableEntryMessage,

--- a/packages/restate-sdk/src/types/rpc.ts
+++ b/packages/restate-sdk/src/types/rpc.ts
@@ -12,7 +12,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/ban-types */
-import {
+import type {
   CombineablePromise,
   Context,
   ObjectContext,
@@ -27,7 +27,7 @@ import {
   serializeNoop,
 } from "../utils/serde";
 
-import {
+import type {
   ServiceHandler,
   ServiceDefinition,
   ObjectHandler,

--- a/packages/restate-sdk/src/types/types.ts
+++ b/packages/restate-sdk/src/types/types.ts
@@ -9,6 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
+import type { ProtocolMessage } from "./protocol";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
   COMPLETION_MESSAGE_TYPE,
@@ -19,7 +20,6 @@ import {
   GET_STATE_KEYS_ENTRY_MESSAGE_TYPE,
   KNOWN_MESSAGE_TYPES,
   PROTOBUF_MESSAGE_BY_TYPE,
-  ProtocolMessage,
   SLEEP_ENTRY_MESSAGE_TYPE,
   START_MESSAGE_TYPE,
   SUSPENSION_MESSAGE_TYPE,

--- a/packages/restate-sdk/src/utils/message_logger.ts
+++ b/packages/restate-sdk/src/utils/message_logger.ts
@@ -14,9 +14,9 @@
 
 import { formatMessageType } from "../types/protocol";
 import { formatMessageAsJson } from "./utils";
+import type { LoggerContext } from "../logger";
 import {
   createRestateConsole,
-  LoggerContext,
   RESTATE_LOG_LEVEL,
   RestateLogLevel,
 } from "../logger";

--- a/packages/restate-sdk/src/utils/rand.ts
+++ b/packages/restate-sdk/src/utils/rand.ts
@@ -12,7 +12,7 @@
 //! Some parts copied from https://github.com/uuidjs/uuid/blob/main/src/stringify.js
 //! License MIT
 
-import { Rand } from "../context";
+import type { Rand } from "../context";
 import { createHash } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { readBigUInt64LE } from "./buffer";

--- a/packages/restate-sdk/src/utils/utils.ts
+++ b/packages/restate-sdk/src/utils/utils.ts
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {
+import type {
   OneWayCallEntryMessage,
   ClearStateEntryMessage,
   CompleteAwakeableEntryMessage,

--- a/packages/restate-sdk/test/awakeable.test.ts
+++ b/packages/restate-sdk/test/awakeable.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
+import type * as restate from "../src/public_api";
 import {
   awakeableMessage,
   checkJournalMismatchError,
@@ -27,7 +27,8 @@ import {
   END_MESSAGE,
 } from "./protoutils";
 
-import { TestDriver, TestResponse, TestGreeter } from "./testdriver";
+import type { TestGreeter } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import { ProtocolMode } from "../src/types/discovery";
 import { describe, expect, it } from "vitest";
 

--- a/packages/restate-sdk/test/complete_awakeable.test.ts
+++ b/packages/restate-sdk/test/complete_awakeable.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
+import type * as restate from "../src/public_api";
 import {
   checkJournalMismatchError,
   resolveAwakeableMessage,
@@ -23,7 +23,8 @@ import {
   rejectAwakeableMessage,
   END_MESSAGE,
 } from "./protoutils";
-import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
+import type { TestGreeter, TestResponse } from "./testdriver";
+import { TestDriver } from "./testdriver";
 import { describe, expect, it } from "vitest";
 
 class ResolveAwakeableGreeter implements TestGreeter {

--- a/packages/restate-sdk/test/eager_state.test.ts
+++ b/packages/restate-sdk/test/eager_state.test.ts
@@ -9,13 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
-import {
-  TestDriver,
-  TestResponse,
-  TestGreeter,
-  TestRequest,
-} from "./testdriver";
+import type * as restate from "../src/public_api";
+import type { TestGreeter, TestRequest } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import {
   CLEAR_ALL_STATE_ENTRY_MESSAGE,
   clearStateMessage,

--- a/packages/restate-sdk/test/get_and_set_state.test.ts
+++ b/packages/restate-sdk/test/get_and_set_state.test.ts
@@ -9,14 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
+import type * as restate from "../src/public_api";
 
-import {
-  TestDriver,
-  TestGreeter,
-  TestRequest,
-  TestResponse,
-} from "./testdriver";
+import type { TestGreeter, TestRequest } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import {
   checkJournalMismatchError,
   clearStateMessage,

--- a/packages/restate-sdk/test/get_state.test.ts
+++ b/packages/restate-sdk/test/get_state.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
+import type * as restate from "../src/public_api";
 import {
   checkJournalMismatchError,
   checkTerminalError,
@@ -25,7 +25,8 @@ import {
   startMessage,
   suspensionMessage,
 } from "./protoutils";
-import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
+import type { TestGreeter } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import { ProtocolMode } from "../src/types/discovery";
 import { describe, expect, it } from "vitest";
 

--- a/packages/restate-sdk/test/lambda.test.ts
+++ b/packages/restate-sdk/test/lambda.test.ts
@@ -10,9 +10,10 @@
  */
 
 import * as restate from "../src/public_api";
-import { APIGatewayProxyEvent, type APIGatewayProxyResult } from "aws-lambda";
+import type { APIGatewayProxyEvent } from "aws-lambda";
+import { type APIGatewayProxyResult } from "aws-lambda";
 import { encodeMessage } from "../src/io/encoder";
-import { Message } from "../src/types/types";
+import type { Message } from "../src/types/types";
 import {
   awakeableMessage,
   END_MESSAGE,
@@ -24,8 +25,10 @@ import {
   startMessage,
 } from "./protoutils";
 import { decodeLambdaBody } from "../src/io/decoder";
-import { TestGreeter, TestResponse } from "./testdriver";
-import { ServiceType, Endpoint } from "../src/types/discovery";
+import type { TestGreeter } from "./testdriver";
+import { TestResponse } from "./testdriver";
+import type { Endpoint } from "../src/types/discovery";
+import { ServiceType } from "../src/types/discovery";
 import { X_RESTATE_SERVER } from "../src/user_agent";
 import {
   serviceDiscoveryProtocolVersionToHeaderValue,

--- a/packages/restate-sdk/test/message_coders.test.ts
+++ b/packages/restate-sdk/test/message_coders.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { streamDecoder } from "../src/io/decoder";
-import { Message } from "../src/types/types";
+import type { Message } from "../src/types/types";
 import { backgroundInvokeMessage } from "./protoutils";
 import { encodeMessage } from "../src/io/encoder";
 import { describe, expect, it } from "vitest";

--- a/packages/restate-sdk/test/promise_combinator_tracker.test.ts
+++ b/packages/restate-sdk/test/promise_combinator_tracker.test.ts
@@ -10,10 +10,10 @@
  */
 
 import { CompletablePromise } from "../src/utils/promises";
+import type { PromiseId } from "../src/promise_combinator_tracker";
 import {
   newJournalEntryPromiseId,
   PromiseCombinatorTracker,
-  PromiseId,
 } from "../src/promise_combinator_tracker";
 import { describe, expect, it } from "vitest";
 

--- a/packages/restate-sdk/test/promise_combinators.test.ts
+++ b/packages/restate-sdk/test/promise_combinators.test.ts
@@ -9,13 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
-import {
-  GreeterApi,
-  TestDriver,
-  TestGreeter,
-  TestResponse,
-} from "./testdriver";
+import type * as restate from "../src/public_api";
+import type { TestGreeter } from "./testdriver";
+import { GreeterApi, TestDriver, TestResponse } from "./testdriver";
 import {
   awakeableMessage,
   completionMessage,

--- a/packages/restate-sdk/test/promises.test.ts
+++ b/packages/restate-sdk/test/promises.test.ts
@@ -9,11 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import {
-  CompletablePromise,
-  wrapDeeply,
-  WrappedPromise,
-} from "../src/utils/promises";
+import type { WrappedPromise } from "../src/utils/promises";
+import { CompletablePromise, wrapDeeply } from "../src/utils/promises";
 import { describe, expect, it } from "vitest";
 
 describe("promises.wrapDeeply", () => {

--- a/packages/restate-sdk/test/protoutils.ts
+++ b/packages/restate-sdk/test/protoutils.ts
@@ -61,9 +61,9 @@ import {
 } from "../src/generated/proto/protocol_pb";
 import { jsonSerialize, formatMessageAsJson } from "../src/utils/utils";
 import { rlog } from "../src/logger";
+import type { JournalErrorContext } from "../src/types/errors";
 import {
   INTERNAL_ERROR_CODE,
-  JournalErrorContext,
   RestateErrorCodes,
   UNKNOWN_ERROR_CODE,
 } from "../src/types/errors";

--- a/packages/restate-sdk/test/service_bind.test.ts
+++ b/packages/restate-sdk/test/service_bind.test.ts
@@ -9,13 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import {
-  TestDriver,
-  TestGreeter,
-  TestRequest,
-  TestResponse,
-} from "./testdriver";
-import * as restate from "../src/public_api";
+import type { TestGreeter, TestRequest } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
+import type * as restate from "../src/public_api";
 import { greetRequest, inputMessage, startMessage } from "./protoutils";
 import { describe, it } from "vitest";
 

--- a/packages/restate-sdk/test/side_effect.test.ts
+++ b/packages/restate-sdk/test/side_effect.test.ts
@@ -9,7 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
+import type { TestGreeter } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import {
   END_MESSAGE,
   errorMessage,
@@ -22,7 +23,7 @@ import {
   greetResponse,
   failure,
 } from "./protoutils";
-import { ObjectContext } from "../src/context";
+import type { ObjectContext } from "../src/context";
 import { TerminalError } from "../src/public_api";
 import { SIDE_EFFECT_ENTRY_MESSAGE_TYPE } from "../src/types/protocol";
 import { describe, expect, it } from "vitest";

--- a/packages/restate-sdk/test/sleep.test.ts
+++ b/packages/restate-sdk/test/sleep.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
+import type * as restate from "../src/public_api";
 import {
   awakeableMessage,
   checkJournalMismatchError,
@@ -28,7 +28,8 @@ import {
 } from "./protoutils";
 import { SLEEP_ENTRY_MESSAGE_TYPE } from "../src/types/protocol";
 import { Empty } from "@bufbuild/protobuf";
-import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
+import type { TestGreeter } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import { ProtocolMode } from "../src/types/discovery";
 import { describe, expect, it } from "vitest";
 

--- a/packages/restate-sdk/test/state_keys.test.ts
+++ b/packages/restate-sdk/test/state_keys.test.ts
@@ -9,8 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
-import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
+import type * as restate from "../src/public_api";
+import type { TestGreeter, TestResponse } from "./testdriver";
+import { TestDriver } from "./testdriver";
 import {
   completionMessage,
   END_MESSAGE,

--- a/packages/restate-sdk/test/state_machine.test.ts
+++ b/packages/restate-sdk/test/state_machine.test.ts
@@ -9,7 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { TestDriver, TestGreeter, TestResponse } from "./testdriver";
+import type { TestGreeter } from "./testdriver";
+import { TestDriver, TestResponse } from "./testdriver";
 import {
   END_MESSAGE,
   greetRequest,

--- a/packages/restate-sdk/test/testdriver.ts
+++ b/packages/restate-sdk/test/testdriver.ts
@@ -15,14 +15,15 @@ import {
   START_MESSAGE_TYPE,
   StartMessage,
 } from "../src/types/protocol";
-import { Connection } from "../src/connection/connection";
+import type { Connection } from "../src/connection/connection";
 import { formatMessageAsJson } from "../src/utils/utils";
 import { Message } from "../src/types/types";
 import { rlog } from "../src/logger";
 import { StateMachine } from "../src/state_machine";
 import { InvocationBuilder } from "../src/invocation";
-import { ObjectContext } from "../src/context";
-import { object, VirtualObjectDefinition } from "../src/public_api";
+import type { ObjectContext } from "../src/context";
+import type { VirtualObjectDefinition } from "../src/public_api";
+import { object } from "../src/public_api";
 import { ProtocolMode } from "../src/types/discovery";
 import { HandlerKind } from "../src/types/rpc";
 import { NodeEndpoint } from "../src/endpoint/node_endpoint";


### PR DESCRIPTION
This is something esm requires, although in theory typescript can try and figure it out for us, this is no longer recommended (they recommend verbatimModuleSyntax true), because some things have side effects just from being imported, so its important to know if you're importing the type or not.

PR is generated simply by running npx eslint --fix --ignore-path .eslintignore --max-warnings=0 --ext .ts .

This PR doesn't change compiled output at all