### PR TITLE
Use .js extensions everywhere

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended-type-checked"
+    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:require-extensions/recommended"
   ],
   "overrides": [
     {
@@ -22,7 +23,7 @@
     "ecmaVersion": "latest",
     "project": ["./tsconfig.eslint.json"]
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "require-extensions"],
   "rules": {
     "no-console": "error",
     "@typescript-eslint/consistent-type-imports": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@typescript-eslint/eslint-plugin": "^7.13.0",
         "@typescript-eslint/parser": "^7.13.0",
         "eslint": "^8.57.0",
+        "eslint-plugin-require-extensions": "^0.1.3",
         "prettier": "^2.8.4",
         "release-it": "^17.2.1",
         "ts-node-dev": "^2.0.0",
@@ -3347,6 +3348,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-require-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz",
+      "integrity": "sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "*"
       }
     },
     "node_modules/eslint-visitor-keys": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-require-extensions": "^0.1.3",
     "prettier": "^2.8.4",
     "release-it": "^17.2.1",
     "ts-node-dev": "^2.0.0",

--- a/packages/restate-sdk-clients/src/ingress.ts
+++ b/packages/restate-sdk-clients/src/ingress.ts
@@ -26,9 +26,9 @@ import type {
   Output,
   Send,
   WorkflowSubmission,
-} from "./api";
+} from "./api.js";
 
-import { Opts, SendOpts } from "./api";
+import { Opts, SendOpts } from "./api.js";
 
 /**
  * Connect to the restate Ingress

--- a/packages/restate-sdk-clients/src/public_api.ts
+++ b/packages/restate-sdk-clients/src/public_api.ts
@@ -29,6 +29,6 @@ export {
   SendOpts,
   Send,
   IngresSendOptions,
-} from "./api";
+} from "./api.js";
 
-export { connect } from "./ingress";
+export { connect } from "./ingress.js";

--- a/packages/restate-sdk-core/src/public_api.ts
+++ b/packages/restate-sdk-core/src/public_api.ts
@@ -18,4 +18,4 @@ export type {
   RestateWorkflowSharedContext,
   Workflow,
   WorkflowDefinitionFrom,
-} from "./core";
+} from "./core.js";

--- a/packages/restate-sdk-examples/src/ingress_client.ts
+++ b/packages/restate-sdk-examples/src/ingress_client.ts
@@ -13,9 +13,9 @@
 
 import * as restate from "@restatedev/restate-sdk-clients";
 
-import type { Greeter } from "./greeter";
-import type { PaymentWorkflow } from "./workflow";
-import type { Counter } from "./object";
+import type { Greeter } from "./greeter.js";
+import type { PaymentWorkflow } from "./workflow.js";
+import type { Counter } from "./object.js";
 
 const Greeter: Greeter = { name: "greeter" };
 const Counter: Counter = { name: "counter" };

--- a/packages/restate-sdk-examples/src/workflow_client.ts
+++ b/packages/restate-sdk-examples/src/workflow_client.ts
@@ -13,7 +13,7 @@
 
 import * as restate from "@restatedev/restate-sdk-clients";
 
-import type { PaymentWorkflow } from "./workflow";
+import type { PaymentWorkflow } from "./workflow.js";
 
 const WF: PaymentWorkflow = { name: "payment" };
 

--- a/packages/restate-sdk/src/cloudflare.ts
+++ b/packages/restate-sdk/src/cloudflare.ts
@@ -9,12 +9,12 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-export * from "./common_api";
+export * from "./common_api.js";
 
 import {
   CloudflareWorkerEndpointImpl,
   type CloudflareWorkerEndpoint,
-} from "./endpoint/cloudflare_endpoint";
+} from "./endpoint/cloudflare_endpoint.js";
 
 /**
  * Create a new {@link RestateEndpoint}.

--- a/packages/restate-sdk/src/common_api.ts
+++ b/packages/restate-sdk/src/common_api.ts
@@ -17,10 +17,10 @@ export {
   WorkflowContext,
   WorkflowSharedContext,
   Rand,
-} from "./context";
+} from "./context.js";
 
-export type { Client, SendClient } from "./types/rpc";
-export { service, object, workflow, handlers } from "./types/rpc";
+export type { Client, SendClient } from "./types/rpc.js";
+export { service, object, workflow, handlers } from "./types/rpc.js";
 
 export type {
   ServiceDefinition,
@@ -28,5 +28,5 @@ export type {
   WorkflowDefinition,
 } from "@restatedev/restate-sdk-core";
 
-export { ServiceBundle, RestateEndpoint } from "./endpoint";
-export { RestateError, TerminalError, TimeoutError } from "./types/errors";
+export { ServiceBundle, RestateEndpoint } from "./endpoint.js";
+export { RestateError, TerminalError, TimeoutError } from "./types/errors.js";

--- a/packages/restate-sdk/src/connection/buffered_connection.ts
+++ b/packages/restate-sdk/src/connection/buffered_connection.ts
@@ -1,5 +1,5 @@
-import { encodeMessages } from "../io/encoder";
-import type { Message } from "../types/types";
+import { encodeMessages } from "../io/encoder.js";
+import type { Message } from "../types/types.js";
 import type { Buffer } from "node:buffer";
 
 export class BufferedConnection {

--- a/packages/restate-sdk/src/connection/connection.ts
+++ b/packages/restate-sdk/src/connection/connection.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { Message } from "../types/types";
+import type { Message } from "../types/types.js";
 
 /**
  * A connection from the service/SDK to Restate.

--- a/packages/restate-sdk/src/connection/http_connection.ts
+++ b/packages/restate-sdk/src/connection/http_connection.ts
@@ -10,12 +10,12 @@
  */
 
 import type stream from "node:stream";
-import { streamDecoder } from "../io/decoder";
-import type { Connection, RestateStreamConsumer } from "./connection";
-import type { Message } from "../types/types";
-import { rlog } from "../logger";
+import { streamDecoder } from "../io/decoder.js";
+import type { Connection, RestateStreamConsumer } from "./connection.js";
+import type { Message } from "../types/types.js";
+import { rlog } from "../logger.js";
 import { finished } from "node:stream/promises";
-import { BufferedConnection } from "./buffered_connection";
+import { BufferedConnection } from "./buffered_connection.js";
 import type { Http2ServerRequest, IncomingHttpHeaders } from "node:http2";
 
 // utility promise, for cases where we want to save allocation of an extra promise

--- a/packages/restate-sdk/src/connection/lambda_connection.ts
+++ b/packages/restate-sdk/src/connection/lambda_connection.ts
@@ -9,15 +9,15 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { Connection } from "./connection";
-import { encodeMessage } from "../io/encoder";
+import type { Connection } from "./connection.js";
+import { encodeMessage } from "../io/encoder.js";
 import {
   ERROR_MESSAGE_TYPE,
   OUTPUT_ENTRY_MESSAGE_TYPE,
   SUSPENSION_MESSAGE_TYPE,
-} from "../types/protocol";
-import type { Message } from "../types/types";
-import { rlog } from "../logger";
+} from "../types/protocol.js";
+import type { Message } from "../types/types.js";
+import { rlog } from "../logger.js";
 import { Buffer } from "node:buffer";
 
 const RESOLVED: Promise<void> = Promise.resolve();

