### PR TITLE
Normalise incoming paths before checking them against signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/restate-sdk-core",
@@ -31,7 +31,7 @@
         "vitest": "^1.6.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.13"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -8501,11 +8501,11 @@
     },
     "packages/restate-e2e-services": {
       "name": "@restatedev/restate-e2e-services",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk": "^1.2.1",
-        "@restatedev/restate-sdk-clients": "^1.2.1",
+        "@restatedev/restate-sdk": "^1.3.1",
+        "@restatedev/restate-sdk-clients": "^1.3.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -8514,16 +8514,16 @@
         "tsx": "^4.15.7"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.13"
       }
     },
     "packages/restate-sdk": {
       "name": "@restatedev/restate-sdk",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^1.8.0",
-        "@restatedev/restate-sdk-core": "^1.2.1"
+        "@restatedev/restate-sdk-core": "^1.3.1"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.15.0",
@@ -8531,41 +8531,41 @@
         "@types/aws-lambda": "^8.10.115"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.13"
       }
     },
     "packages/restate-sdk-clients": {
       "name": "@restatedev/restate-sdk-clients",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk-core": "^1.2.1"
+        "@restatedev/restate-sdk-core": "^1.3.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.13"
       }
     },
     "packages/restate-sdk-core": {
       "name": "@restatedev/restate-sdk-core",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.13"
       }
     },
     "packages/restate-sdk-examples": {
       "name": "@restatedev/restate-sdk-examples",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk": "^1.2.1",
-        "@restatedev/restate-sdk-clients": "^1.2.1"
+        "@restatedev/restate-sdk": "^1.3.1",
+        "@restatedev/restate-sdk-clients": "^1.3.1"
       },
       "devDependencies": {
         "tsx": "^4.15.7"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.13"
       }
     }
   }

--- a/packages/restate-sdk/src/endpoint/request_signing/validate.ts
+++ b/packages/restate-sdk/src/endpoint/request_signing/validate.ts
@@ -9,6 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
+import type { PathComponents } from "../../types/components.js";
 import type { KeySetV1 } from "./v1.js";
 import { SCHEME_V1, validateV1 } from "./v1.js";
 
@@ -22,7 +23,7 @@ export type ValidateSuccess = { valid: true; validKey: string; scheme: string };
 
 export async function validateRequestSignature(
   keySet: KeySetV1,
-  path: string,
+  path: PathComponents,
   headers: { [name: string]: string | string[] | undefined }
 ): Promise<ValidateResponse> {
   const scheme = headerValue(SIGNATURE_SCHEME_HEADER, headers) ?? "unsigned";

--- a/packages/restate-sdk/test/testdriver.ts
+++ b/packages/restate-sdk/test/testdriver.ts
@@ -205,6 +205,7 @@ export class UUT<N extends string, T> {
     const method = restateServer
       .componentByName(options.service ? options.service : this.defaultService)
       ?.handlerMatching({
+        type: "invoke",
         componentName: options.service ? options.service : this.defaultService,
         handlerName: options.handler ? options.handler : this.defaultHandler,
       });


### PR DESCRIPTION
THe runtime does not absolutise its paths against the http url - it just signs something like /invoke/a/b or /discover. We should normalise the paths we receive when checking against the signature.