### PR TITLE
Logging fixes

### DIFF
--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -84,6 +84,7 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
     readonly input: vm.WasmInput,
     public readonly console: Console,
     public readonly handlerKind: HandlerKind,
+    private readonly vmLogger: Console,
     private readonly invocationRequest: Request,
     private readonly invocationEndPromise: CompletablePromise<void>,
     private readonly inputReader: ReadableStreamDefaultReader<Uint8Array>,
@@ -835,7 +836,7 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
       !(error instanceof RestateError) ||
       error.code !== SUSPENDED_ERROR_CODE
     ) {
-      this.console.warn("Function completed with an error.\n", error);
+      this.vmLogger.warn("Invocation completed with an error.\n", error);
     }
     this.coreVm.notify_error(error.message, error.stack);
 


### PR DESCRIPTION
- Use vm logger for invocation start/end logs
- The vm logger should have source: journal
- We should use the custom logger for logs that happen before the start message is processed
- We should use the terminology 'Invocation completed' not 'Function completed'
- Bring back 'Replaying invocation'