### PR TITLE
Add `FATAL` log level

### DIFF
--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -518,6 +518,8 @@ function wasmLogLevelToRestateLogLevel(level: vm.LogLevel): RestateLogLevel {
       return RestateLogLevel.WARN;
     case vm.LogLevel.ERROR:
       return RestateLogLevel.ERROR;
+    case vm.LogLevel.FATAL:
+      return RestateLogLevel.FATAL;
   }
 }
 
@@ -533,5 +535,7 @@ function restateLogLevelToWasmLogLevel(level: RestateLogLevel): vm.LogLevel {
       return vm.LogLevel.WARN;
     case RestateLogLevel.ERROR:
       return vm.LogLevel.ERROR;
+    case RestateLogLevel.FATAL:
+      return vm.LogLevel.FATAL;
   }
 }

--- a/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.d.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.d.ts
@@ -15,6 +15,7 @@ export enum LogLevel {
   INFO = 2,
   WARN = 3,
   ERROR = 4,
+  FATAL = 5,
 }
 export interface WasmFailure {
   code: number;

--- a/packages/restate-sdk/src/logging/console_logger_transport.ts
+++ b/packages/restate-sdk/src/logging/console_logger_transport.ts
@@ -43,6 +43,8 @@ export const defaultLoggerTransport: LoggerTransport = (
       return console.warn(p, message, ...optionalParams);
     case RestateLogLevel.ERROR:
       return console.error(p, message, ...optionalParams);
+    case RestateLogLevel.FATAL:
+      return console.error(p, message, ...optionalParams);
     default:
       throw new TypeError(`unset or unknown log level ${params.level}`);
   }
@@ -78,6 +80,8 @@ function logLevelFromName(name?: string): RestateLogLevel | null {
       return RestateLogLevel.WARN;
     case "ERROR":
       return RestateLogLevel.ERROR;
+    case "FATAL":
+      return RestateLogLevel.FATAL;
     default:
       throw new TypeError(`unknown name ${name}`);
   }
@@ -95,6 +99,8 @@ function logLevel(level: RestateLogLevel): number {
       return 4;
     case RestateLogLevel.ERROR:
       return 5;
+    case RestateLogLevel.FATAL:
+      return 6;
   }
 }
 

--- a/packages/restate-sdk/src/logging/logger_transport.ts
+++ b/packages/restate-sdk/src/logging/logger_transport.ts
@@ -22,6 +22,7 @@ export enum RestateLogLevel {
   INFO = "info",
   WARN = "warn",
   ERROR = "error",
+  FATAL = "fatal",
 }
 
 /**


### PR DESCRIPTION
Add `FATAL` log level

Summary:
This is to avoid spammy logs in tests, mainly the `e2e-verification-tests`
