### PR TITLE
Remove restate-sdk-zod from the examples

### DIFF
--- a/packages/restate-sdk-examples/package.json
+++ b/packages/restate-sdk-examples/package.json
@@ -37,8 +37,7 @@
   },
   "dependencies": {
     "@restatedev/restate-sdk": "^1.4.0",
-    "@restatedev/restate-sdk-clients": "^1.4.0",
-    "@restatedev/restate-sdk-zod": "^1.4.0"
+    "@restatedev/restate-sdk-clients": "^1.4.0"
   },
   "devDependencies": {
     "tsx": "^4.15.7",


### PR DESCRIPTION
This commit removes the dependency on sdk-zod
that was added to the examples, since this artifact wasn't yet published.