### PR TITLE
Improve error handling

### DIFF
--- a/packages/restate-e2e-services/src/app.ts
+++ b/packages/restate-e2e-services/src/app.ts
@@ -83,14 +83,16 @@ server.on("session", (session) => {
     console.log("Session closed. Total:", ACTIVE_SESSIONS);
   });
 });
-server.on("stream", (session) => {
+server.on("stream", (stream) => {
   ACTIVE_STREAMS++;
-  console.log("New stream opened.. Total:", ACTIVE_STREAMS);
+  console.log("New stream opened. Total:", ACTIVE_STREAMS);
 
-  session.on("close", () => {
+  const handleCloseStream = () => {
     --ACTIVE_STREAMS;
     console.log("Stream closed. Total:", ACTIVE_STREAMS);
-  });
+  };
+  stream.on("close", handleCloseStream);
+  stream.on("error", handleCloseStream);
 });
 
 setInterval(() => {

--- a/packages/restate-e2e-services/src/app.ts
+++ b/packages/restate-e2e-services/src/app.ts
@@ -74,10 +74,6 @@ const server = http2.createServer((req, res) => {
   handler(req, res);
 });
 
-function totalStreamsCount() {
-  return Array.from(sessions.values()).reduce((p, c) => p + c.size, 0);
-}
-
 server.on("session", (session) => {
   const sessionId = ACTIVE_SESSIONS++;
   const streams = new Set();
@@ -100,6 +96,8 @@ server.on("session", (session) => {
     stream.on("close", handleCloseStream);
     stream.on("error", handleCloseStream);
   });
+
+  return undefined;
 });
 
 setInterval(() => {
@@ -107,8 +105,11 @@ setInterval(() => {
   console.log(
     `${new Date().toISOString()}: Inflight requests: ${INFLIGHT_REQUESTS}`
   );
+  // eslint-disable-next-line no-console
   console.table(
-    Array.from(sessions.values()).map((set) => ({ "#streams": set.size }))
+    Array.from(sessions.values()).map((set: Set<string>) => ({
+      "#streams": set.size,
+    }))
   );
 }, 30 * 1000);
 

--- a/packages/restate-e2e-services/src/app.ts
+++ b/packages/restate-e2e-services/src/app.ts
@@ -54,9 +54,7 @@ REGISTRY.register(fqdns, endpoint);
 
 const settings: http2.Settings = {};
 if (process.env.MAX_CONCURRENT_STREAMS) {
-  settings.maxConcurrentStreams = parseInt(
-    process.env.MAX_CONCURRENT_STREAMS || "256"
-  );
+  settings.maxConcurrentStreams = parseInt(process.env.MAX_CONCURRENT_STREAMS);
 }
 
 if (process.env.E2E_REQUEST_SIGNING) {

--- a/packages/restate-e2e-services/src/app.ts
+++ b/packages/restate-e2e-services/src/app.ts
@@ -63,6 +63,7 @@ if (process.env.E2E_REQUEST_SIGNING) {
 
 let INFLIGHT_REQUESTS = 0;
 let ACTIVE_SESSIONS = 0;
+let ACTIVE_STREAMS = 0;
 
 const handler = endpoint.http2Handler();
 const server = http2.createServer((req, res) => {
@@ -80,6 +81,15 @@ server.on("session", (session) => {
   session.on("close", () => {
     --ACTIVE_SESSIONS;
     console.log("Session closed. Total:", ACTIVE_SESSIONS);
+  });
+});
+server.on("stream", (session) => {
+  ACTIVE_STREAMS++;
+  console.log("New stream opened.. Total:", ACTIVE_STREAMS);
+
+  session.on("close", () => {
+    --ACTIVE_STREAMS;
+    console.log("Stream closed. Total:", ACTIVE_STREAMS);
   });
 });
 

--- a/packages/restate-e2e-services/src/app.ts
+++ b/packages/restate-e2e-services/src/app.ts
@@ -83,12 +83,8 @@ server.on("session", (session) => {
   const streams = new Set();
   sessions.set(sessionId, streams);
 
-  console.log("New session opened. Total:", sessions.size);
-  console.log();
-
   const handleCloseSession = () => {
     sessions.delete(sessionId);
-    console.log("Session closed. Total:", sessions.size);
   };
 
   session.on("close", handleCloseSession);
@@ -97,17 +93,8 @@ server.on("session", (session) => {
   session.on("stream", (stream) => {
     streams.add(`${sessionId}_${stream.id}`);
 
-    console.log(
-      `New stream opened: ${stream.id}. Total per connection: ${streams.size}`
-    );
-    console.log("Total streams:", totalStreamsCount());
-
     const handleCloseStream = () => {
       streams.delete(`${sessionId}_${stream.id}`);
-      console.log(
-        `Stream closed: ${stream.id}. Total per connection: ${streams.size}`
-      );
-      console.log("Total streams:", totalStreamsCount());
     };
 
     stream.on("close", handleCloseStream);
@@ -119,6 +106,9 @@ setInterval(() => {
   // eslint-disable-next-line no-console
   console.log(
     `${new Date().toISOString()}: Inflight requests: ${INFLIGHT_REQUESTS}`
+  );
+  console.table(
+    Array.from(sessions.values()).map((set) => ({ "#streams": set.size }))
   );
 }, 30 * 1000);
 

--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -268,6 +268,9 @@ export class GenericHandler implements RestateHandler {
       );
 
       const inputReader = body.getReader();
+      abortSignal.addEventListener("abort", () => {
+        inputReader.cancel();
+      });
 
       // Now buffer input entries
       while (!coreVm.is_ready_to_execute()) {

--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -268,9 +268,13 @@ export class GenericHandler implements RestateHandler {
       );
 
       const inputReader = body.getReader();
-      abortSignal.addEventListener("abort", () => {
-        inputReader.cancel();
-      });
+      abortSignal.addEventListener(
+        "abort",
+        () => {
+          inputReader.cancel();
+        },
+        { once: true }
+      );
 
       // Now buffer input entries
       while (!coreVm.is_ready_to_execute()) {

--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -271,7 +271,7 @@ export class GenericHandler implements RestateHandler {
       abortSignal.addEventListener(
         "abort",
         () => {
-          inputReader.cancel();
+          void inputReader.cancel();
         },
         { once: true }
       );

--- a/packages/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/node_endpoint.ts
@@ -118,7 +118,9 @@ export class NodeEndpoint implements RestateEndpoint {
             "Error while handling connection: " + (error.stack ?? error.message)
           );
           response.destroy(error);
-          abortController.abort();
+          if (!abortController.signal.aborted) {
+            abortController.abort();
+          }
         }
       })().catch(() => {});
     };

--- a/packages/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/node_endpoint.ts
@@ -118,9 +118,7 @@ export class NodeEndpoint implements RestateEndpoint {
             "Error while handling connection: " + (error.stack ?? error.message)
           );
           response.destroy(error);
-          if (!abortController.signal.aborted) {
-            abortController.abort();
-          }
+          abortController.abort();
         }
       })().catch(() => {});
     };

--- a/packages/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/restate-sdk/src/endpoint/node_endpoint.ts
@@ -75,6 +75,7 @@ export class NodeEndpoint implements RestateEndpoint {
     return (request, response) => {
       (async () => {
         const abortController = new AbortController();
+
         request.once("aborted", () => {
           abortController.abort();
         });
@@ -84,21 +85,33 @@ export class NodeEndpoint implements RestateEndpoint {
         request.once("error", () => {
           abortController.abort();
         });
+
+        if (request.destroyed || request.aborted) {
+          this.builder.rlog.error("Client disconnected");
+          abortController.abort();
+        }
+
         try {
           const url = request.url;
+          const webRequestBody = Readable.toWeb(request);
+
           const resp = await handler.handle({
             url,
             headers: request.headers,
-            body: Readable.toWeb(request),
+            body: webRequestBody,
             extraArgs: [],
             abortSignal: abortController.signal,
           });
+
+          if (response.destroyed) {
+            return;
+          }
+
           response.writeHead(resp.statusCode, resp.headers);
           const responseWeb = Writable.toWeb(
             response
           ) as WritableStream<Uint8Array>;
           await resp.body.pipeTo(responseWeb);
-          await new Promise<void>((resolve) => response.end(resolve));
         } catch (e) {
           const error = ensureError(e);
           this.builder.rlog.error(


### PR DESCRIPTION
- Adds more logging to the end-to-end tests to count the number of connections and streams.  
-  Aims to be more defensive in handling streams instead of waiting for an error to occur and then catching it.