--- a/packages/restate-sdk/src/context.ts
+++ b/packages/restate-sdk/src/context.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { Client, SendClient } from "./types/rpc";
+import type { Client, SendClient } from "./types/rpc.js";
 import type {
   RestateContext,
   RestateObjectContext,
@@ -23,7 +23,7 @@ import type {
   Workflow,
   WorkflowDefinitionFrom,
 } from "@restatedev/restate-sdk-core";
-import { ContextImpl } from "./context_impl";
+import { ContextImpl } from "./context_impl.js";
 
 /**
  * Represents the original request as sent to this handler.

--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -21,9 +21,9 @@ import type {
   RunAction,
   SendOptions,
   WorkflowContext,
-} from "./context";
-import type { StateMachine } from "./state_machine";
-import type { GetStateKeysEntryMessage_StateKeys } from "./generated/proto/protocol_pb";
+} from "./context.js";
+import type { StateMachine } from "./state_machine.js";
+import type { GetStateKeysEntryMessage_StateKeys } from "./generated/proto/protocol_pb.js";
 import {
   AwakeableEntryMessage,
   OneWayCallEntryMessage,
@@ -37,7 +37,7 @@ import {
   GetPromiseEntryMessage,
   PeekPromiseEntryMessage,
   CompletePromiseEntryMessage,
-} from "./generated/proto/protocol_pb";
+} from "./generated/proto/protocol_pb.js";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
   AWAKEABLE_IDENTIFIER_PREFIX,
@@ -54,7 +54,7 @@ import {
   GET_PROMISE_MESSAGE_TYPE,
   PEEK_PROMISE_MESSAGE_TYPE,
   COMPLETE_PROMISE_MESSAGE_TYPE,
-} from "./types/protocol";
+} from "./types/protocol.js";
 import {
   RetryableError,
   TerminalError,
@@ -63,12 +63,12 @@ import {
   INTERNAL_ERROR_CODE,
   UNKNOWN_ERROR_CODE,
   errorToFailure,
-} from "./types/errors";
-import { jsonSerialize, jsonDeserialize } from "./utils/utils";
+} from "./types/errors.js";
+import { jsonSerialize, jsonDeserialize } from "./utils/utils.js";
 import type { PartialMessage } from "@bufbuild/protobuf";
 import { protoInt64 } from "@bufbuild/protobuf";
-import type { Client, SendClient } from "./types/rpc";
-import { HandlerKind } from "./types/rpc";
+import type { Client, SendClient } from "./types/rpc.js";
+import { HandlerKind } from "./types/rpc.js";
 import type {
   Service,
   ServiceDefinitionFrom,
@@ -77,11 +77,11 @@ import type {
   WorkflowDefinitionFrom,
   Workflow,
 } from "@restatedev/restate-sdk-core";
-import { RandImpl } from "./utils/rand";
-import { newJournalEntryPromiseId } from "./promise_combinator_tracker";
-import type { WrappedPromise } from "./utils/promises";
+import { RandImpl } from "./utils/rand.js";
+import { newJournalEntryPromiseId } from "./promise_combinator_tracker.js";
+import type { WrappedPromise } from "./utils/promises.js";
 import { Buffer } from "node:buffer";
-import { deserializeJson, serializeJson } from "./utils/serde";
+import { deserializeJson, serializeJson } from "./utils/serde.js";
 
 export type InternalCombineablePromise<T> = CombineablePromise<T> & {
   journalIndex: number;

--- a/packages/restate-sdk/src/endpoint/cloudflare_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/cloudflare_endpoint.ts
@@ -14,20 +14,20 @@ import type {
   VirtualObjectDefinition,
 } from "@restatedev/restate-sdk-core";
 
-import { rlog } from "../logger";
-import type { Component } from "../types/components";
+import { rlog } from "../logger.js";
+import type { Component } from "../types/components.js";
 
-import type { KeySetV1 } from "./request_signing/v1";
+import type { KeySetV1 } from "./request_signing/v1.js";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";
-import { EndpointBuilder } from "./endpoint_builder";
+import { EndpointBuilder } from "./endpoint_builder.js";
 import type { ExportedHandler } from "@cloudflare/workers-types";
 import type {
   RestateEndpoint,
   RestateEndpointBase,
   ServiceBundle,
-} from "../endpoint";
-import { CloudflareHandler } from "./handlers/cloudflare";
-import { GenericHandler } from "./handlers/generic";
+} from "../endpoint.js";
+import { CloudflareHandler } from "./handlers/cloudflare.js";
+import { GenericHandler } from "./handlers/generic.js";
 
 /**
  * CloudflareWorkerEndpoint encapsulates all the Restate services served by this endpoint.

--- a/packages/restate-sdk/src/endpoint/endpoint_builder.ts
+++ b/packages/restate-sdk/src/endpoint/endpoint_builder.ts
@@ -17,17 +17,17 @@ import type {
   VirtualObjectDefinition,
 } from "@restatedev/restate-sdk-core";
 
-import { HandlerWrapper } from "../types/rpc";
-import type { Component } from "../types/components";
+import { HandlerWrapper } from "../types/rpc.js";
+import type { Component } from "../types/components.js";
 import {
   ServiceComponent,
   VirtualObjectComponent,
   WorkflowComponent,
-} from "../types/components";
+} from "../types/components.js";
 
-import type * as discovery from "../types/discovery";
-import type { KeySetV1 } from "./request_signing/v1";
-import { parseKeySetV1 } from "./request_signing/v1";
+import type * as discovery from "../types/discovery.js";
+import type { KeySetV1 } from "./request_signing/v1.js";
+import { parseKeySetV1 } from "./request_signing/v1.js";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";
 
 function isServiceDefinition<P extends string, M>(

--- a/packages/restate-sdk/src/endpoint/handlers/cloudflare.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/cloudflare.ts
@@ -11,7 +11,7 @@
 
 import type { ExportedHandler, Request } from "@cloudflare/workers-types";
 import { Response } from "@cloudflare/workers-types";
-import type { GenericHandler, RestateRequest } from "./generic";
+import type { GenericHandler, RestateRequest } from "./generic.js";
 
 export class CloudflareHandler implements ExportedHandler {
   constructor(private readonly handler: GenericHandler) {}

--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -9,13 +9,13 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { rlog } from "../../logger";
-import { LambdaConnection } from "../../connection/lambda_connection";
-import { InvocationBuilder } from "../../invocation";
-import { decodeMessagesBuffer } from "../../io/decoder";
-import type { Message } from "../../types/types";
-import { StateMachine } from "../../state_machine";
-import { ensureError } from "../../types/errors";
+import { rlog } from "../../logger.js";
+import { LambdaConnection } from "../../connection/lambda_connection.js";
+import { InvocationBuilder } from "../../invocation.js";
+import { decodeMessagesBuffer } from "../../io/decoder.js";
+import type { Message } from "../../types/types.js";
+import { StateMachine } from "../../state_machine.js";
+import { ensureError } from "../../types/errors.js";
 import {
   OUTPUT_ENTRY_MESSAGE_TYPE,
   isServiceProtocolVersionSupported,
@@ -23,16 +23,16 @@ import {
   selectSupportedServiceDiscoveryProtocolVersion,
   serviceDiscoveryProtocolVersionToHeaderValue,
   serviceProtocolVersionToHeaderValue,
-} from "../../types/protocol";
-import { ProtocolMode } from "../../types/discovery";
-import type { ComponentHandler } from "../../types/components";
-import { parseUrlComponents } from "../../types/components";
-import { validateRequestSignature } from "../request_signing/validate";
-import { X_RESTATE_SERVER } from "../../user_agent";
+} from "../../types/protocol.js";
+import { ProtocolMode } from "../../types/discovery.js";
+import type { ComponentHandler } from "../../types/components.js";
+import { parseUrlComponents } from "../../types/components.js";
+import { validateRequestSignature } from "../request_signing/validate.js";
+import { X_RESTATE_SERVER } from "../../user_agent.js";
 import { Buffer } from "node:buffer";
-import { ServiceDiscoveryProtocolVersion } from "../../generated/proto/discovery_pb";
-import type { ServiceProtocolVersion } from "../../generated/proto/protocol_pb";
-import type { EndpointBuilder } from "../endpoint_builder";
+import { ServiceDiscoveryProtocolVersion } from "../../generated/proto/discovery_pb.js";
+import type { ServiceProtocolVersion } from "../../generated/proto/protocol_pb.js";
+import type { EndpointBuilder } from "../endpoint_builder.js";
 
 export interface Headers {
   [name: string]: string | string[] | undefined;

--- a/packages/restate-sdk/src/endpoint/handlers/lambda.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/lambda.ts
@@ -17,7 +17,7 @@ import type {
   Context,
 } from "aws-lambda";
 import { Buffer } from "node:buffer";
-import type { GenericHandler, RestateRequest } from "./generic";
+import type { GenericHandler, RestateRequest } from "./generic.js";
 
 export class LambdaHandler {
   constructor(private readonly handler: GenericHandler) {}

--- a/packages/restate-sdk/src/endpoint/handlers/node.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/node.ts
@@ -13,27 +13,27 @@ import stream from "node:stream";
 import { pipeline, finished } from "node:stream/promises";
 import type { Http2ServerRequest, Http2ServerResponse } from "http2";
 import type http2 from "http2";
-import { RestateHttp2Connection } from "../../connection/http_connection";
-import { ensureError } from "../../types/errors";
-import { InvocationBuilder } from "../../invocation";
-import { StateMachine } from "../../state_machine";
-import { rlog } from "../../logger";
-import type { ComponentHandler } from "../../types/components";
-import { parseUrlComponents } from "../../types/components";
-import type { Endpoint } from "../../types/discovery";
-import { ProtocolMode } from "../../types/discovery";
-import { validateRequestSignature } from "../request_signing/validate";
+import { RestateHttp2Connection } from "../../connection/http_connection.js";
+import { ensureError } from "../../types/errors.js";
+import { InvocationBuilder } from "../../invocation.js";
+import { StateMachine } from "../../state_machine.js";
+import { rlog } from "../../logger.js";
+import type { ComponentHandler } from "../../types/components.js";
+import { parseUrlComponents } from "../../types/components.js";
+import type { Endpoint } from "../../types/discovery.js";
+import { ProtocolMode } from "../../types/discovery.js";
+import { validateRequestSignature } from "../request_signing/validate.js";
 import type { ServerHttp2Stream } from "node:http2";
-import { X_RESTATE_SERVER } from "../../user_agent";
+import { X_RESTATE_SERVER } from "../../user_agent.js";
 import {
   isServiceProtocolVersionSupported,
   parseServiceProtocolVersion,
   selectSupportedServiceDiscoveryProtocolVersion,
   serviceDiscoveryProtocolVersionToHeaderValue,
   serviceProtocolVersionToHeaderValue,
-} from "../../types/protocol";
-import { ServiceDiscoveryProtocolVersion } from "../../generated/proto/discovery_pb";
-import type { EndpointBuilder } from "../endpoint_builder";
+} from "../../types/protocol.js";
+import { ServiceDiscoveryProtocolVersion } from "../../generated/proto/discovery_pb.js";
+import type { EndpointBuilder } from "../endpoint_builder.js";
 
 export class Http2Handler {
   constructor(private readonly endpoint: EndpointBuilder) {}

--- a/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
@@ -14,19 +14,19 @@ import type {
   VirtualObjectDefinition,
 } from "@restatedev/restate-sdk-core";
 
-import { rlog } from "../logger";
-import type { Component } from "../types/components";
+import { rlog } from "../logger.js";
+import type { Component } from "../types/components.js";
 
-import type { KeySetV1 } from "./request_signing/v1";
+import type { KeySetV1 } from "./request_signing/v1.js";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";
-import { EndpointBuilder } from "./endpoint_builder";
+import { EndpointBuilder } from "./endpoint_builder.js";
 import type {
   RestateEndpoint,
   RestateEndpointBase,
   ServiceBundle,
-} from "../endpoint";
-import { GenericHandler } from "./handlers/generic";
-import { LambdaHandler } from "./handlers/lambda";
+} from "../endpoint.js";
+import { GenericHandler } from "./handlers/generic.js";
+import { LambdaHandler } from "./handlers/lambda.js";
 
 /**
  * LambdaEndpoint encapsulates all the Restate services served by this endpoint.

--- a/packages/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/node_endpoint.ts
@@ -12,23 +12,23 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { RestateEndpoint, ServiceBundle } from "../public_api";
+import type { RestateEndpoint, ServiceBundle } from "../public_api.js";
 import type {
   ServiceDefinition,
   VirtualObjectDefinition,
 } from "@restatedev/restate-sdk-core";
 
-import { rlog } from "../logger";
+import { rlog } from "../logger.js";
 import type { Http2ServerRequest, Http2ServerResponse } from "http2";
 import * as http2 from "http2";
-import { Http2Handler } from "./handlers/node";
-import { LambdaHandler } from "./handlers/lambda";
-import type { Component } from "../types/components";
+import { Http2Handler } from "./handlers/node.js";
+import { LambdaHandler } from "./handlers/lambda.js";
+import type { Component } from "../types/components.js";
 
-import type { KeySetV1 } from "./request_signing/v1";
+import type { KeySetV1 } from "./request_signing/v1.js";
 import type { WorkflowDefinition } from "@restatedev/restate-sdk-core";
-import { EndpointBuilder } from "./endpoint_builder";
-import { GenericHandler } from "./handlers/generic";
+import { EndpointBuilder } from "./endpoint_builder.js";
+import { GenericHandler } from "./handlers/generic.js";
 
 export class NodeEndpoint implements RestateEndpoint {
   private builder: EndpointBuilder = new EndpointBuilder();

--- a/packages/restate-sdk/src/endpoint/request_signing/v1.ts
+++ b/packages/restate-sdk/src/endpoint/request_signing/v1.ts
@@ -10,11 +10,11 @@
  */
 
 import { Buffer } from "node:buffer";
-import type { ValidateResponse, ValidateSuccess } from "./validate";
-import { headerValue } from "./validate";
-import type { Key } from "./ed25519";
-import { importKey, verify } from "./ed25519";
-import base from "./basex";
+import type { ValidateResponse, ValidateSuccess } from "./validate.js";
+import { headerValue } from "./validate.js";
+import type { Key } from "./ed25519.js";
+import { importKey, verify } from "./ed25519.js";
+import base from "./basex.js";
 
 const JWT_HEADER = "x-restate-jwt-v1";
 export const SCHEME_V1 = "v1";

--- a/packages/restate-sdk/src/endpoint/request_signing/validate.ts
+++ b/packages/restate-sdk/src/endpoint/request_signing/validate.ts
@@ -9,8 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { KeySetV1 } from "./v1";
-import { SCHEME_V1, validateV1 } from "./v1";
+import type { KeySetV1 } from "./v1.js";
+import { SCHEME_V1, validateV1 } from "./v1.js";
 
 const SIGNATURE_SCHEME_HEADER = "x-restate-signature-scheme";
 

--- a/packages/restate-sdk/src/invocation.ts
+++ b/packages/restate-sdk/src/invocation.ts
@@ -11,19 +11,22 @@
 
 /*eslint-disable @typescript-eslint/no-non-null-assertion*/
 
-import type { Message } from "./types/types";
+import type { Message } from "./types/types.js";
 import type {
   InputEntryMessage,
   StartMessage,
-} from "./generated/proto/protocol_pb";
-import { formatMessageAsJson } from "./utils/utils";
-import { INPUT_ENTRY_MESSAGE_TYPE, START_MESSAGE_TYPE } from "./types/protocol";
-import type { RestateStreamConsumer } from "./connection/connection";
-import { LocalStateStore } from "./local_state_store";
-import { ensureError } from "./types/errors";
-import { LoggerContext } from "./logger";
-import { CompletablePromise } from "./utils/promises";
-import type { ComponentHandler } from "./types/components";
+} from "./generated/proto/protocol_pb.js";
+import { formatMessageAsJson } from "./utils/utils.js";
+import {
+  INPUT_ENTRY_MESSAGE_TYPE,
+  START_MESSAGE_TYPE,
+} from "./types/protocol.js";
+import type { RestateStreamConsumer } from "./connection/connection.js";
+import { LocalStateStore } from "./local_state_store.js";
+import { ensureError } from "./types/errors.js";
+import { LoggerContext } from "./logger.js";
+import { CompletablePromise } from "./utils/promises.js";
+import type { ComponentHandler } from "./types/components.js";
 import { Buffer } from "node:buffer";
 
 enum State {

--- a/packages/restate-sdk/src/io/decoder.ts
+++ b/packages/restate-sdk/src/io/decoder.ts
@@ -21,12 +21,12 @@
 // at this point the decodedStream is a high level stream of objects {header, message}
 
 import stream from "node:stream";
-import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
-import { Header, Message } from "../types/types";
+import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol.js";
+import { Header, Message } from "../types/types.js";
 import type { AnyMessage } from "@bufbuild/protobuf";
-import { ensureError } from "../types/errors";
+import { ensureError } from "../types/errors.js";
 import { Buffer } from "node:buffer";
-import { readBigUInt64BE } from "../utils/buffer";
+import { readBigUInt64BE } from "../utils/buffer.js";
 
 type Output = { push(msg: Message): void };
 type DecoderState = { state: number; header: Header | undefined; buf: Buffer };

--- a/packages/restate-sdk/src/io/encoder.ts
+++ b/packages/restate-sdk/src/io/encoder.ts
@@ -10,11 +10,11 @@
  */
 
 import stream from "node:stream";
-import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol";
-import type { Message } from "../types/types";
-import { Header } from "../types/types";
+import { PROTOBUF_MESSAGE_BY_TYPE } from "../types/protocol.js";
+import type { Message } from "../types/types.js";
+import { Header } from "../types/types.js";
 import { Buffer } from "node:buffer";
-import { writeBigUInt64BE } from "../utils/buffer";
+import { writeBigUInt64BE } from "../utils/buffer.js";
 
 export function streamEncoder(): stream.Transform {
   return new stream.Transform({

--- a/packages/restate-sdk/src/journal.ts
+++ b/packages/restate-sdk/src/journal.ts
@@ -9,9 +9,12 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as p from "./types/protocol";
-import type { Failure, RunEntryMessage } from "./generated/proto/protocol_pb";
-import { GetStateKeysEntryMessage_StateKeys } from "./generated/proto/protocol_pb";
+import * as p from "./types/protocol.js";
+import type {
+  Failure,
+  RunEntryMessage,
+} from "./generated/proto/protocol_pb.js";
+import { GetStateKeysEntryMessage_StateKeys } from "./generated/proto/protocol_pb.js";
 import type {
   AwakeableEntryMessage,
   CompletionMessage,
@@ -23,7 +26,7 @@ import type {
   InputEntryMessage,
   SleepEntryMessage,
   SuspensionMessage,
-} from "./types/protocol";
+} from "./types/protocol.js";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
   BACKGROUND_INVOKE_ENTRY_MESSAGE_TYPE,
@@ -40,12 +43,12 @@ import {
   SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
   SLEEP_ENTRY_MESSAGE_TYPE,
   SUSPENSION_MESSAGE_TYPE,
-} from "./types/protocol";
-import { equalityCheckers, jsonDeserialize } from "./utils/utils";
-import { Message } from "./types/types";
-import type { Invocation } from "./invocation";
-import { failureToError, RetryableError } from "./types/errors";
-import { CompletablePromise } from "./utils/promises";
+} from "./types/protocol.js";
+import { equalityCheckers, jsonDeserialize } from "./utils/utils.js";
+import { Message } from "./types/types.js";
+import type { Invocation } from "./invocation.js";
+import { failureToError, RetryableError } from "./types/errors.js";
+import { CompletablePromise } from "./utils/promises.js";
 import { Buffer } from "node:buffer";
 
 const RESOLVED = Promise.resolve(undefined);

--- a/packages/restate-sdk/src/lambda.ts
+++ b/packages/restate-sdk/src/lambda.ts
@@ -9,12 +9,12 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-export * from "./common_api";
+export * from "./common_api.js";
 
 import {
   LambdaEndpointImpl,
   type LambdaEndpoint,
-} from "./endpoint/lambda_endpoint";
+} from "./endpoint/lambda_endpoint.js";
 
 /**
  * Create a new {@link RestateEndpoint}.

--- a/packages/restate-sdk/src/local_state_store.ts
+++ b/packages/restate-sdk/src/local_state_store.ts
@@ -13,15 +13,15 @@ import type {
   GetStateEntryMessage,
   GetStateKeysEntryMessage,
   StartMessage_StateEntry,
-} from "./generated/proto/protocol_pb";
+} from "./generated/proto/protocol_pb.js";
 import {
   ClearAllStateEntryMessage,
   ClearStateEntryMessage,
   Empty,
   GetStateKeysEntryMessage_StateKeys,
   SetStateEntryMessage,
-} from "./generated/proto/protocol_pb";
-import { jsonSerialize } from "./utils/utils";
+} from "./generated/proto/protocol_pb.js";
+import { jsonSerialize } from "./utils/utils.js";
 import { Buffer } from "node:buffer";
 
 export class LocalStateStore {

--- a/packages/restate-sdk/src/promise_combinator_tracker.ts
+++ b/packages/restate-sdk/src/promise_combinator_tracker.ts
@@ -1,5 +1,5 @@
-import type { WrappedPromise } from "./utils/promises";
-import { CompletablePromise, wrapDeeply } from "./utils/promises";
+import type { WrappedPromise } from "./utils/promises.js";
+import { CompletablePromise, wrapDeeply } from "./utils/promises.js";
 
 export enum PromiseType {
   JournalEntry,

--- a/packages/restate-sdk/src/public_api.ts
+++ b/packages/restate-sdk/src/public_api.ts
@@ -9,10 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-export * from "./common_api";
+export * from "./common_api.js";
 
-import type { RestateEndpoint } from "./endpoint";
-import { NodeEndpoint } from "./endpoint/node_endpoint";
+import type { RestateEndpoint } from "./endpoint.js";
+import { NodeEndpoint } from "./endpoint/node_endpoint.js";
 
 /**
  * Create a new {@link RestateEndpoint}.

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -9,15 +9,15 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as p from "./types/protocol";
-import { ContextImpl } from "./context_impl";
+import * as p from "./types/protocol.js";
+import { ContextImpl } from "./context_impl.js";
 import type {
   Connection,
   RestateStreamConsumer,
-} from "./connection/connection";
-import { Message } from "./types/types";
-import type { StateMachineConsole } from "./utils/message_logger";
-import { createStateMachineConsole } from "./utils/message_logger";
+} from "./connection/connection.js";
+import { Message } from "./types/types.js";
+import type { StateMachineConsole } from "./utils/message_logger.js";
+import { createStateMachineConsole } from "./utils/message_logger.js";
 import {
   COMBINATOR_ENTRY_MESSAGE,
   COMPLETION_MESSAGE_TYPE,
@@ -29,34 +29,34 @@ import {
   OutputEntryMessage,
   SUSPENSION_MESSAGE_TYPE,
   SuspensionMessage,
-} from "./types/protocol";
-import { Journal } from "./journal";
-import type { Invocation } from "./invocation";
-import type { JournalErrorContext } from "./types/errors";
+} from "./types/protocol.js";
+import { Journal } from "./journal.js";
+import type { Invocation } from "./invocation.js";
+import type { JournalErrorContext } from "./types/errors.js";
 import {
   ensureError,
   TerminalError,
   RetryableError,
   errorToErrorMessage,
-} from "./types/errors";
-import type { LocalStateStore } from "./local_state_store";
-import type { LoggerContext } from "./logger";
-import { createRestateConsole } from "./logger";
-import type { WrappedPromise } from "./utils/promises";
+} from "./types/errors.js";
+import type { LocalStateStore } from "./local_state_store.js";
+import type { LoggerContext } from "./logger.js";
+import { createRestateConsole } from "./logger.js";
+import type { WrappedPromise } from "./utils/promises.js";
 import {
   CompletablePromise,
   wrapDeeply,
   WRAPPED_PROMISE_PENDING,
-} from "./utils/promises";
-import type { PromiseId } from "./promise_combinator_tracker";
+} from "./utils/promises.js";
+import type { PromiseId } from "./promise_combinator_tracker.js";
 import {
   PromiseCombinatorTracker,
   PromiseType,
-} from "./promise_combinator_tracker";
-import { CombinatorEntryMessage } from "./generated/proto/javascript_pb";
-import { ProtocolMode } from "./types/discovery";
+} from "./promise_combinator_tracker.js";
+import { CombinatorEntryMessage } from "./generated/proto/javascript_pb.js";
+import { ProtocolMode } from "./types/discovery.js";
 import { Buffer } from "node:buffer";
-import type { HandlerKind } from "./types/rpc";
+import type { HandlerKind } from "./types/rpc.js";
 
 export class StateMachine implements RestateStreamConsumer {
   private journal: Journal;

--- a/packages/restate-sdk/src/types/components.ts
+++ b/packages/restate-sdk/src/types/components.ts
@@ -12,10 +12,10 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as d from "./discovery";
-import type { ContextImpl } from "../context_impl";
-import type { HandlerWrapper } from "./rpc";
-import { HandlerKind } from "./rpc";
+import * as d from "./discovery.js";
+import type { ContextImpl } from "../context_impl.js";
+import type { HandlerWrapper } from "./rpc.js";
+import { HandlerKind } from "./rpc.js";
 
 //
 // Interfaces

--- a/packages/restate-sdk/src/types/errors.ts
+++ b/packages/restate-sdk/src/types/errors.ts
@@ -11,9 +11,9 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ErrorMessage, Failure } from "../generated/proto/protocol_pb";
-import { formatMessageAsJson } from "../utils/utils";
-import type * as p from "./protocol";
+import { ErrorMessage, Failure } from "../generated/proto/protocol_pb.js";
+import { formatMessageAsJson } from "../utils/utils.js";
+import type * as p from "./protocol.js";
 
 export const INTERNAL_ERROR_CODE = 500;
 export const TIMEOUT_ERROR_CODE = 408;

--- a/packages/restate-sdk/src/types/protocol.ts
+++ b/packages/restate-sdk/src/types/protocol.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Message } from "@bufbuild/protobuf";
-import { CombinatorEntryMessage } from "../generated/proto/javascript_pb";
+import { CombinatorEntryMessage } from "../generated/proto/javascript_pb.js";
 import {
   AwakeableEntryMessage,
   OneWayCallEntryMessage,
@@ -35,8 +35,8 @@ import {
   PeekPromiseEntryMessage,
   CompletePromiseEntryMessage,
   ServiceProtocolVersion,
-} from "../generated/proto/protocol_pb";
-import { ServiceDiscoveryProtocolVersion } from "../generated/proto/discovery_pb";
+} from "../generated/proto/protocol_pb.js";
+import { ServiceDiscoveryProtocolVersion } from "../generated/proto/discovery_pb.js";
 
 // Re-export the protobuf messages.
 export {
@@ -61,7 +61,7 @@ export {
   GetPromiseEntryMessage,
   PeekPromiseEntryMessage,
   CompletePromiseEntryMessage,
-} from "../generated/proto/protocol_pb";
+} from "../generated/proto/protocol_pb.js";
 
 // Export the protocol message types as defined by the restate protocol.
 export const START_MESSAGE_TYPE = 0x0000n;

--- a/packages/restate-sdk/src/types/rpc.ts
+++ b/packages/restate-sdk/src/types/rpc.ts
@@ -19,13 +19,13 @@ import type {
   ObjectSharedContext,
   WorkflowContext,
   WorkflowSharedContext,
-} from "../context";
+} from "../context.js";
 import {
   deserializeJson,
   deserializeNoop,
   serializeJson,
   serializeNoop,
-} from "../utils/serde";
+} from "../utils/serde.js";
 
 import type {
   ServiceHandler,

--- a/packages/restate-sdk/src/types/types.ts
+++ b/packages/restate-sdk/src/types/types.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { ProtocolMessage } from "./protocol";
+import type { ProtocolMessage } from "./protocol.js";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
   COMPLETION_MESSAGE_TYPE,
@@ -23,7 +23,7 @@ import {
   SLEEP_ENTRY_MESSAGE_TYPE,
   START_MESSAGE_TYPE,
   SUSPENSION_MESSAGE_TYPE,
-} from "./protocol";
+} from "./protocol.js";
 
 export class Message {
   constructor(

--- a/packages/restate-sdk/src/user_agent.ts
+++ b/packages/restate-sdk/src/user_agent.ts
@@ -9,6 +9,6 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { SDK_VERSION } from "./generated/version";
+import { SDK_VERSION } from "./generated/version.js";
 
 export const X_RESTATE_SERVER = `restate-sdk-typescript/${SDK_VERSION}`;

--- a/packages/restate-sdk/src/utils/message_logger.ts
+++ b/packages/restate-sdk/src/utils/message_logger.ts
@@ -12,14 +12,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
 
-import { formatMessageType } from "../types/protocol";
-import { formatMessageAsJson } from "./utils";
-import type { LoggerContext } from "../logger";
+import { formatMessageType } from "../types/protocol.js";
+import { formatMessageAsJson } from "./utils.js";
+import type { LoggerContext } from "../logger.js";
 import {
   createRestateConsole,
   RESTATE_LOG_LEVEL,
   RestateLogLevel,
-} from "../logger";
+} from "../logger.js";
 
 /**
  * The environment variable which is read to determine the debug log settings.

--- a/packages/restate-sdk/src/utils/rand.ts
+++ b/packages/restate-sdk/src/utils/rand.ts
@@ -12,10 +12,10 @@
 //! Some parts copied from https://github.com/uuidjs/uuid/blob/main/src/stringify.js
 //! License MIT
 
-import type { Rand } from "../context";
+import type { Rand } from "../context.js";
 import { createHash } from "node:crypto";
 import { Buffer } from "node:buffer";
-import { readBigUInt64LE } from "./buffer";
+import { readBigUInt64LE } from "./buffer.js";
 
 export class RandImpl implements Rand {
   private randstate256: [bigint, bigint, bigint, bigint];

--- a/packages/restate-sdk/src/utils/serde.ts
+++ b/packages/restate-sdk/src/utils/serde.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { TerminalError } from "../types/errors";
+import { TerminalError } from "../types/errors.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function serializeJson(item: any): Uint8Array {

--- a/packages/restate-sdk/src/utils/utils.ts
+++ b/packages/restate-sdk/src/utils/utils.ts
@@ -19,7 +19,7 @@ import type {
   CallEntryMessage,
   OutputEntryMessage,
   SetStateEntryMessage,
-} from "../generated/proto/protocol_pb";
+} from "../generated/proto/protocol_pb.js";
 import {
   AWAKEABLE_ENTRY_MESSAGE_TYPE,
   BACKGROUND_INVOKE_ENTRY_MESSAGE_TYPE,
@@ -31,7 +31,7 @@ import {
   SET_STATE_ENTRY_MESSAGE_TYPE,
   SIDE_EFFECT_ENTRY_MESSAGE_TYPE,
   SLEEP_ENTRY_MESSAGE_TYPE,
-} from "../types/protocol";
+} from "../types/protocol.js";
 import { Buffer } from "node:buffer";
 
 export function jsonSerialize(obj: any): string {

--- a/packages/restate-sdk/test/awakeable.test.ts
+++ b/packages/restate-sdk/test/awakeable.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
+import type * as restate from "../src/public_api.js";
 import {
   awakeableMessage,
   checkJournalMismatchError,
@@ -25,11 +25,11 @@ import {
   startMessage,
   suspensionMessage,
   END_MESSAGE,
-} from "./protoutils";
+} from "./protoutils.js";
 
-import type { TestGreeter } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
-import { ProtocolMode } from "../src/types/discovery";
+import type { TestGreeter } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
+import { ProtocolMode } from "../src/types/discovery.js";
 import { describe, expect, it } from "vitest";
 
 class AwakeableGreeter implements TestGreeter {

--- a/packages/restate-sdk/test/complete_awakeable.test.ts
+++ b/packages/restate-sdk/test/complete_awakeable.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
+import type * as restate from "../src/public_api.js";
 import {
   checkJournalMismatchError,
   resolveAwakeableMessage,
@@ -22,9 +22,9 @@ import {
   startMessage,
   rejectAwakeableMessage,
   END_MESSAGE,
-} from "./protoutils";
-import type { TestGreeter, TestResponse } from "./testdriver";
-import { TestDriver } from "./testdriver";
+} from "./protoutils.js";
+import type { TestGreeter, TestResponse } from "./testdriver.js";
+import { TestDriver } from "./testdriver.js";
 import { describe, expect, it } from "vitest";
 
 class ResolveAwakeableGreeter implements TestGreeter {

--- a/packages/restate-sdk/test/eager_state.test.ts
+++ b/packages/restate-sdk/test/eager_state.test.ts
@@ -9,9 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
-import type { TestGreeter, TestRequest } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
+import type * as restate from "../src/public_api.js";
+import type { TestGreeter, TestRequest } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
 import {
   CLEAR_ALL_STATE_ENTRY_MESSAGE,
   clearStateMessage,
@@ -28,8 +28,8 @@ import {
   setStateMessage,
   startMessage,
   suspensionMessage,
-} from "./protoutils";
-import { ProtocolMode } from "../src/types/discovery";
+} from "./protoutils.js";
+import { ProtocolMode } from "../src/types/discovery.js";
 import { describe, expect, it } from "vitest";
 
 const input = inputMessage(greetRequest("Two"));

--- a/packages/restate-sdk/test/get_and_set_state.test.ts
+++ b/packages/restate-sdk/test/get_and_set_state.test.ts
@@ -9,10 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
+import type * as restate from "../src/public_api.js";
 
-import type { TestGreeter, TestRequest } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
+import type { TestGreeter, TestRequest } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
 import {
   checkJournalMismatchError,
   clearStateMessage,
@@ -26,8 +26,8 @@ import {
   setStateMessage,
   startMessage,
   suspensionMessage,
-} from "./protoutils";
-import { ProtocolMode } from "../src/types/discovery";
+} from "./protoutils.js";
+import { ProtocolMode } from "../src/types/discovery.js";
 import { describe, expect, it } from "vitest";
 
 class GetAndSetGreeter implements TestGreeter {

--- a/packages/restate-sdk/test/get_state.test.ts
+++ b/packages/restate-sdk/test/get_state.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
+import type * as restate from "../src/public_api.js";
 import {
   checkJournalMismatchError,
   checkTerminalError,
@@ -24,10 +24,10 @@ import {
   setStateMessage,
   startMessage,
   suspensionMessage,
-} from "./protoutils";
-import type { TestGreeter } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
-import { ProtocolMode } from "../src/types/discovery";
+} from "./protoutils.js";
+import type { TestGreeter } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
+import { ProtocolMode } from "../src/types/discovery.js";
 import { describe, expect, it } from "vitest";
 
 class GetStringStateGreeter implements TestGreeter {

--- a/packages/restate-sdk/test/lambda.test.ts
+++ b/packages/restate-sdk/test/lambda.test.ts
@@ -9,11 +9,11 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import * as restate from "../src/public_api";
+import * as restate from "../src/public_api.js";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import { type APIGatewayProxyResult } from "aws-lambda";
-import { encodeMessage } from "../src/io/encoder";
-import type { Message } from "../src/types/types";
+import { encodeMessage } from "../src/io/encoder.js";
+import type { Message } from "../src/types/types.js";
 import {
   awakeableMessage,
   END_MESSAGE,
@@ -23,19 +23,19 @@ import {
   inputMessage,
   outputMessage,
   startMessage,
-} from "./protoutils";
-import { decodeLambdaBody } from "../src/io/decoder";
-import type { TestGreeter } from "./testdriver";
-import { TestResponse } from "./testdriver";
-import type { Endpoint } from "../src/types/discovery";
-import { ServiceType } from "../src/types/discovery";
-import { X_RESTATE_SERVER } from "../src/user_agent";
+} from "./protoutils.js";
+import { decodeLambdaBody } from "../src/io/decoder.js";
+import type { TestGreeter } from "./testdriver.js";
+import { TestResponse } from "./testdriver.js";
+import type { Endpoint } from "../src/types/discovery.js";
+import { ServiceType } from "../src/types/discovery.js";
+import { X_RESTATE_SERVER } from "../src/user_agent.js";
 import {
   serviceDiscoveryProtocolVersionToHeaderValue,
   serviceProtocolVersionToHeaderValue,
-} from "../src/types/protocol";
-import { ServiceProtocolVersion } from "../src/generated/proto/protocol_pb";
-import { ServiceDiscoveryProtocolVersion } from "../src/generated/proto/discovery_pb";
+} from "../src/types/protocol.js";
+import { ServiceProtocolVersion } from "../src/generated/proto/protocol_pb.js";
+import { ServiceDiscoveryProtocolVersion } from "../src/generated/proto/discovery_pb.js";
 import { describe, expect, it } from "vitest";
 
 class LambdaGreeter implements TestGreeter {

--- a/packages/restate-sdk/test/message_coders.test.ts
+++ b/packages/restate-sdk/test/message_coders.test.ts
@@ -9,10 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { streamDecoder } from "../src/io/decoder";
-import type { Message } from "../src/types/types";
-import { backgroundInvokeMessage } from "./protoutils";
-import { encodeMessage } from "../src/io/encoder";
+import { streamDecoder } from "../src/io/decoder.js";
+import type { Message } from "../src/types/types.js";
+import { backgroundInvokeMessage } from "./protoutils.js";
+import { encodeMessage } from "../src/io/encoder.js";
 import { describe, expect, it } from "vitest";
 
 describe("The stream decoder", () => {

--- a/packages/restate-sdk/test/promise_combinator_tracker.test.ts
+++ b/packages/restate-sdk/test/promise_combinator_tracker.test.ts
@@ -9,12 +9,12 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { CompletablePromise } from "../src/utils/promises";
-import type { PromiseId } from "../src/promise_combinator_tracker";
+import { CompletablePromise } from "../src/utils/promises.js";
+import type { PromiseId } from "../src/promise_combinator_tracker.js";
 import {
   newJournalEntryPromiseId,
   PromiseCombinatorTracker,
-} from "../src/promise_combinator_tracker";
+} from "../src/promise_combinator_tracker.js";
 import { describe, expect, it } from "vitest";
 
 describe("PromiseCombinatorTracker with Promise.any", () => {

--- a/packages/restate-sdk/test/promise_combinators.test.ts
+++ b/packages/restate-sdk/test/promise_combinators.test.ts
@@ -9,9 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
-import type { TestGreeter } from "./testdriver";
-import { GreeterApi, TestDriver, TestResponse } from "./testdriver";
+import type * as restate from "../src/public_api.js";
+import type { TestGreeter } from "./testdriver.js";
+import { GreeterApi, TestDriver, TestResponse } from "./testdriver.js";
 import {
   awakeableMessage,
   completionMessage,
@@ -28,14 +28,14 @@ import {
   sideEffectMessage,
   ackMessage,
   invokeMessage,
-} from "./protoutils";
+} from "./protoutils.js";
 import {
   COMBINATOR_ENTRY_MESSAGE,
   SLEEP_ENTRY_MESSAGE_TYPE,
-} from "../src/types/protocol";
-import { TimeoutError } from "../src/types/errors";
-import { CombineablePromise } from "../src/context";
-import { Empty } from "../src/generated/proto/protocol_pb";
+} from "../src/types/protocol.js";
+import { TimeoutError } from "../src/types/errors.js";
+import { CombineablePromise } from "../src/context.js";
+import { Empty } from "../src/generated/proto/protocol_pb.js";
 import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
 

--- a/packages/restate-sdk/test/promises.test.ts
+++ b/packages/restate-sdk/test/promises.test.ts
@@ -9,8 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { WrappedPromise } from "../src/utils/promises";
-import { CompletablePromise, wrapDeeply } from "../src/utils/promises";
+import type { WrappedPromise } from "../src/utils/promises.js";
+import { CompletablePromise, wrapDeeply } from "../src/utils/promises.js";
 import { describe, expect, it } from "vitest";
 
 describe("promises.wrapDeeply", () => {

--- a/packages/restate-sdk/test/protocol_stream.test.ts
+++ b/packages/restate-sdk/test/protocol_stream.test.ts
@@ -16,12 +16,12 @@ import {
   GET_STATE_ENTRY_MESSAGE_TYPE,
   SetStateEntryMessage,
   SET_STATE_ENTRY_MESSAGE_TYPE,
-} from "../src/types/protocol";
-import { RestateHttp2Connection } from "../src/connection/http_connection";
-import { Header, Message } from "../src/types/types";
+} from "../src/types/protocol.js";
+import { RestateHttp2Connection } from "../src/connection/http_connection.js";
+import { Header, Message } from "../src/types/types.js";
 import * as stream from "stream";
 import { setTimeout } from "timers/promises";
-import { CompletablePromise } from "../src/utils/promises";
+import { CompletablePromise } from "../src/utils/promises.js";
 import { describe, expect, it } from "vitest";
 
 // The following test suite is taken from headers.rs

--- a/packages/restate-sdk/test/protoutils.ts
+++ b/packages/restate-sdk/test/protoutils.ts
@@ -51,22 +51,22 @@ import {
   ClearAllStateEntryMessage,
   GET_STATE_KEYS_ENTRY_MESSAGE_TYPE,
   GetStateKeysEntryMessage,
-} from "../src/types/protocol";
-import { Message } from "../src/types/types";
-import { CombinatorEntryMessage } from "../src/generated/proto/javascript_pb";
+} from "../src/types/protocol.js";
+import { Message } from "../src/types/types.js";
+import { CombinatorEntryMessage } from "../src/generated/proto/javascript_pb.js";
 import {
   Failure,
   RunEntryMessage,
   StartMessage_StateEntry,
-} from "../src/generated/proto/protocol_pb";
-import { jsonSerialize, formatMessageAsJson } from "../src/utils/utils";
-import { rlog } from "../src/logger";
-import type { JournalErrorContext } from "../src/types/errors";
+} from "../src/generated/proto/protocol_pb.js";
+import { jsonSerialize, formatMessageAsJson } from "../src/utils/utils.js";
+import { rlog } from "../src/logger.js";
+import type { JournalErrorContext } from "../src/types/errors.js";
 import {
   INTERNAL_ERROR_CODE,
   RestateErrorCodes,
   UNKNOWN_ERROR_CODE,
-} from "../src/types/errors";
+} from "../src/types/errors.js";
 import { expect } from "vitest";
 
 export type StartMessageOpts = {

--- a/packages/restate-sdk/test/service_bind.test.ts
+++ b/packages/restate-sdk/test/service_bind.test.ts
@@ -9,10 +9,10 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { TestGreeter, TestRequest } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
-import type * as restate from "../src/public_api";
-import { greetRequest, inputMessage, startMessage } from "./protoutils";
+import type { TestGreeter, TestRequest } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
+import type * as restate from "../src/public_api.js";
+import { greetRequest, inputMessage, startMessage } from "./protoutils.js";
 import { describe, it } from "vitest";
 
 const greeter: TestGreeter = {

--- a/packages/restate-sdk/test/side_effect.test.ts
+++ b/packages/restate-sdk/test/side_effect.test.ts
@@ -9,8 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { TestGreeter } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
+import type { TestGreeter } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
 import {
   END_MESSAGE,
   errorMessage,
@@ -22,10 +22,10 @@ import {
   suspensionMessage,
   greetResponse,
   failure,
-} from "./protoutils";
-import type { ObjectContext } from "../src/context";
-import { TerminalError } from "../src/public_api";
-import { SIDE_EFFECT_ENTRY_MESSAGE_TYPE } from "../src/types/protocol";
+} from "./protoutils.js";
+import type { ObjectContext } from "../src/context.js";
+import { TerminalError } from "../src/public_api.js";
+import { SIDE_EFFECT_ENTRY_MESSAGE_TYPE } from "../src/types/protocol.js";
 import { describe, expect, it } from "vitest";
 
 class GreeterWithName implements TestGreeter {

--- a/packages/restate-sdk/test/sleep.test.ts
+++ b/packages/restate-sdk/test/sleep.test.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
+import type * as restate from "../src/public_api.js";
 import {
   awakeableMessage,
   checkJournalMismatchError,
@@ -25,12 +25,12 @@ import {
   sleepMessage,
   startMessage,
   suspensionMessage,
-} from "./protoutils";
-import { SLEEP_ENTRY_MESSAGE_TYPE } from "../src/types/protocol";
+} from "./protoutils.js";
+import { SLEEP_ENTRY_MESSAGE_TYPE } from "../src/types/protocol.js";
 import { Empty } from "@bufbuild/protobuf";
-import type { TestGreeter } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
-import { ProtocolMode } from "../src/types/discovery";
+import type { TestGreeter } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
+import { ProtocolMode } from "../src/types/discovery.js";
 import { describe, expect, it } from "vitest";
 
 const wakeupTime = 1835661783000;

--- a/packages/restate-sdk/test/state_keys.test.ts
+++ b/packages/restate-sdk/test/state_keys.test.ts
@@ -9,9 +9,9 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type * as restate from "../src/public_api";
-import type { TestGreeter, TestResponse } from "./testdriver";
-import { TestDriver } from "./testdriver";
+import type * as restate from "../src/public_api.js";
+import type { TestGreeter, TestResponse } from "./testdriver.js";
+import { TestDriver } from "./testdriver.js";
 import {
   completionMessage,
   END_MESSAGE,
@@ -23,8 +23,8 @@ import {
   outputMessage,
   startMessage,
   suspensionMessage,
-} from "./protoutils";
-import { GetStateKeysEntryMessage_StateKeys } from "../src/generated/proto/protocol_pb";
+} from "./protoutils.js";
+import { GetStateKeysEntryMessage_StateKeys } from "../src/generated/proto/protocol_pb.js";
 import { describe, expect, it } from "vitest";
 
 const INPUT_MESSAGE = inputMessage(greetRequest("bob"));

--- a/packages/restate-sdk/test/state_machine.test.ts
+++ b/packages/restate-sdk/test/state_machine.test.ts
@@ -9,8 +9,8 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { TestGreeter } from "./testdriver";
-import { TestDriver, TestResponse } from "./testdriver";
+import type { TestGreeter } from "./testdriver.js";
+import { TestDriver, TestResponse } from "./testdriver.js";
 import {
   END_MESSAGE,
   greetRequest,
@@ -18,7 +18,7 @@ import {
   inputMessage,
   outputMessage,
   startMessage,
-} from "./protoutils";
+} from "./protoutils.js";
 import { describe, expect, it } from "vitest";
 
 class Greeter implements TestGreeter {

--- a/packages/restate-sdk/test/testdriver.ts
+++ b/packages/restate-sdk/test/testdriver.ts
@@ -14,19 +14,19 @@ import {
   ENTRY_ACK_MESSAGE_TYPE,
   START_MESSAGE_TYPE,
   StartMessage,
-} from "../src/types/protocol";
-import type { Connection } from "../src/connection/connection";
-import { formatMessageAsJson } from "../src/utils/utils";
-import { Message } from "../src/types/types";
-import { rlog } from "../src/logger";
-import { StateMachine } from "../src/state_machine";
-import { InvocationBuilder } from "../src/invocation";
-import type { ObjectContext } from "../src/context";
-import type { VirtualObjectDefinition } from "../src/public_api";
-import { object } from "../src/public_api";
-import { ProtocolMode } from "../src/types/discovery";
-import { HandlerKind } from "../src/types/rpc";
-import { NodeEndpoint } from "../src/endpoint/node_endpoint";
+} from "../src/types/protocol.js";
+import type { Connection } from "../src/connection/connection.js";
+import { formatMessageAsJson } from "../src/utils/utils.js";
+import { Message } from "../src/types/types.js";
+import { rlog } from "../src/logger.js";
+import { StateMachine } from "../src/state_machine.js";
+import { InvocationBuilder } from "../src/invocation.js";
+import type { ObjectContext } from "../src/context.js";
+import type { VirtualObjectDefinition } from "../src/public_api.js";
+import { object } from "../src/public_api.js";
+import { ProtocolMode } from "../src/types/discovery.js";
+import { HandlerKind } from "../src/types/rpc.js";
+import { NodeEndpoint } from "../src/endpoint/node_endpoint.js";
 
 export type TestRequest = {
   name: string;

--- a/packages/restate-sdk/test/utils.test.ts
+++ b/packages/restate-sdk/test/utils.test.ts
@@ -13,8 +13,8 @@ import {
   jsonDeserialize,
   jsonSerialize,
   formatMessageAsJson,
-} from "../src/utils/utils";
-import { RandImpl } from "../src/utils/rand";
+} from "../src/utils/utils.js";
+import { RandImpl } from "../src/utils/rand.js";
 import { describe, expect, it } from "vitest";
 
 describe("JSON de-/serialization", () => {


### PR DESCRIPTION
Enforced by eslint (and this pr autogenerated by it also)
Unfortunately, node enforces that these extensions are set, and its the only way to be truly ESM compliant. We can hack around it with transpilers, but its better to just do it 'properly'.