### PR TITLE
Expose HttpCallError in restate-sdk-clients

### DIFF
--- a/packages/restate-sdk-clients/src/public_api.ts
+++ b/packages/restate-sdk-clients/src/public_api.ts
@@ -31,4 +31,7 @@ export {
   IngresSendOptions,
 } from "./api.js";
 
-export { connect } from "./ingress.js";
+export {
+  connect,
+  HttpCallError,
+} from "./ingress.js";


### PR DESCRIPTION
To enable usage in userland such as
```js
import { HttpCallError } from '@restatedev/restate-sdk-clients'

try {
  // Send request
} catch (error) {
  if (error instanceof HttpCallError) {
    // Type narrowed error, now access properties such as `status`
  }
}
```

Export block now multiline to align with existing exports above