### PR TITLE
Validate sleep duration is non-negative.

### DIFF
--- a/packages/restate-sdk/src/context_impl.ts
+++ b/packages/restate-sdk/src/context_impl.ts
@@ -439,6 +439,11 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
   }
 
   public sleep(millis: number): RestatePromise<void> {
+    if (millis < 0) {
+      throw new Error(
+        `Invalid duration. The sleep function only accepts non-negative values. Received: ${millis}ms.`
+      );
+    }
     return this.processCompletableEntry(
       (vm) => vm.sys_sleep(BigInt(millis)),
       completeUsing(VoidAsUndefined)


### PR DESCRIPTION
### Before:
At the moment a negative sleep duration causes the service to crash with this error

```
[restate][2025-05-13T08:31:17.172Z][greeter/greet][inv_18mP0bGrYLaj5Z610aSA2q60Kh2chnBoSG] DEBUG: Executing 'Timer with duration 18446744073709551.615s'
panicked at /home/slinkydeveloper/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/restate-sdk-shared-core-0.3.0/src/vm/mod.rs:678:22:
millis since Unix epoch should fit in u64: TryFromIntError(())

Stack:

Error
    at imports.wbg.__wbg_new_8a6f238a6ece86ea (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:1383:17)
    at wasm://wasm/00310276:wasm-function[1479]:0xa756e
    at wasm://wasm/00310276:wasm-function[433]:0x5c4a3
    at wasm://wasm/00310276:wasm-function[1030]:0x91d71
    at wasm://wasm/00310276:wasm-function[586]:0x67280
    at wasm://wasm/00310276:wasm-function[1032]:0x94bc5
    at WasmVM.sys_sleep (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:831:22)
    at <anonymous> (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:443:18)
    at ContextImpl.processCompletableEntry (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:554:16)
    at ContextImpl.sleep (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:442:17)


[restate][2025-05-13T08:31:17.174Z][greeter/greet][inv_18mP0bGrYLaj5Z610aSA2q60Kh2chnBoSG] WARN: Error when processing a Restate context operation.
 RuntimeError: unreachable
    at wasm://wasm/00310276:wasm-function[433]:0x5c4c7
    at wasm://wasm/00310276:wasm-function[1030]:0x91d71
    at wasm://wasm/00310276:wasm-function[586]:0x67280
    at wasm://wasm/00310276:wasm-function[1032]:0x94bc5
    at WasmVM.sys_sleep (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:831:22)
    at <anonymous> (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:443:18)
    at ContextImpl.processCompletableEntry (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:554:16)
    at ContextImpl.sleep (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:442:17)
    at Object.greet (/Users/nik/Developer/sdk-typescript/packages/restate-sdk-examples/src/greeter.ts:18:17)
    at Object.handlerCopy (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/types/rpc.ts:390:22)
[restate][2025-05-13T08:31:17.176Z][greeter/greet][inv_18mP0bGrYLaj5Z610aSA2q60Kh2chnBoSG] WARN: Invocation completed with an error.
 Error: recursive use of an object detected which would lead to unsafe aliasing in rust
    at imports.wbg.__wbindgen_throw (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:1600:11)
    at wasm://wasm/00310276:wasm-function[1435]:0xa6778
    at wasm://wasm/00310276:wasm-function[1437]:0xa6794
    at wasm://wasm/00310276:wasm-function[719]:0x6ece3
    at wasm://wasm/00310276:wasm-function[458]:0x5e1d5
    at WasmVM.notify_error (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:693:10)
    at ContextImpl.handleInvocationEndError (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:573:17)
    at ContextImpl.processCompletableEntry (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:556:12)
    at ContextImpl.sleep (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/context_impl.ts:442:17)
    at Object.greet (/Users/nik/Developer/sdk-typescript/packages/restate-sdk-examples/src/greeter.ts:18:17)
file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:1600
    throw new Error(getStringFromWasm0(arg0, arg1));
          ^

Error: recursive use of an object detected which would lead to unsafe aliasing in rust
    at imports.wbg.__wbindgen_throw (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:1600:11)
    at wasm://wasm/00310276:wasm-function[1435]:0xa6778
    at wasm://wasm/00310276:wasm-function[1437]:0xa6794
    at wasm://wasm/00310276:wasm-function[719]:0x6ece3
    at wasm://wasm/00310276:wasm-function[458]:0x5e1d5
    at WasmVM.notify_error (file:///Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js:693:10)
    at <anonymous> (/Users/nik/Developer/sdk-typescript/packages/restate-sdk/src/endpoint/handlers/generic.ts:385:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

### After:
<img width="1078" alt="Screenshot 2025-05-13 at 12 13 17" src="https://github.com/user-attachments/assets/5d1c8f0b-261f-42f4-a72a-7d0e5901e4fd" />

One downside of this approach is that we will not have a SLEEP COMMAND entry in the journal. Since the duration of sleep is recorded as part of an immutable SLEEP entry, I am not sure what's the best way to commit the entry while keeping the error recoverable (ie. changing  the duration).