### PR TITLE
[workflow] Pass JSON serde in workflowClient

### DIFF
--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -135,8 +135,14 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
         get: (_target, prop) => {
           const route = prop as string;
           return (...args: unknown[]) => {
-            const requestBytes = serializeJson(args.shift());
-            return this.invoke(name, route, requestBytes, key);
+            return this.invoke(
+              name,
+              route,
+              args.shift(),
+              key,
+              serializeJson,
+              deserializeJson
+            );
           };
         },
       }


### PR DESCRIPTION
#402  Fixed a combineable promise ergonomic issue, but missed the `workflowClient`  proxy, which skips the deserialization of any workflow handler invocation. 
