### PR TITLE
Remove deprecated APIs

### DIFF
--- a/packages/restate-e2e-services/src/app.ts
+++ b/packages/restate-e2e-services/src/app.ts
@@ -36,11 +36,8 @@ REGISTRY.register(fqdns, endpoint);
 if (process.env.E2E_REQUEST_SIGNING) {
   endpoint.withIdentityV1(...process.env.E2E_REQUEST_SIGNING.split(","));
 }
-if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
-  endpoint.listen().catch((e) => {
-    // eslint-disable-next-line no-console
-    console.error(e);
-  });
-}
 
-export const handler = endpoint.lambdaHandler();
+endpoint.listen().catch((e) => {
+  // eslint-disable-next-line no-console
+  console.error(e);
+});

--- a/packages/restate-sdk-clients/src/api.ts
+++ b/packages/restate-sdk-clients/src/api.ts
@@ -90,14 +90,6 @@ export interface IngresCallOptions<I = unknown, O = unknown> {
    */
   headers?: Record<string, string>;
 
-  /**
-   * Do not auto serialize the input and output of the handler.
-   * Setting this to true, would allow you to send binary data to the handler,
-   * and not assuming that the payload is JSON.
-   * @deprecated please use inputSerde and outputSerde instead, and provide `restate.serde.binary` as an argument.
-   */
-  raw?: boolean;
-
   input?: Serde<I>;
 
   output?: Serde<O>;

--- a/packages/restate-sdk-clients/src/ingress.ts
+++ b/packages/restate-sdk-clients/src/ingress.ts
@@ -140,14 +140,10 @@ const doComponentInvocation = async <I, O>(
       fragments.push("send");
     }
   }
-  const raw: boolean = params.opts?.opts.raw ?? false;
   //
   // request body
   //
