### PR TITLE
Use the host AbortSignal if provided

### DIFF
--- a/packages/restate-sdk/src/endpoint/handlers/fetch.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/fetch.ts
@@ -25,6 +25,7 @@ export function fetcher(handler: GenericHandler) {
         headers,
         body: event.body,
         extraArgs,
+        abortSignal: event.signal,
       };
 
       const resp = await handler.handle(request);


### PR DESCRIPTION
For runtimes like Deno, CF, Bun that provide a fetch compatible server api, we should thread trough the abort signal that is provided by them. For node and lambda we will provide our own.