### PR TITLE
Resolve leak on aborted invocation

### DIFF
--- a/packages/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/restate-sdk/src/endpoint/handlers/generic.ts
@@ -274,6 +274,7 @@ export class GenericHandler implements RestateHandler {
       abortSignal.addEventListener(
         "abort",
         () => {
+          invocationLoggers.delete(loggerId);
           void inputReader.cancel();
         },
         { once: true }


### PR DESCRIPTION
On AbortError we were not removing the logger, causing a leak.