### PR TITLE
Fix replaying detection in logger.ts

### DIFF
--- a/packages/restate-sdk/src/state_machine.ts
+++ b/packages/restate-sdk/src/state_machine.ts
@@ -104,7 +104,7 @@ export class StateMachine implements RestateStreamConsumer {
         logger,
         LogSource.USER,
         loggerContext,
-        this.journal.isReplaying.bind(this.journal)
+        this.journal.nextEntryWillBeReplayed.bind(this.journal)
       ),
       handlerKind,
       invocation.userKey,


### PR DESCRIPTION
isReplaying isn't always accurate as it transitions at the next journal entry. What we care about is whether the next entry will replay (if not, we should log)