### PR TITLE
Convert to ESM modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/restate-sdk-examples"
       ],
       "devDependencies": {
+        "@arethetypeswrong/cli": "^0.15.3",
         "@release-it-plugins/workspaces": "^4.2.0",
         "@types/node": "^20.10.4",
         "@typescript-eslint/eslint-plugin": "^7.13.0",
@@ -31,6 +32,63 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@andrewbranch/untar.js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+      "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+      "dev": true
+    },
+    "node_modules/@arethetypeswrong/cli": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.15.3.tgz",
+      "integrity": "sha512-sIMA9ZJBWDEg1+xt5RkAEflZuf8+PO8SdKj17x6PtETuUho+qlZJg4DgmKc3q+QwQ9zOB5VLK6jVRbFdNLdUIA==",
+      "dev": true,
+      "dependencies": {
+        "@arethetypeswrong/core": "0.15.1",
+        "chalk": "^4.1.2",
+        "cli-table3": "^0.6.3",
+        "commander": "^10.0.1",
+        "marked": "^9.1.2",
+        "marked-terminal": "^6.0.0",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "attw": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@arethetypeswrong/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==",
+      "dev": true,
+      "dependencies": {
+        "@andrewbranch/untar.js": "^1.0.3",
+        "fflate": "^0.8.2",
+        "semver": "^7.5.4",
+        "ts-expose-internals-conditionally": "1.0.0-empty.0",
+        "typescript": "5.3.3",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -318,6 +376,16 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240605.0.tgz",
       "integrity": "sha512-zJw4Q6CnkaQ5JZmHRkNiSs5GfiRgUIUL8BIHPQkd2XUHZkIBv9M9yc0LKEwMYGpCFC+oSOltet6c9RjP9uQ99g==",
       "dev": true
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1889,6 +1957,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2434,6 +2508,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+      "dev": true,
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
+    },
     "node_modules/chai": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
@@ -2466,6 +2553,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chardet": {
@@ -2573,6 +2669,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -2608,6 +2719,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3081,6 +3201,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true
     },
     "node_modules/enhanced-resolve": {
@@ -3811,6 +3937,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -5451,6 +5583,62 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.2.0.tgz",
+      "integrity": "sha512-ubWhwcBFHnXsjYNsu+Wndpg0zhY4CahSpPlA70PlO0rR9r2sZpkyU+rkCsOWH+KMEkx847UpALON+HWgxowFtw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^6.2.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^5.3.0",
+        "cli-table3": "^0.6.3",
+        "node-emoji": "^2.1.3",
+        "supports-hyperlinks": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <12"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/matcher-collection": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -5671,6 +5859,33 @@
       ],
       "engines": {
         "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+      "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-emoji/node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/node-fetch": {
@@ -6561,6 +6776,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "~4.0.0"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -7248,6 +7472,18 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7509,6 +7745,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7604,6 +7853,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/ts-expose-internals-conditionally": {
+      "version": "1.0.0-empty.0",
+      "resolved": "https://registry.npmjs.org/ts-expose-internals-conditionally/-/ts-expose-internals-conditionally-1.0.0-empty.0.tgz",
+      "integrity": "sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==",
+      "dev": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -7888,6 +8143,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -7994,6 +8258,15 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/validate-peer-dependencies": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "packages/restate-sdk-clients",
     "packages/restate-sdk-examples"
   ],
-  "type": "commonjs",
+  "type": "module",
   "scripts": {
     "build": "npm run build -ws --if-present",
     "proto": "npm run proto -ws --if-present",
@@ -32,6 +32,7 @@
     "clean": "rm -rf packages/restate-sdk/dist && rm -rf packages/restate-sdk-examples/dist && rm -rf packages/restate-sdk-ingress/dist"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.15.3",
     "@release-it-plugins/workspaces": "^4.2.0",
     "@types/node": "^20.10.4",
     "@typescript-eslint/eslint-plugin": "^7.13.0",

--- a/packages/restate-sdk-clients/package.json
+++ b/packages/restate-sdk-clients/package.json
@@ -13,14 +13,30 @@
   "bugs": {
     "url": "https://github.com/restatedev/sdk-typescript/issues"
   },
-  "type": "commonjs",
-  "main": "./dist/src/public_api.js",
-  "types": "./dist/src/public_api.d.ts",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/cjs/src/public_api.js",
+  "types": "./dist/cjs/src/public_api.d.ts",
+  "module": "./dist/esm/src/public_api.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/src/public_api.d.ts",
+        "default": "./dist/esm/src/public_api.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/public_api.d.ts",
+        "default": "./dist/cjs/src/public_api.js"
+      }
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
     "test": "vitest run --silent --passWithNoTests",
     "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",

