### PR TITLE
Replace commands to run examples with working ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ npm run lint
 
 Launch a sample program (requires no build)
 ```shell
-npm run example
+npm run -w packages/restate-sdk-examples greeter
+npm run -w packages/restate-sdk-examples object
+npm run -w packages/restate-sdk-examples workflow
 ```
 
 ### Testing end-to-end with Restate Server


### PR DESCRIPTION
The README mentions `npm run example` which doesn't exist.
This PR replaces it with working commands from the examples package.

Based on a discussion in discord, this just runs the deployments/services without registering or executing them.