### PR TITLE
[client] Add 'raw' opt/sendOpt to skip JSON serde

### DIFF
--- a/packages/restate-sdk-clients/src/api.ts
+++ b/packages/restate-sdk-clients/src/api.ts
@@ -88,6 +88,13 @@ export interface IngresCallOptions {
    * Headers to attach to the request.
    */
   headers?: Record<string, string>;
+
+  /**
+   * Do not auto serialize the input and output of the handler.
+   * Setting this to true, would allow you to send binary data to the handler,
+   * and not assuming that the payload is JSON.
+   */
+  raw?: boolean;
 }
 
 export interface IngresSendOptions extends IngresCallOptions {

--- a/packages/restate-sdk-examples/src/ingress_client.ts
+++ b/packages/restate-sdk-examples/src/ingress_client.ts
@@ -146,6 +146,24 @@ const workflow = async (name: string) => {
   console.log(await client.workflowAttach());
 };
 
+const binaryRawCall = async (name: string) => {
+  const counter = ingress.objectClient(Counter, name);
+
+  const buffer = new TextEncoder().encode("hello!");
+
+  const outBuffer = await counter.binary(
+    buffer,
+    restate.Opts.from({
+      raw: true, // <-- tell the client to avoid JSON encoding/decoding
+      headers: { "content-type": "application/octet-stream" },
+    })
+  );
+
+  const str = new TextDecoder().decode(outBuffer);
+
+  console.log(`We got a buffer for ${name} : ${str}`);
+};
+
 // Before running this example, make sure
 // to run and register `greeter`, `counter` and `workflow` services.
 //
@@ -156,10 +174,10 @@ const workflow = async (name: string) => {
 // 3. restate deployment add localhost:9080
 
 Promise.resolve()
-  .then(() => sendAndCollectResultLater("boby"))
-  .then(() => simpleCall("bob"))
   .then(() => objectCall("bob"))
   .then(() => objectCall("mop"))
+  .then(() => simpleCall("bob"))
+  .then(() => sendAndCollectResultLater("boby"))
   .then(() => workflow("boby"))
   .then(() => idempotentCall("joe", "idemp-1"))
   .then(() => idempotentCall("joe", "idemp-1"))
@@ -167,4 +185,5 @@ Promise.resolve()
   .then(() => globalCustomHeaders("bob"))
   .then(() => customInterface("bob"))
   .then(() => delayedCall("bob"))
+  .then(() => binaryRawCall("bob"))
   .catch((e) => console.error(e));

--- a/packages/restate-sdk-examples/src/object.ts
+++ b/packages/restate-sdk-examples/src/object.ts
@@ -36,6 +36,24 @@ const counter = restate.object({
         return (await ctx.get("count")) ?? 0;
       }
     ),
+
+    /**
+     * Handlers (shared or exclusive) can be configured to bypass JSON serialization,
+     * by specifying the input (accept) and output (contentType) content types.
+     *
+     * to call that handler with binary data, you can use the following curl command:
+     * curl -X POST -H "Content-Type: application/octet-stream" --data-binary 'hello' ${RESTATE_INGRESS_URL}/counter/mykey/binary
+     */
+    binary: restate.handlers.object.exclusive(
+      {
+        accept: "application/octet-stream",
+        contentType: "application/octet-stream",
+      },
+      async (ctx: restate.ObjectContext, data: Uint8Array) => {
+        // console.log("Received binary data", data);
+        return data;
+      }
+    ),
   },
 });
 


### PR DESCRIPTION
This PR adds a `raw` optional property to the client To allow skipping JSON serde. This will pass the raw input buffer to the underlying fetch

Given the following object def:
```ts
const counter = restate.object({
  name: "counter",
  handlers: {
    /**
     * Handlers (shared or exclusive) can be configured to bypass JSON serialization,
     * by specifying the input (accept) and output (contentType) content types.
     *
     * to call that handler with binary data, you can use the following curl command:
     * curl -X POST -H "Content-Type: application/octet-stream" --data-binary 'hello' ${RESTATE_INGRESS_URL}/counter/mykey/binary
     */
    binary: restate.handlers.object.exclusive(
      {
        accept: "application/octet-stream",
        contentType: "application/octet-stream",
      },
      async (ctx: restate.ObjectContext, data: Uint8Array) => {
        // console.log("Received binary data", data);
        return data;
      }
    ),
  },
});
```

Now it is possible to invoke this handler from the client like this:

```ts
const client = restate.connect({ url: "http://localhost:8080" });

const counter = client.objectClient(Counter, "counter1");

const buffer: Uint8Array = new TextEncoder().encode("hello!");

const outBuffer: Uint8Array = await counter.binary(
    buffer,
    restate.Opts.from({
      raw: true, // <-- tell the client to avoid JSON encoding/decoding
      headers: { "content-type": "application/octet-stream" },
    })
 );

 const str = new TextDecoder().decode(outBuffer);

console.log(`We got a buffer for ${name} : ${str}`);
```