--- a/packages/restate-sdk-clients/tsconfig.json
+++ b/packages/restate-sdk-clients/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist/esm"
   },
   "include": ["src/**/*.ts"],
   "references": [

--- a/packages/restate-sdk-core/package.json
+++ b/packages/restate-sdk-core/package.json
@@ -13,14 +13,30 @@
   "bugs": {
     "url": "https://github.com/restatedev/sdk-typescript/issues"
   },
-  "type": "commonjs",
-  "main": "./dist/src/public_api.js",
-  "types": "./dist/src/public_api.d.ts",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/cjs/src/public_api.js",
+  "types": "./dist/cjs/src/public_api.d.ts",
+  "module": "./dist/esm/src/public_api.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/src/public_api.d.ts",
+        "default": "./dist/esm/src/public_api.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/public_api.d.ts",
+        "default": "./dist/cjs/src/public_api.js"
+      }
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
     "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "format-check": "prettier --ignore-path .eslintignore --check \"**/*.+(js|ts|json)\"",

--- a/packages/restate-sdk-core/tsconfig.json
+++ b/packages/restate-sdk-core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist/esm"
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/restate-sdk-examples/package.json
+++ b/packages/restate-sdk-examples/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "https://github.com/restatedev/sdk-typescript/issues"
   },
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/src/public_api.js",
   "types": "./dist/src/public_api.d.ts",
   "files": [

--- a/packages/restate-sdk/package.json
+++ b/packages/restate-sdk/package.json
@@ -13,38 +13,60 @@
   "bugs": {
     "url": "https://github.com/restatedev/sdk-typescript/issues"
   },
-  "type": "commonjs",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/cjs/src/public_api.js",
+  "module": "./dist/esm/src/public_api.js",
   "exports": {
     ".": {
-      "import": "./dist/src/public_api.js",
-      "require": "./dist/src/public_api.js",
-      "types": "./dist/src/public_api.d.ts"
+      "import": {
+        "types": "./dist/esm/src/public_api.d.ts",
+        "default": "./dist/esm/src/public_api.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/public_api.d.ts",
+        "default": "./dist/cjs/src/public_api.js"
+      }
     },
     "./cloudflare": {
-      "import": "./dist/src/cloudflare.js",
-      "require": "./dist/src/cloudflare.js",
-      "types": "./dist/src/cloudflare.d.ts"
+      "import": {
+        "types": "./dist/esm/src/cloudflare.d.ts",
+        "default": "./dist/esm/src/cloudflare.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/cloudflare.d.ts",
+        "default": "./dist/cjs/src/cloudflare.js"
+      }
     },
     "./lambda": {
-      "import": "./dist/src/lambda.js",
-      "require": "./dist/src/lambda.js",
-      "types": "./dist/src/lambda.d.ts"
+      "import": {
+        "types": "./dist/esm/src/lambda.d.ts",
+        "default": "./dist/esm/src/lambda.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/lambda.d.ts",
+        "default": "./dist/cjs/src/lambda.js"
+      }
     }
   },
+  "types": "./dist/cjs/src/public_api.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "gen:version": "node ./scripts/version.js",
+    "gen:version": "node ./scripts/version.mjs",
     "proto": "npx buf mod update && npx buf generate",
     "prebuild": "npm run gen:version",
-    "build": "tsc -b",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
     "pretest": "npm run gen:version",
     "test": "vitest run --silent",
     "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "format-check": "prettier --ignore-path .eslintignore --check \"**/*.+(js|ts|json)\"",
     "verify": "npm run format-check && npm run gen:version && npm run lint && npm run test && npm run build",
+    "attw": "attw --pack",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/restate-sdk/scripts/version.mjs
+++ b/packages/restate-sdk/scripts/version.mjs
@@ -13,19 +13,13 @@
 // taken from package.json into a src/generated/version.ts
 // file.
 
-const fs = require("node:fs");
-const path = require("node:path");
+import * as fs from "node:fs";
 
 //
-// figure out where we are
+// compute the relative paths to the package root, which `npm run` always executes fro
 //
-const cwd = path.dirname(__filename);
-
-//
-// compute the relative paths to this script
-//
-const packageJsonPath = `${cwd}/../package.json`;
-const targetDir = `${cwd}/../src/generated`;
+const packageJsonPath = `./package.json`;
+const targetDir = `./src/generated`;
 const targetFile = `${targetDir}/version.ts`;
 
 //

--- a/packages/restate-sdk/tsconfig.json
+++ b/packages/restate-sdk/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist/esm"
   },
   "include": ["src/**/*.ts"],
   "references": [{ "path": "../restate-sdk-core" }]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
     "composite": true,
     "baseUrl": ".",
     "target": "esnext",
-    "module": "commonjs",
+    "module": "nodenext",
     "lib": ["esnext"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This PR changes the `dist` directory to have two subdirs `esm` and `cjs` with different entrypoints in package.json
The files in the cjs directory are identical to the files previously produced in dist
The files in the esm directory are valid esm modules which will be used in esm import contexts