### PR TITLE
The supported maxProtocolVersion should be 1, instead of 2.

### DIFF
--- a/packages/restate-sdk/src/endpoint/endpoint_builder.ts
+++ b/packages/restate-sdk/src/endpoint/endpoint_builder.ts
@@ -134,7 +134,7 @@ export class EndpointBuilder {
     const endpoint: discovery.Endpoint = {
       protocolMode,
       minProtocolVersion: 1,
-      maxProtocolVersion: 2,
+      maxProtocolVersion: 1,
       services,
     };
 


### PR DESCRIPTION
The SDK is communicating a wrong protocol version. It claims to support 2, while it doesn't, leading to an invocation failure: https://github.com/restatedev/restate/actions/runs/10559650982/job/29252180888?pr=1893