### PR TITLE
Add abort controller signal for efficient resource cleanup

### DIFF
--- a/packages/restate-sdk/src/context.ts
+++ b/packages/restate-sdk/src/context.ts
@@ -68,6 +68,13 @@ export interface Request {
    * Care should be taken to use them deterministically.
    */
   readonly extraArgs: unknown[];
+
+  /**
+   * This is a signal that is aborted when the current attempt has been completed either successful or unsuccessfully.
+   * When the signal is aborted, the current attempt has been completed and the handler should not perform any more work, other
+   * than cleanup any external resources that might be shared across attempts (e.g. database connections).
+   */
+  readonly attemptCompletedSignal: AbortSignal;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -277,6 +277,8 @@ export class GenericHandler implements RestateHandler {
     // Get input
     const input = coreVm.sys_input();
 
+    const abortController = new AbortController();
+
     const invocationRequest: Request = {
       id: input.invocation_id,
       headers: input.headers.reduce((headers, { key, value }) => {
@@ -294,6 +296,7 @@ export class GenericHandler implements RestateHandler {
       ),
       body: input.input,
       extraArgs,
+      attemptCompletedSignal: abortController.signal,
     };
 
     // Prepare logger
@@ -395,6 +398,11 @@ export class GenericHandler implements RestateHandler {
         inputReader.cancel().catch(() => {});
       })
       .finally(() => {
+        try {
+          abortController.abort();
+        } catch (e) {
+          // suppressed
+        }
         invocationLoggers.delete(loggerId);
       })
       .catch(() => {});


### PR DESCRIPTION
This PR adds a new field to `ctx.request`, that allows to subscribe to attempt cleanup AbortSignal signals. Use this to cleanup any externally held resources, like database connections, etc'.