### PR TITLE
Support absolute and relative urls in request object

### DIFF
--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -114,7 +114,8 @@ export class GenericHandler implements RestateHandler {
     request: RestateRequest,
     context?: AdditionalContext
   ): Promise<RestateResponse> {
-    const path = request.url;
+    // this is the recommended way to get the relative path from a url that may be relative or absolute
+    const path = new URL(request.url, "https://example.com").pathname;
 
     const error = await this.validateConnectionSignature(path, request.headers);
     if (error !== null) {


### PR DESCRIPTION
This will vary from platform to platform; in node the url is always relative, but in cloudflare et all it may be absolute. The identity verification will fail if we don't have it as relative.