### PR TITLE
Allow providing a custom logger

### DIFF
--- a/packages/restate-sdk/src/common_api.ts
+++ b/packages/restate-sdk/src/common_api.ts
@@ -30,3 +30,10 @@ export type {
 
 export type { ServiceBundle, RestateEndpoint } from "./endpoint.js";
 export { RestateError, TerminalError, TimeoutError } from "./types/errors.js";
+
+export {
+  setLogger,
+  type Logger,
+  type LogParams,
+  type LoggerContext,
+} from "./logger.js";

--- a/packages/restate-sdk/src/common_api.ts
+++ b/packages/restate-sdk/src/common_api.ts
@@ -30,3 +30,10 @@ export type {
 
 export type { ServiceBundle, RestateEndpoint } from "./endpoint.js";
 export { RestateError, TerminalError, TimeoutError } from "./types/errors.js";
+export type {
+  Logger,
+  LogParams,
+  RestateLogLevel,
+  LoggerContext,
+  LogSource,
+} from "./logger.js";

--- a/packages/restate-sdk/src/common_api.ts
+++ b/packages/restate-sdk/src/common_api.ts
@@ -30,10 +30,3 @@ export type {
 
 export type { ServiceBundle, RestateEndpoint } from "./endpoint.js";
 export { RestateError, TerminalError, TimeoutError } from "./types/errors.js";
-
-export {
-  setLogger,
-  type Logger,
-  type LogParams,
-  type LoggerContext,
-} from "./logger.js";

--- a/packages/restate-sdk/src/connection/connection.ts
+++ b/packages/restate-sdk/src/connection/connection.ts
@@ -12,7 +12,6 @@
 import type stream from "node:stream/web";
 import { streamDecoder } from "../io/decoder.js";
 import type { Message } from "../types/types.js";
-import { rlog } from "../logger.js";
 import { encodeMessage } from "../io/encoder.js";
 import { WritableStream } from "node:stream/web";
 
@@ -59,10 +58,11 @@ export class RestateConnection implements Connection {
    * create a RestateBidiConnection stream from a duplex stream
    */
   public static from(
+    rlog: Console,
     headers: Record<string, string | string[] | undefined>,
     rawStream: stream.ReadableWritablePair<Uint8Array, Uint8Array>
   ): RestateConnection {
-    return new RestateConnection(headers, rawStream);
+    return new RestateConnection(rlog, headers, rawStream);
   }
 
   // --------------------------------------------------------------------------
@@ -78,6 +78,7 @@ export class RestateConnection implements Connection {
   private readonly sdkOutput: stream.WritableStreamDefaultWriter<Uint8Array>;
 
   constructor(
+    rlog: Console,
     private readonly attemptHeaders: Record<
       string,
       string | string[] | undefined

--- a/packages/restate-sdk/src/endpoint.ts
+++ b/packages/restate-sdk/src/endpoint.ts
@@ -15,6 +15,7 @@ import type {
   ServiceDefinition,
   WorkflowDefinition,
 } from "@restatedev/restate-sdk-core";
+import type { Logger } from "./logger.js";
 
 /**
  * Utility interface for a bundle of one or more services belonging together
@@ -56,6 +57,29 @@ export interface RestateEndpointBase<E> {
    *
    */
   withIdentityV1(...keys: string[]): E;
+
+  /**
+   * Replace the default console-based {@link Logger}
+   * @param logger
+   * @example
+   * Using console:
+   * ```ts
+   *     restate.setLogger((params, message, ...o) => {console.log(`${params.level}: `, message, ...o)})
+   *  ```
+   * @example
+   * Using winston:
+   * ```ts
+   *     const logger = createLogger({ ... })
+   *     restate.setLogger((params, message, ...o) => {logger.log(params.level, {invocationId: params.context?.invocationId}, [message, ...o].join(' '))})
+   *  ```
+   * @example
+   * Using pino:
+   * ```ts
+   *     const logger = pino()
+   *     restate.setLogger((params, message, ...o) => {logger[params.level]({invocationId: params.context?.invocationId}, [message, ...o].join(' '))})
+   *  ```
+   */
+  setLogger(logger: Logger): void;
 }
 
 /**

--- a/packages/restate-sdk/src/endpoint.ts
+++ b/packages/restate-sdk/src/endpoint.ts
@@ -79,7 +79,7 @@ export interface RestateEndpointBase<E> {
    *     restate.setLogger((params, message, ...o) => {logger[params.level]({invocationId: params.context?.invocationId}, [message, ...o].join(' '))})
    *  ```
    */
-  setLogger(logger: Logger): void;
+  setLogger(logger: Logger): E;
 }
 
 /**

--- a/packages/restate-sdk/src/endpoint/endpoint_builder.ts
+++ b/packages/restate-sdk/src/endpoint/endpoint_builder.ts
@@ -29,6 +29,12 @@ import {
 import type * as discovery from "../types/discovery.js";
 import type { KeySetV1 } from "./request_signing/v1.js";
 import { parseKeySetV1 } from "./request_signing/v1.js";
+import {
+  LogSource,
+  type Logger,
+  createRestateConsole,
+  defaultLogger,
+} from "../logger.js";
 
 function isServiceDefinition<P extends string, M>(
   m: Record<string, any>
@@ -50,6 +56,15 @@ function isWorkflowDefinition<P extends string, M>(
 
 export class EndpointBuilder {
   private readonly services: Map<string, Component> = new Map();
+  public logger: Logger = defaultLogger;
+
+  /**
+   * This is a simple console without contextual info.
+   *
+   * This should be used only in cases where no contextual info is available.
+   */
+  public rlog = createRestateConsole(this.logger, LogSource.SYSTEM);
+
   private _keySet?: KeySetV1;
 
   public get keySet(): KeySetV1 | undefined {
@@ -104,6 +119,12 @@ export class EndpointBuilder {
     parseKeySetV1(keys).forEach((buffer, key) =>
       this._keySet?.set(key, buffer)
     );
+    return this;
+  }
+
+  public setLogger(newLogger: Logger) {
+    this.logger = newLogger;
+    this.rlog = createRestateConsole(this.logger, LogSource.SYSTEM);
     return this;
   }
 

--- a/packages/restate-sdk/src/endpoint/fetch_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/fetch_endpoint.ts
@@ -25,6 +25,7 @@ import type {
 import { GenericHandler } from "./handlers/generic.js";
 import { fetcher } from "./handlers/fetch.js";
 import { ProtocolMode } from "../types/discovery.js";
+import type { Logger } from "../logger.js";
 
 /**
  * Generic Fetch encapsulates all the Restate services served by this endpoint.
@@ -88,6 +89,11 @@ export class FetchEndpointImpl implements FetchEndpoint {
 
   public withIdentityV1(...keys: string[]): FetchEndpoint {
     this.builder.withIdentityV1(...keys);
+    return this;
+  }
+
+  public setLogger(newLogger: Logger): FetchEndpoint {
+    this.builder.setLogger(newLogger);
     return this;
   }
 

--- a/packages/restate-sdk/src/endpoint/handlers/lambda.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/lambda.ts
@@ -21,7 +21,6 @@ import type { GenericHandler, RestateRequest } from "./generic.js";
 import { WritableStream, type ReadableStream } from "node:stream/web";
 import { OnceStream } from "../../utils/streams.js";
 import { X_RESTATE_SERVER } from "../../user_agent.js";
-import { rlog } from "../../logger.js";
 import { ensureError } from "../../types/errors.js";
 
 export class LambdaHandler {
@@ -72,7 +71,7 @@ export class LambdaHandler {
     } catch (e) {
       // unlike in the streaming case, we can actually catch errors in the response body and form a nicer error
       const error = ensureError(e);
-      rlog.error(
+      this.handler.endpoint.rlog.error(
         "Error while collecting invocation response: " +
           (error.stack ?? error.message)
       );

--- a/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
@@ -25,6 +25,7 @@ import type {
 import { GenericHandler } from "./handlers/generic.js";
 import { LambdaHandler } from "./handlers/lambda.js";
 import { ProtocolMode } from "../types/discovery.js";
+import type { Logger } from "../logger.js";
 
 /**
  * LambdaEndpoint encapsulates all the Restate services served by this endpoint.
@@ -77,6 +78,11 @@ export class LambdaEndpointImpl implements LambdaEndpoint {
 
   public withIdentityV1(...keys: string[]): LambdaEndpoint {
     this.builder.withIdentityV1(...keys);
+    return this;
+  }
+
+  public setLogger(logger: Logger): LambdaEndpoint {
+    this.builder.setLogger(logger);
     return this;
   }
 

--- a/packages/restate-sdk/src/logger.ts
+++ b/packages/restate-sdk/src/logger.ts
@@ -60,6 +60,7 @@ function logLevelFromName(name?: string): RestateLogLevel | null {
 export type LogParams = {
   source: LogSource;
   level: RestateLogLevel;
+  replaying: boolean;
   context?: LoggerContext;
 };
 
@@ -143,17 +144,17 @@ function loggerForLevel(
   logger: Logger,
   source: LogSource,
   level: RestateLogLevel,
-  shouldLog: () => boolean,
+  isReplaying: () => boolean,
   context?: LoggerContext
 ): PropertyDescriptor {
   return {
     get: (): Logger => {
-      if (!shouldLog()) {
-        return () => {
-          // empty logger
-        };
-      }
-      return logger.bind(null, { source, level, context });
+      return logger.bind(null, {
+        source,
+        level,
+        replaying: isReplaying(),
+        context,
+      });
     },
   };
 }
@@ -168,42 +169,42 @@ export function createRestateConsole(
   logger: Logger,
   source: LogSource,
   context?: LoggerContext,
-  shouldLog: () => boolean = () => true
+  isReplaying: () => boolean = () => false
 ): Console {
   return Object.create(console, {
     trace: loggerForLevel(
       logger,
       source,
       RestateLogLevel.TRACE,
-      shouldLog,
+      isReplaying,
       context
     ),
     debug: loggerForLevel(
       logger,
       source,
       RestateLogLevel.DEBUG,
-      shouldLog,
+      isReplaying,
       context
     ),
     info: loggerForLevel(
       logger,
       source,
       RestateLogLevel.INFO,
-      shouldLog,
+      isReplaying,
       context
     ),
     warn: loggerForLevel(
       logger,
       source,
       RestateLogLevel.WARN,
-      shouldLog,
+      isReplaying,
       context
     ),
     error: loggerForLevel(
       logger,
       source,
       RestateLogLevel.ERROR,
-      shouldLog,
+      isReplaying,
       context
     ),
   }) as Console;

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -98,11 +98,8 @@ export class StateMachine implements RestateStreamConsumer {
     this.restateContext = new ContextImpl(
       this.invocation.id,
       // The console exposed by RestateContext filters logs in replay, while the internal one is based on the ENV variables.
-      createRestateConsole(
-        logger,
-        LogSource.USER,
-        loggerContext,
-        () => !this.journal.isReplaying()
+      createRestateConsole(logger, LogSource.USER, loggerContext, () =>
+        this.journal.isReplaying()
       ),
       handlerKind,
       invocation.userKey,

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -41,7 +41,7 @@ import {
 } from "./types/errors.js";
 import type { LocalStateStore } from "./local_state_store.js";
 import type { LoggerContext } from "./logger.js";
-import { createRestateConsole } from "./logger.js";
+import { LogSource, createRestateConsole } from "./logger.js";
 import type { WrappedPromise } from "./utils/promises.js";
 import {
   CompletablePromise,
@@ -97,7 +97,11 @@ export class StateMachine implements RestateStreamConsumer {
     this.restateContext = new ContextImpl(
       this.invocation.id,
       // The console exposed by RestateContext filters logs in replay, while the internal one is based on the ENV variables.
-      createRestateConsole(loggerContext, () => !this.journal.isReplaying()),
+      createRestateConsole(
+        LogSource.USER,
+        loggerContext,
+        () => !this.journal.isReplaying()
+      ),
       handlerKind,
       invocation.userKey,
       invocation.invocationValue,

--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -40,7 +40,7 @@ import {
   errorToErrorMessage,
 } from "./types/errors.js";
 import type { LocalStateStore } from "./local_state_store.js";
-import type { LoggerContext } from "./logger.js";
+import type { Logger, LoggerContext } from "./logger.js";
 import { LogSource, createRestateConsole } from "./logger.js";
 import type { WrappedPromise } from "./utils/promises.js";
 import {
@@ -88,16 +88,18 @@ export class StateMachine implements RestateStreamConsumer {
     private readonly connection: Connection,
     private readonly invocation: Invocation,
     handlerKind: HandlerKind,
+    logger: Logger,
     loggerContext: LoggerContext,
     private readonly suspensionMillis: number = 30_000
   ) {
     this.localStateStore = invocation.localStateStore;
-    this.console = createStateMachineConsole(loggerContext);
+    this.console = createStateMachineConsole(logger, loggerContext);
 
     this.restateContext = new ContextImpl(
       this.invocation.id,
       // The console exposed by RestateContext filters logs in replay, while the internal one is based on the ENV variables.
       createRestateConsole(
+        logger,
         LogSource.USER,
         loggerContext,
         () => !this.journal.isReplaying()

--- a/packages/restate-sdk/src/utils/message_logger.ts
+++ b/packages/restate-sdk/src/utils/message_logger.ts
@@ -17,6 +17,7 @@ import { formatMessageAsJson } from "./utils.js";
 import type { LoggerContext } from "../logger.js";
 import {
   createRestateConsole,
+  LogSource,
   RESTATE_LOG_LEVEL,
   RestateLogLevel,
 } from "../logger.js";
@@ -81,7 +82,7 @@ export type StateMachineConsole = Console & {
 export function createStateMachineConsole(
   context: LoggerContext
 ): StateMachineConsole {
-  const console = createRestateConsole(context);
+  const console = createRestateConsole(LogSource.JOURNAL, context);
 
   Object.defineProperties(console, {
     debugJournalMessage: {

--- a/packages/restate-sdk/src/utils/message_logger.ts
+++ b/packages/restate-sdk/src/utils/message_logger.ts
@@ -14,11 +14,12 @@
 
 import { formatMessageType } from "../types/protocol.js";
 import { formatMessageAsJson } from "./utils.js";
-import type { LoggerContext } from "../logger.js";
+import type { Logger, LoggerContext } from "../logger.js";
 import {
   createRestateConsole,
+  logLevel,
   LogSource,
-  RESTATE_LOG_LEVEL,
+  DEFAULT_LOGGER_LOG_LEVEL,
   RestateLogLevel,
 } from "../logger.js";
 
@@ -46,7 +47,7 @@ enum JournalLoggingLogLevel {
 
 const DEFAULT_DEBUG_LOG_LEVEL =
   globalThis?.process?.env["NODE_ENV"]?.toUpperCase() === "PRODUCTION" ||
-  RESTATE_LOG_LEVEL > RestateLogLevel.DEBUG
+  logLevel(DEFAULT_LOGGER_LOG_LEVEL) > logLevel(RestateLogLevel.DEBUG)
     ? JournalLoggingLogLevel.OFF
     : JournalLoggingLogLevel.DEBUG;
 
@@ -80,9 +81,10 @@ export type StateMachineConsole = Console & {
 };
 
 export function createStateMachineConsole(
+  logger: Logger,
   context: LoggerContext
 ): StateMachineConsole {
-  const console = createRestateConsole(LogSource.JOURNAL, context);
+  const console = createRestateConsole(logger, LogSource.JOURNAL, context);
 
   Object.defineProperties(console, {
     debugJournalMessage: {

--- a/packages/restate-sdk/test/awakeable.test.ts
+++ b/packages/restate-sdk/test/awakeable.test.ts
@@ -29,7 +29,6 @@ import {
 
 import type { TestGreeter } from "./testdriver.js";
 import { TestDriver, TestResponse } from "./testdriver.js";
-import { ProtocolMode } from "../src/types/discovery.js";
 import { describe, expect, it } from "vitest";
 
 class AwakeableGreeter implements TestGreeter {
@@ -55,14 +54,10 @@ describe("AwakeableGreeter", () => {
   });
 
   it("sends message to runtime for request-response case", async () => {
-    const result = await new TestDriver(
-      new AwakeableGreeter(),
-      [
-        startMessage({ knownEntries: 1, key: "Till" }),
-        inputMessage(greetRequest("Till")),
-      ],
-      ProtocolMode.REQUEST_RESPONSE
-    ).run();
+    const result = await new TestDriver(new AwakeableGreeter(), [
+      startMessage({ knownEntries: 1, key: "Till" }),
+      inputMessage(greetRequest("Till")),
+    ]).run();
 
     expect(result).toStrictEqual([awakeableMessage(), suspensionMessage([1])]);
   });

--- a/packages/restate-sdk/test/protoutils.ts
+++ b/packages/restate-sdk/test/protoutils.ts
@@ -59,8 +59,7 @@ import {
   RunEntryMessage,
   StartMessage_StateEntry,
 } from "../src/generated/proto/protocol_pb.js";
-import { jsonSerialize, formatMessageAsJson } from "../src/utils/utils.js";
-import { rlog } from "../src/logger.js";
+import { jsonSerialize } from "../src/utils/utils.js";
 import type { JournalErrorContext } from "../src/types/errors.js";
 import {
   INTERNAL_ERROR_CODE,
@@ -590,12 +589,3 @@ export const CLEAR_ALL_STATE_ENTRY_MESSAGE = new Message(
   CLEAR_ALL_STATE_ENTRY_MESSAGE_TYPE,
   new ClearAllStateEntryMessage()
 );
-
-// a utility function to print the results of a test
-export function printResults(results: Message[]) {
-  rlog.info(
-    results.map(
-      (el) => el.messageType + " - " + formatMessageAsJson(el.message) + "\n"
-    )
-  );
-}

--- a/packages/restate-sdk/test/testdriver.ts
+++ b/packages/restate-sdk/test/testdriver.ts
@@ -18,7 +18,6 @@ import {
 import type { Connection } from "../src/connection/connection.js";
 import { formatMessageAsJson } from "../src/utils/utils.js";
 import { Message } from "../src/types/types.js";
-import { rlog } from "../src/logger.js";
 import { StateMachine } from "../src/state_machine.js";
 import { InvocationBuilder } from "../src/invocation.js";
 import type { ObjectContext } from "../src/context.js";
@@ -26,6 +25,7 @@ import type { VirtualObjectDefinition } from "../src/public_api.js";
 import { object } from "../src/public_api.js";
 import { HandlerKind } from "../src/types/rpc.js";
 import { NodeEndpoint } from "../src/endpoint/node_endpoint.js";
+import type { EndpointBuilder } from "../src/endpoint/endpoint_builder.js";
 
 export type TestRequest = {
   name: string;
@@ -152,6 +152,10 @@ export class TestDriver implements Connection {
       this,
       invocation,
       HandlerKind.EXCLUSIVE,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      (
+        this.restateServer as unknown as { builder: EndpointBuilder }
+      ).builder.logger,
       invocation.inferLoggerContext()
     );
   }
@@ -180,7 +184,9 @@ export class TestDriver implements Connection {
 
   send(msg: Message): Promise<void> {
     this.result.push(msg);
-    rlog.debug(
+    (
+      this.restateServer as unknown as { builder: EndpointBuilder }
+    ).builder.rlog.debug(
       `Adding result to the result array. Message type: ${
         msg.messageType
       }, message:

--- a/packages/restate-sdk/tsconfig.json
+++ b/packages/restate-sdk/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/esm"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts"],
   "references": [{ "path": "../restate-sdk-core" }]
 }


### PR DESCRIPTION
Fixes #339

Allows you to provide a logging function that receives some parameters about the log (the context of the invocation, the level, where it came from) in addition to the message and extra params and allows the user to decide what to do with it