### PR TITLE
Support omitting content type for void handlers

### DIFF
--- a/packages/restate-sdk-core/src/serde_api.ts
+++ b/packages/restate-sdk-core/src/serde_api.ts
@@ -14,8 +14,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 export interface Serde<T> {
-  readonly contentType: string;
-  readonly jsonSchema?: object;
+  contentType?: string;
+  jsonSchema?: object;
 
   serialize(value: T): Uint8Array;
 
@@ -35,8 +35,6 @@ class BinarySerde implements Serde<Uint8Array> {
 }
 
 class VoidSerde implements Serde<void> {
-  contentType = "application/octet-stream";
-
   serialize(value: any): Uint8Array {
     if (value !== undefined) {
       throw new Error("Expected undefined value");

--- a/packages/restate-sdk/src/types/discovery.ts
+++ b/packages/restate-sdk/src/types/discovery.ts
@@ -26,15 +26,15 @@ export enum ServiceHandlerType {
   SHARED = "SHARED",
 }
 
-type InputPayload = {
-  required: boolean;
-  contentType: string;
+export type InputPayload = {
+  required?: boolean;
+  contentType?: string;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   jsonSchema?: any; // You should specify the type of jsonSchema if known
 };
 
-type OutputPayload = {
-  contentType: string;
+export type OutputPayload = {
+  contentType?: string;
   setContentTypeIfEmpty: boolean;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   jsonSchema?: any; // You should specify the type of jsonSchema if known

--- a/packages/restate-sdk/src/types/rpc.ts
+++ b/packages/restate-sdk/src/types/rpc.ts
@@ -406,8 +406,8 @@ export class HandlerWrapper {
     return handler[HANDLER_SYMBOL] as HandlerWrapper | undefined;
   }
 
-  public readonly accept: string;
-  public readonly contentType: string;
+  public readonly accept?: string;
+  public readonly contentType?: string;
 
   private constructor(
     public readonly kind: HandlerKind,


### PR DESCRIPTION
This PR propagates properly the discovery metadata for handlers that either have a void return type, or void parameter.
Previously we would report application/json as content type, which is not correct in these cases.

