### PR TITLE
Improve type inference for workflows defied from an interface

### DIFF
--- a/packages/restate-sdk-core/src/core.ts
+++ b/packages/restate-sdk-core/src/core.ts
@@ -114,9 +114,7 @@ export type WorkflowDefinition<P extends string, M> = {
   name: P;
 };
 
-export type Workflow<M> = M extends WorkflowDefinition<string, infer W>
-  ? W
-  : never;
+export type Workflow<M> = M extends WorkflowDefinition<string, infer W> ? W : M;
 
 export type WorkflowDefinitionFrom<M> = M extends WorkflowDefinition<
   string,


### PR DESCRIPTION
with this PR it is now possible to init a workflow client by defining an interface manually. For example:

```ts

type MyWorkflow = {

    run(ctx: unknown, arg: string): Promise<string>;

}

ingress.workflowClient<MyWorkflow>( { ... },
theKey).submitWorkflow("hi")

```