### PR TITLE
Fix propagation of error when creating the VM. 

### DIFF
--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -120,7 +120,10 @@ export class GenericHandler implements RestateHandler {
       this.endpoint.rlog.error(
         "Error while handling invocation: " + (error.stack ?? error.message)
       );
-      return this.toErrorResponse(500, error.message);
+      return this.toErrorResponse(
+        error instanceof RestateError ? error.code : 500,
+        error.message
+      );
     }
   }
 


### PR DESCRIPTION
This prevents the runtime from detecting a protocol version violation, thus not showing the nice error message.