-  let inputSerde = params.opts?.opts.input;
-  if (!inputSerde) {
-    inputSerde = raw ? serde.binary : serde.json;
-  }
+  const inputSerde = params.opts?.opts.input ?? serde.json;
 
   const { body, contentType } = serializeBodyWithContentType(
     params.parameter,
@@ -207,8 +203,7 @@ const doComponentInvocation = async <I, O>(
   }
   const responseBuf = await httpResponse.arrayBuffer();
   if (!params.send) {
-    const outputSerde =
-      params.opts?.opts.output ?? (raw ? serde.binary : serde.json);
+    const outputSerde = params.opts?.opts.output ?? serde.json;
     return outputSerde.deserialize(new Uint8Array(responseBuf)) as O;
   }
   const json = serde.json.deserialize(new Uint8Array(responseBuf)) as O;

--- a/packages/restate-sdk/src/common_api.ts
+++ b/packages/restate-sdk/src/common_api.ts
@@ -47,12 +47,11 @@ export type {
   WorkflowDefinition,
 } from "@restatedev/restate-sdk-core";
 
-export type { ServiceBundle, RestateEndpoint } from "./endpoint.js";
+export type { RestateEndpoint } from "./endpoint.js";
 export { RestateError, TerminalError, TimeoutError } from "./types/errors.js";
 export type {
   LoggerTransport,
   LogMetadata,
-  LogParams,
   RestateLogLevel,
   LoggerContext,
   LogSource,

--- a/packages/restate-sdk/src/endpoint.ts
+++ b/packages/restate-sdk/src/endpoint.ts
@@ -17,21 +17,6 @@ import type {
 } from "@restatedev/restate-sdk-core";
 import type { LoggerTransport } from "./logging/logger_transport.js";
 
-/**
- * Utility interface for a bundle of one or more services belonging together
- * and being registered together.
- *
- * @deprecated Service bundle is unused and will be removed.
- */
-export interface ServiceBundle {
-  /**
-   * Called to register the services at the endpoint.
-   *
-   * @deprecated Service bundle is unused and will be removed.
-   */
-  registerServices(endpoint: RestateEndpoint): void;
-}
-
 export interface RestateEndpointBase<E> {
   /**
    * Binds a new durable service / virtual object / workflow.
@@ -44,14 +29,6 @@ export interface RestateEndpointBase<E> {
       | VirtualObjectDefinition<P, M>
       | WorkflowDefinition<P, M>
   ): E;
-
-  /**
-   * Adds one or more services to this endpoint. This will call the
-   * {@link ServiceBundle.registerServices} function to register all services at this endpoint.
-   *
-   * @deprecated service bundle is deprecated
-   */
-  bindBundle(services: ServiceBundle): E;
 
   /**
    * Provide a list of v1 request identity public keys eg `publickeyv1_2G8dCQhArfvGpzPw5Vx2ALciR4xCLHfS5YaT93XjNxX9` to validate
@@ -116,18 +93,6 @@ export interface RestateEndpointBase<E> {
  * ```
  */
 export interface RestateEndpoint extends RestateEndpointBase<RestateEndpoint> {
-  /**
-   * Creates the invocation handler function to be called by AWS Lambda.
-   *
-   * The returned type of this function is `(event: APIGatewayProxyEvent | APIGatewayProxyEventV2) => Promise<APIGatewayProxyResult | APIGatewayProxyResultV2>`.
-   * We use `any` types here to avoid a dependency on the `@types/aws-lambda` dependency for consumers of this API.
-   *
-   * @returns The invocation handler function for to be called by AWS Lambda.
-   * @deprecated import "@restatedev/restate-sdk/lambda" instead
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  lambdaHandler(): (event: any, ctx: any) => Promise<any>;
-
   /**
    * Serve this Restate Endpoint as HTTP2 server, listening to the given port.
    *

--- a/packages/restate-sdk/src/endpoint/fetch_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/fetch_endpoint.ts
@@ -16,11 +16,7 @@ import type {
 } from "@restatedev/restate-sdk-core";
 import type { Component } from "../types/components.js";
 import { EndpointBuilder } from "./endpoint_builder.js";
-import type {
-  RestateEndpoint,
-  RestateEndpointBase,
-  ServiceBundle,
-} from "../endpoint.js";
+import type { RestateEndpointBase } from "../endpoint.js";
 import { GenericHandler } from "./handlers/generic.js";
 import { fetcher } from "./handlers/fetch.js";
 import { ProtocolMode } from "../types/discovery.js";
@@ -71,11 +67,6 @@ export class FetchEndpointImpl implements FetchEndpoint {
 
   public addComponent(component: Component) {
     this.builder.addComponent(component);
-  }
-
-  bindBundle(services: ServiceBundle): FetchEndpoint {
-    services.registerServices(this as unknown as RestateEndpoint);
-    return this;
   }
 
   public bind<P extends string, M>(

--- a/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/lambda_endpoint.ts
@@ -16,11 +16,7 @@ import type {
 } from "@restatedev/restate-sdk-core";
 import type { Component } from "../types/components.js";
 import { EndpointBuilder } from "./endpoint_builder.js";
-import type {
-  RestateEndpoint,
-  RestateEndpointBase,
-  ServiceBundle,
-} from "../endpoint.js";
+import type { RestateEndpointBase } from "../endpoint.js";
 import { GenericHandler } from "./handlers/generic.js";
 import { LambdaHandler } from "./handlers/lambda.js";
 import { ProtocolMode } from "../types/discovery.js";
@@ -58,11 +54,6 @@ export class LambdaEndpointImpl implements LambdaEndpoint {
 
   public addComponent(component: Component) {
     this.builder.addComponent(component);
-  }
-
-  bindBundle(services: ServiceBundle): LambdaEndpoint {
-    services.registerServices(this as unknown as RestateEndpoint);
-    return this;
   }
 
   public bind<P extends string, M>(

--- a/packages/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/node_endpoint.ts
@@ -12,7 +12,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { RestateEndpoint, ServiceBundle } from "../public_api.js";
+import type { RestateEndpoint } from "../public_api.js";
 import type {
   ServiceDefinition,
   VirtualObjectDefinition,
@@ -44,11 +44,6 @@ export class NodeEndpoint implements RestateEndpoint {
 
   public addComponent(component: Component) {
     this.builder.addComponent(component);
-  }
-
-  public bindBundle(services: ServiceBundle): RestateEndpoint {
-    services.registerServices(this);
-    return this;
   }
 
   public bind<P extends string, M>(

--- a/packages/restate-sdk/src/logging/logger_transport.ts
+++ b/packages/restate-sdk/src/logging/logger_transport.ts
@@ -44,11 +44,6 @@ export type LogMetadata = {
 };
 
 /**
- * @deprecated use {@link LogMetadata}
- */
-export type LogParams = LogMetadata;
-
-/**
  * Logger transport, often known in other logging libraries as appender. Filtering of log events should happen within this function as well.
  *
  * This can be overridden in {@link RestateEndpointBase.setLogger} to customize logging. The default Logger transport will log to console.
@@ -58,11 +53,6 @@ export type LoggerTransport = (
   message?: any,
   ...optionalParams: any[]
 ) => void;
-
-/**
- * @deprecated use {@link LoggerTransport}
- */
-export type Logger = LoggerTransport;
 
 /**
  * Logger context.


### PR DESCRIPTION
Remove
* ServiceBundle API
* old custom logger API, they have been renamed to `LogMetadata` and `LoggerTransport`
* old lambda handler API, use the `restate-sdk-lambda` package for that
* old input/output serializer/deserializers functions and the raw attribute. Use custom `serde`s for those.