### PR TITLE
Add support for Protocol version V2

### DIFF
--- a/packages/restate-sdk/proto/protocol.proto
+++ b/packages/restate-sdk/proto/protocol.proto
@@ -19,6 +19,9 @@ enum ServiceProtocolVersion {
   SERVICE_PROTOCOL_VERSION_UNSPECIFIED = 0;
   // initial service protocol version
   V1 = 1;
+  // Added
+  // * Entry retry mechanism: ErrorMessage.next_retry_interval, StartMessage.retry_count_since_last_stored_entry and StartMessage.duration_since_last_stored_entry
+  V2 = 2;
 }
 
 // --- Core frames ---
@@ -47,6 +50,18 @@ message StartMessage {
 
   // If this invocation has a key associated (e.g. for objects and workflows), then this key is filled in. Empty otherwise.
   string key = 6;
+
+  // Retry count since the last stored entry.
+  //
+  // Please not this count might not be accurate, as it's not durably stored,
+  // thus it's susceptible to Restate's crashes/leader election changes.
+  uint32 retry_count_since_last_stored_entry = 7;
+
+  // Duration since the last stored entry, in milliseconds.
+  //
+  // Please note this duration might not be accurate,
+  // and might change depending on which Restate replica executes the request.
+  uint64 duration_since_last_stored_entry = 8;
 }
 
 // Type: 0x0000 + 1
@@ -90,6 +105,10 @@ message ErrorMessage {
   optional string related_entry_name = 5;
   // Entry type.
   optional uint32 related_entry_type = 6;
+
+  // Interval before executing the next retry, specified as duration in milliseconds.
+  // If provided, it will override the default retry policy used by Restate's invoker ONLY for the next retry attempt.
+  optional uint64 next_retry_interval = 8;
 }
 
 // Type: 0x0000 + 4

--- a/packages/restate-sdk/src/endpoint/endpoint_builder.ts
+++ b/packages/restate-sdk/src/endpoint/endpoint_builder.ts
@@ -130,15 +130,12 @@ export class EndpointBuilder {
 
   computeDiscovery(protocolMode: discovery.ProtocolMode): discovery.Endpoint {
     const services = [...this.services.values()].map((c) => c.discovery());
-
-    const endpoint: discovery.Endpoint = {
+    return {
       protocolMode,
       minProtocolVersion: 1,
       maxProtocolVersion: 2,
       services,
     };
-
-    return endpoint;
   }
 
   private bindServiceComponent(name: string, router: any) {

--- a/packages/restate-sdk/src/types/protocol.ts
+++ b/packages/restate-sdk/src/types/protocol.ts
@@ -230,7 +230,7 @@ export const SUSPENSION_TRIGGERS: bigint[] = [
 const MIN_SERVICE_PROTOCOL_VERSION: ServiceProtocolVersion =
   ServiceProtocolVersion.V1;
 const MAX_SERVICE_PROTOCOL_VERSION: ServiceProtocolVersion =
-  ServiceProtocolVersion.V1;
+  ServiceProtocolVersion.V2;
 
 const MIN_SERVICE_DISCOVERY_PROTOCOL_VERSION: ServiceDiscoveryProtocolVersion =
   ServiceDiscoveryProtocolVersion.V1;
@@ -272,6 +272,9 @@ export function parseServiceProtocolVersion(
   if (versionString === "application/vnd.restate.invocation.v1") {
     return ServiceProtocolVersion.V1;
   }
+  if (versionString === "application/vnd.restate.invocation.v2") {
+    return ServiceProtocolVersion.V2;
+  }
 
   return ServiceProtocolVersion.SERVICE_PROTOCOL_VERSION_UNSPECIFIED;
 }
@@ -282,6 +285,8 @@ export function serviceProtocolVersionToHeaderValue(
   switch (serviceProtocolVersion) {
     case ServiceProtocolVersion.V1:
       return "application/vnd.restate.invocation.v1";
+    case ServiceProtocolVersion.V2:
+      return "application/vnd.restate.invocation.v2";
     default:
       throw new Error(
         `Unsupported service discovery protocol version: ${serviceProtocolVersion}`


### PR DESCRIPTION
Although we don't implement any feature from Protocol version 2, we now solve the issue of the discovery, where the sdk declared to support v2 and then failing on the invocation path.