### PR TITLE
Use typesVersions workaround to support node10 resolution

### DIFF
--- a/packages/restate-sdk-clients/package.json
+++ b/packages/restate-sdk-clients/package.json
@@ -41,7 +41,8 @@
     "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "format-check": "prettier --ignore-path .eslintignore --check \"**/*.+(js|ts|json)\"",
-    "verify": "npm run format-check && npm run lint && npm run test && npm run build",
+    "attw": "attw --pack",
+    "verify": "npm run format-check && npm run lint && npm run test && npm run build && npm run attw",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/restate-sdk-core/package.json
+++ b/packages/restate-sdk-core/package.json
@@ -40,7 +40,8 @@
     "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "format-check": "prettier --ignore-path .eslintignore --check \"**/*.+(js|ts|json)\"",
-    "verify": "npm run format-check && npm run lint && npm run build",
+    "attw": "attw --pack",
+    "verify": "npm run format-check && npm run lint && npm run build && npm run attw",
     "release": "release-it"
   },
   "engines": {

--- a/packages/restate-sdk/package.json
+++ b/packages/restate-sdk/package.json
@@ -49,6 +49,16 @@
       }
     }
   },
+  "typesVersions": {
+    "*": {
+      "cloudflare": [
+        "dist/cjs/src/cloudflare.d.ts"
+      ],
+      "lambda": [
+        "dist/cjs/src/lambda.d.ts"
+      ]
+    }
+  },
   "types": "./dist/cjs/src/public_api.d.ts",
   "files": [
     "dist"
@@ -65,8 +75,8 @@
     "lint": "eslint --ignore-path .eslintignore --max-warnings=0 --ext .ts .",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "format-check": "prettier --ignore-path .eslintignore --check \"**/*.+(js|ts|json)\"",
-    "verify": "npm run format-check && npm run gen:version && npm run lint && npm run test && npm run build",
     "attw": "attw --pack",
+    "verify": "npm run format-check && npm run gen:version && npm run lint && npm run test && npm run build && npm run attw",
     "release": "release-it"
   },
   "dependencies": {


### PR DESCRIPTION
We don't need to support node v10, but we do need to support modern node with tsc using node10 module resolution, sadly.

https://github.com/andrewbranch/example-subpath-exports-ts-compat/tree/main/examples/node_modules/types-versions-wildcards