### PR TITLE
Allow JsonSerde serializer to passthrough a Uint8Array value

### DIFF
--- a/packages/restate-sdk-core/src/serde_api.ts
+++ b/packages/restate-sdk-core/src/serde_api.ts
@@ -28,6 +28,9 @@ class JsonSerde<T> implements Serde<T | undefined> {
     if (value == undefined) {
       return new Uint8Array(0);
     }
+    if (value instanceof Uint8Array) {
+      return value
+    }
     return new TextEncoder().encode(JSON.stringify(value));
   }
 


### PR DESCRIPTION
Feel free to reject if this isn't aligned with your thinking on scope of the Serdes

Use case:
If you have an existing Uint8Array that represents a JSON payload, and not wanting/needing to decode into a string and then `JSON.parse` it before handing it over to JsonSerde, just for it to call `JSON.stringify` and re-encode it back to a Uint8Array

Imagine scenario wanting to take an HTTP response raw body, or read JSON file from disk etc etc

Simply thinking from a performance perspective

Should be fine from typescript perspective too as `serde.json` is `Serde<any>`

Only possible _risk_ is that the value isn't actually representing a JSON payload, would that cause JsonSerde.deserialize to fail on the other end? I'm not sure on the impact of that - interested in your thoughts