### PR TITLE
[types] Align VODefinition with Service and Workflow

### DIFF
--- a/packages/restate-sdk-core/src/core.ts
+++ b/packages/restate-sdk-core/src/core.ts
@@ -93,7 +93,7 @@ export type VirtualObject<M> = M extends VirtualObjectDefinition<
   infer O
 >
   ? O
-  : never;
+  : M;
 
 export type VirtualObjectDefinitionFrom<M> = M extends VirtualObjectDefinition<
   string,


### PR DESCRIPTION
This change aligns the definition with service and workflow definitions.

With that PR, the following is working:

```ts
interface Greeter {
  greet(ctx: unknown, name: string) => Promise<string>;
}

```

Then given,
```ts
const greeter = restate.object({
    name: "greeter",
    handlers: {
    
         greet: async (ctx: ObjectContext, name: string)  => {
         }
     
   } satisfies Greeter
});
```

It is possible to:

```ts

ctx.objectSendClient<Greeter>( { name : "greeter }, "boby").greet( ... )

```
