### PR TITLE
Replace chained `endpoint` API with unified `createEndpointHandler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ const greeter = restate.service({
     },
 });
 
-restate.endpoint()
-    .bind(greeter)
-    .listen(9080);
+restate.serve({ services: [greeter], port: 9080 });
 ```
 
 ## Community

--- a/packages/restate-sdk-cloudflare-workers/patches/fetch.js
+++ b/packages/restate-sdk-cloudflare-workers/patches/fetch.js
@@ -10,13 +10,46 @@
  */
 export * from "./common_api.js";
 import { FetchEndpointImpl } from "./endpoint/fetch_endpoint.js";
-import { cloudflareWorkersBundlerPatch } from "./endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js"
+import { withOptions } from "./endpoint/withOptions.js";
+import { cloudflareWorkersBundlerPatch } from "./endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js";
 /**
  * Create a new {@link RestateEndpoint} in request response protocol mode.
  * Bidirectional mode (must be served over http2) can be enabled with .enableHttp2()
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint() {
-    cloudflareWorkersBundlerPatch()
-    return new FetchEndpointImpl("REQUEST_RESPONSE");
+  cloudflareWorkersBundlerPatch();
+  return new FetchEndpointImpl("REQUEST_RESPONSE");
 }
+
+/**
+ * Creates a Cloudflare worker handler that encapsulates all the Restate services served by this endpoint.
+ *
+ * @param options - Configuration options for the endpoint handler.
+ * @returns A worker handler.
+ *
+ * @example
+ * A typical request-response handler would look like this:
+ * ```
+ * import { createEndpointHandler } from "@restatedev/restate-sdk/restate-sdk-cloudflare-workers";
+ *
+ * export const handler = createEndpointHandler({ services: [myService] })
+ *
+ * @example
+ * A typical bidirectional handler (works with http2 and some http1.1 servers) would look like this:
+ * ```
+ * import { createEndpointHandler } from "@restatedev/restate-sdk/restate-sdk-cloudflare-workers";
+ *
+ * export const handler = createEndpointHandler({ services: [myService], bidirectional: true })
+ *
+ */
+export function createEndpointHandler(options) {
+  return withOptions(
+    new FetchEndpointImpl(
+      options.bidirectional ? "BIDI_STREAM" : "REQUEST_RESPONSE"
+    ),
+    options
+  ).handler().fetch;
+}
+
 //# sourceMappingURL=fetch.js.map

--- a/packages/restate-sdk-cloudflare-workers/patches/fetch.js
+++ b/packages/restate-sdk-cloudflare-workers/patches/fetch.js
@@ -44,6 +44,7 @@ export function endpoint() {
  *
  */
 export function createEndpointHandler(options) {
+  cloudflareWorkersBundlerPatch();
   return withOptions(
     new FetchEndpointImpl(
       options.bidirectional ? "BIDI_STREAM" : "REQUEST_RESPONSE"

--- a/packages/restate-sdk-cloudflare-workers/patches/fetch.js
+++ b/packages/restate-sdk-cloudflare-workers/patches/fetch.js
@@ -15,7 +15,6 @@ import { cloudflareWorkersBundlerPatch } from "./endpoint/handlers/vm/sdk_shared
 /**
  * Create a new {@link RestateEndpoint} in request response protocol mode.
  * Bidirectional mode (must be served over http2) can be enabled with .enableHttp2()
- * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint() {
   cloudflareWorkersBundlerPatch();

--- a/packages/restate-sdk-examples/src/greeter.ts
+++ b/packages/restate-sdk-examples/src/greeter.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import { service, endpoint, type Context } from "@restatedev/restate-sdk";
+import { service, serve, type Context } from "@restatedev/restate-sdk";
 
 const greeter = service({
   name: "greeter",
@@ -22,4 +22,4 @@ const greeter = service({
 
 export type Greeter = typeof greeter;
 
-endpoint().bind(greeter).listen();
+serve({ services: [greeter] });

--- a/packages/restate-sdk-examples/src/greeter_with_options.ts
+++ b/packages/restate-sdk-examples/src/greeter_with_options.ts
@@ -11,7 +11,7 @@
 
 import {
   service,
-  endpoint,
+  serve,
   handlers,
   TerminalError,
   type Context,
@@ -49,10 +49,10 @@ const greeter = service({
 
 export type Greeter = typeof greeter;
 
-endpoint()
-  .bind(greeter)
-  .defaultServiceOptions({
+serve({
+  services: [greeter],
+  defaultServiceOptions: {
     // You can configure default service options that will be applied to every service.
     journalRetention: { days: 10 },
-  })
-  .listen();
+  },
+});

--- a/packages/restate-sdk-examples/src/object.ts
+++ b/packages/restate-sdk-examples/src/object.ts
@@ -59,4 +59,4 @@ export const counter = restate.object({
 
 export type Counter = typeof counter;
 
-restate.endpoint().bind(counter).listen();
+restate.serve({ services: [counter] });

--- a/packages/restate-sdk-examples/src/workflow.ts
+++ b/packages/restate-sdk-examples/src/workflow.ts
@@ -120,4 +120,4 @@ const payment = restate.workflow({
 
 export type PaymentWorkflow = typeof payment;
 
-restate.endpoint().bind(payment).listen();
+restate.serve({ services: [payment] });

--- a/packages/restate-sdk-examples/src/zod_greeter.ts
+++ b/packages/restate-sdk-examples/src/zod_greeter.ts
@@ -34,4 +34,4 @@ const greeter = restate.service({
 
 export type Greeter = typeof greeter;
 
-restate.endpoint().bind(greeter).listen();
+restate.serve({ services: [greeter] });

--- a/packages/restate-sdk-examples/test/hello.test.ts
+++ b/packages/restate-sdk-examples/test/hello.test.ts
@@ -13,7 +13,7 @@ import * as restate from "@restatedev/restate-sdk";
 import { describe, it } from "vitest";
 
 describe("HelloGreeter", () => {
-  it("Demonstrates how to write a simple services", () => {
+  it("Demonstrates how we used to write a simple services", () => {
     const myservice = restate.service({
       name: "myservice",
       handlers: {
@@ -24,6 +24,22 @@ describe("HelloGreeter", () => {
     });
 
     restate.endpoint().bind(myservice);
+
+    //---> 	.listen();
+  });
+
+  it("Demonstrates how to write a simple services", () => {
+    const myservice = restate.service({
+      name: "myservice",
+      handlers: {
+        greet: async (ctx: restate.Context) => {
+          return await ctx.run("greet", () => "hi there!");
+        },
+      },
+    });
+
+    restate.createEndpointHandler({ services: [myservice] });
+
     //---> 	.listen();
   });
 });

--- a/packages/restate-sdk-examples/test/testcontainers.test.ts
+++ b/packages/restate-sdk-examples/test/testcontainers.test.ts
@@ -26,9 +26,9 @@ describe("ExampleObject", () => {
 
   // Deploy Restate and the Service endpoint once for all the tests in this suite
   beforeAll(async () => {
-    restateTestEnvironment = await RestateTestEnvironment.start(
-      (restateServer) => restateServer.bind(counter)
-    );
+    restateTestEnvironment = await RestateTestEnvironment.start({
+      services: [counter],
+    });
     rs = clients.connect({ url: restateTestEnvironment.baseUrl() });
   }, 20_000);
 
@@ -127,7 +127,7 @@ describe("Custom testcontainer config", () => {
   // Deploy Restate and the Service endpoint once for all the tests in this suite
   beforeAll(async () => {
     restateTestEnvironment = await RestateTestEnvironment.start(
-      (restateServer) => restateServer.bind(counter),
+      { services: [counter] },
       () =>
         new RestateContainer()
           .withEnvironment({ RESTATE_LOG_FORMAT: "json" })

--- a/packages/restate-sdk-testcontainers/src/public_api.ts
+++ b/packages/restate-sdk-testcontainers/src/public_api.ts
@@ -32,4 +32,5 @@ export type {
   WorkflowOptions,
   TerminalError,
   RestateError,
+  EndpointOptions,
 } from "@restatedev/restate-sdk";

--- a/packages/restate-sdk-testcontainers/src/restate_test_environment.ts
+++ b/packages/restate-sdk-testcontainers/src/restate_test_environment.ts
@@ -11,7 +11,11 @@
 
 /* eslint-disable no-console */
 
-import { endpoint, createEndpointHandler } from "@restatedev/restate-sdk";
+import {
+  endpoint,
+  createEndpointHandler,
+  serde,
+} from "@restatedev/restate-sdk";
 import type {
   TypedState,
   UntypedState,

--- a/packages/restate-sdk-testcontainers/src/restate_test_environment.ts
+++ b/packages/restate-sdk-testcontainers/src/restate_test_environment.ts
@@ -173,7 +173,6 @@ export class RestateTestEnvironment {
 
   /**
    *
-   * @deprecated Please use {@link EndpointOptions} instead of this.
    * @example
    * ```
    * RestateTestEnvironment.start({ services: [mysService] })

--- a/packages/restate-sdk-zod/README.md
+++ b/packages/restate-sdk-zod/README.md
@@ -36,7 +36,7 @@ const greeter = restate.service({
 
 export type Greeter = typeof greeter;
 
-restate.endpoint().bind(greeter).listen();
+restate.serve({ services: [greeter], port: 9080 });
 ```
 
 For the SDK main package, checkout [`@restatedev/restate-sdk`](../restate-sdk).

--- a/packages/restate-sdk/README.md
+++ b/packages/restate-sdk/README.md
@@ -23,9 +23,7 @@ const greeter = restate.service({
     },
 });
 
-restate.endpoint()
-    .bind(greeter)
-    .listen(9080);
+restate.serve({ services: [greeter], port: 9080 });
 ```
 
 ## Community

--- a/packages/restate-sdk/package.json
+++ b/packages/restate-sdk/package.json
@@ -28,6 +28,16 @@
         "default": "./dist/cjs/src/public_api.js"
       }
     },
+    "./node": {
+      "import": {
+        "types": "./dist/esm/src/node.d.ts",
+        "default": "./dist/esm/src/node.js"
+      },
+      "require": {
+        "types": "./dist/cjs/src/node.d.ts",
+        "default": "./dist/cjs/src/node.js"
+      }
+    },
     "./fetch": {
       "import": {
         "types": "./dist/esm/src/fetch.d.ts",
@@ -51,6 +61,9 @@
   },
   "typesVersions": {
     "*": {
+      "node": [
+        "dist/cjs/src/node.d.ts"
+      ],
       "fetch": [
         "dist/cjs/src/fetch.d.ts"
       ],

--- a/packages/restate-sdk/src/common_api.ts
+++ b/packages/restate-sdk/src/common_api.ts
@@ -123,3 +123,4 @@ export type {
   LoggerContext,
   LogSource,
 } from "./logging/logger_transport.js";
+export type { EndpointOptions } from "./endpoint/types.js";

--- a/packages/restate-sdk/src/context.ts
+++ b/packages/restate-sdk/src/context.ts
@@ -463,7 +463,7 @@ export interface Context extends RestateContext {
    * export type Service = typeof service;
    *
    *
-   * restate.endpoint().bind(service).listen(9080);
+   * restate.serve({ services: [service], port: 9080 });
    * ```
    * *Client side:*
    * ```ts
@@ -540,7 +540,7 @@ export interface Context extends RestateContext {
    * // option 2: export the API definition with type and name (name)
    * const MyService: MyApi = { name: "myservice" };
    *
-   * restate.endpoint().bind(service).listen(9080);
+   * restate.serve({ services: [service], port: 9080 });
    * ```
    * *Client side:*
    * ```ts

--- a/packages/restate-sdk/src/endpoint/types.ts
+++ b/packages/restate-sdk/src/endpoint/types.ts
@@ -1,0 +1,58 @@
+import type {
+  DefaultServiceOptions,
+  LoggerTransport,
+  ServiceDefinition,
+  VirtualObjectDefinition,
+  WorkflowDefinition,
+} from "../common_api.js";
+
+/**
+ * Options for creating an endpoint handler for Node.js HTTP/2 servers.
+ */
+export interface EndpointOptions {
+  /**
+   * A list of Restate services, virtual objects, or workflows that will be exposed via the endpoint.
+   */
+  services: Array<
+    | ServiceDefinition<string, unknown>
+    | VirtualObjectDefinition<string, unknown>
+    | WorkflowDefinition<string, unknown>
+  >;
+  /**
+   * Provide a list of v1 request identity public keys eg `publickeyv1_2G8dCQhArfvGpzPw5Vx2ALciR4xCLHfS5YaT93XjNxX9` to validate
+   * incoming requests against, limiting requests to Restate clusters with the corresponding private keys. This public key format is
+   * logged by the Restate process at startup if a request identity private key is provided.
+   *
+   * If this function is called, all incoming requests irrelevant of endpoint type will be expected to have
+   * `x-restate-signature-scheme: v1` and `x-restate-jwt-v1: <valid jwt signed with one of these keys>`. If not called,
+   *
+   */
+  identityKeys?: string[];
+  /**
+   * Default service options that will be used by all services bind to this endpoint.
+   *
+   * Options can be overridden on each service/handler.
+   */
+  defaultServiceOptions?: DefaultServiceOptions;
+  /**
+   * Replace the default console-based {@link LoggerTransport}
+   * @example
+   * Using console:
+   * ```ts
+   * createEndpointHandler({ logger: (meta, message, ...o) => {console.log(`${meta.level}: `, message, ...o)}})
+   * ```
+   * @example
+   * Using winston:
+   * ```ts
+   * const logger = createLogger({ ... })
+   * createEndpointHandler({ logger: (meta, message, ...o) => {logger.log(meta.level, {invocationId: meta.context?.invocationId}, [message, ...o].join(' '))} })
+   * ```
+   * @example
+   * Using pino:
+   * ```ts
+   * const logger = pino()
+   * createEndpointHandler({ logger: (meta, message, ...o) => {logger[meta.level]({invocationId: meta.context?.invocationId}, [message, ...o].join(' '))}} )
+   * ```
+   */
+  logger?: LoggerTransport;
+}

--- a/packages/restate-sdk/src/endpoint/withOptions.ts
+++ b/packages/restate-sdk/src/endpoint/withOptions.ts
@@ -1,0 +1,24 @@
+import type { RestateEndpointBase } from "../endpoint.js";
+import type { EndpointOptions } from "./types.js";
+
+export function withOptions<E extends RestateEndpointBase<E>>(
+  endpoint: E,
+  { identityKeys, defaultServiceOptions, logger, services }: EndpointOptions
+): E {
+  let endpointWithOptions = endpoint;
+  if (identityKeys && identityKeys.length > 0) {
+    endpointWithOptions = endpointWithOptions.withIdentityV1(...identityKeys);
+  }
+  if (defaultServiceOptions) {
+    endpointWithOptions = endpointWithOptions.defaultServiceOptions(
+      defaultServiceOptions
+    );
+  }
+  if (logger) {
+    endpointWithOptions = endpointWithOptions.setLogger(logger);
+  }
+
+  return services.reduce((results, service) => {
+    return results.bind(service);
+  }, endpointWithOptions);
+}

--- a/packages/restate-sdk/src/fetch.ts
+++ b/packages/restate-sdk/src/fetch.ts
@@ -21,7 +21,6 @@ import { withOptions } from "./endpoint/withOptions.js";
 /**
  * Create a new {@link RestateEndpoint} in request response protocol mode.
  * Bidirectional mode (must be served over http2) can be enabled with .enableHttp2()
- * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): FetchEndpoint {
   return new FetchEndpointImpl("REQUEST_RESPONSE");

--- a/packages/restate-sdk/src/fetch.ts
+++ b/packages/restate-sdk/src/fetch.ts
@@ -15,11 +15,56 @@ import {
   type FetchEndpoint,
   FetchEndpointImpl,
 } from "./endpoint/fetch_endpoint.js";
+import type { EndpointOptions } from "./endpoint/types.js";
+import { withOptions } from "./endpoint/withOptions.js";
 
 /**
  * Create a new {@link RestateEndpoint} in request response protocol mode.
  * Bidirectional mode (must be served over http2) can be enabled with .enableHttp2()
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): FetchEndpoint {
   return new FetchEndpointImpl("REQUEST_RESPONSE");
+}
+
+interface FetchEndpointOptions extends EndpointOptions {
+  /**
+   * Enables bidirectional communication for the handler.
+   *
+   * When set to `true`, the handler supports bidirectional streaming (e.g., via HTTP/2 or compatible HTTP/1.1 servers).
+   * When `false`, the handler operates in request-response mode only.
+   *
+   * @default false
+   */
+  bidirectional?: boolean;
+}
+
+/**
+ * Creates a Fetch handler that encapsulates all the Restate services served by this endpoint.
+ *
+ * @param {FetchEndpointOptions} options - Configuration options for the endpoint handler.
+ * @returns A fetch handler function.
+ *
+ * @example
+ * A typical request-response handler would look like this:
+ * ```
+ * import { createEndpointHandler } from "@restatedev/restate-sdk/fetch";
+ *
+ * export const handler = createEndpointHandler({ services: [myService] })
+ *
+ * @example
+ * A typical bidirectional handler (works with http2 and some http1.1 servers) would look like this:
+ * ```
+ * import { createEndpointHandler } from "@restatedev/restate-sdk/fetch";
+ *
+ * export const handler = createEndpointHandler({ services: [myService], bidirectional: true })
+ *
+ */
+export function createEndpointHandler(options: FetchEndpointOptions) {
+  return withOptions<FetchEndpoint>(
+    new FetchEndpointImpl(
+      options.bidirectional ? "BIDI_STREAM" : "REQUEST_RESPONSE"
+    ),
+    options
+  ).handler().fetch;
 }

--- a/packages/restate-sdk/src/lambda.ts
+++ b/packages/restate-sdk/src/lambda.ts
@@ -20,7 +20,6 @@ import { withOptions } from "./endpoint/withOptions.js";
 
 /**
  * Create a new {@link LambdaEndpoint}.
- * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): LambdaEndpoint {
   return new LambdaEndpointImpl();

--- a/packages/restate-sdk/src/lambda.ts
+++ b/packages/restate-sdk/src/lambda.ts
@@ -19,7 +19,7 @@ import type { EndpointOptions } from "./endpoint/types.js";
 import { withOptions } from "./endpoint/withOptions.js";
 
 /**
- * Create a new {@link RestateEndpoint}.
+ * Create a new {@link LambdaEndpoint}.
  * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): LambdaEndpoint {

--- a/packages/restate-sdk/src/lambda.ts
+++ b/packages/restate-sdk/src/lambda.ts
@@ -15,10 +15,33 @@ import {
   LambdaEndpointImpl,
   type LambdaEndpoint,
 } from "./endpoint/lambda_endpoint.js";
+import type { EndpointOptions } from "./endpoint/types.js";
+import { withOptions } from "./endpoint/withOptions.js";
 
 /**
  * Create a new {@link RestateEndpoint}.
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): LambdaEndpoint {
   return new LambdaEndpointImpl();
+}
+
+/**
+ * Creates a Lambda handler that encapsulates all the Restate services served by this endpoint.
+ *
+ * @param {EndpointOptions} options - Configuration options for the endpoint handler.
+ * @returns A Lambda handler function.
+ *
+ * @example
+ * A typical endpoint served as Lambda would look like this:
+ * ```
+ * import { createEndpointHandler } from "@restatedev/restate-sdk/lambda";
+ *
+ * export const handler = createEndpointHandler({ services: [myService] })
+ */
+export function createEndpointHandler(options: EndpointOptions) {
+  return withOptions<LambdaEndpoint>(
+    new LambdaEndpointImpl(),
+    options
+  ).handler();
 }

--- a/packages/restate-sdk/src/node.ts
+++ b/packages/restate-sdk/src/node.ts
@@ -18,6 +18,11 @@ import { withOptions } from "./endpoint/withOptions.js";
 /**
  * Creates an HTTP/2 request handler for the provided services.
  *
+ * @example
+ * ```
+ * const httpServer = http2.createServer(createEndpointHandler({ services: [myService] }));
+ * httpServer.listen(port);
+ * ```
  * @param {EndpointOptions} options - Configuration options for the endpoint handler.
  * @returns An HTTP/2 request handler function.
  */
@@ -26,4 +31,26 @@ export function createEndpointHandler(options: EndpointOptions) {
     new NodeEndpoint(),
     options
   ).http2Handler();
+}
+
+interface ServeOptions extends EndpointOptions {
+  port?: number;
+}
+
+/**
+ * Serves this Restate services as HTTP2 server, listening to the given port.
+ *
+ * If the port is undefined, this method will use the port set in the `PORT`
+ * environment variable. If that variable is undefined as well, the method will
+ * default to port 9080.
+ *
+ * The returned promise resolves with the bound port when the server starts listening, or rejects with a failure otherwise.
+ *
+ * If you need to manually control the server lifecycle, we suggest to manually instantiate the http2 server and use {@link createEndpointHandler}.
+ *
+ * @param {ServeOptions} options - Configuration options for the endpoint handler.
+ * @returns a Promise that resolves with the bound port, or rejects with a failure otherwise.
+ */
+export function serve({ port, ...options }: ServeOptions) {
+  return withOptions<RestateEndpoint>(new NodeEndpoint(), options).listen(port);
 }

--- a/packages/restate-sdk/src/node.ts
+++ b/packages/restate-sdk/src/node.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023-2024 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+export * from "./common_api.js";
+import type { RestateEndpoint } from "./endpoint.js";
+import { NodeEndpoint } from "./endpoint/node_endpoint.js";
+import type { EndpointOptions } from "./endpoint/types.js";
+import { withOptions } from "./endpoint/withOptions.js";
+
+/**
+ * Creates an HTTP/2 request handler for the provided services.
+ *
+ * @param {EndpointOptions} options - Configuration options for the endpoint handler.
+ * @returns An HTTP/2 request handler function.
+ */
+export function createEndpointHandler(options: EndpointOptions) {
+  return withOptions<RestateEndpoint>(
+    new NodeEndpoint(),
+    options
+  ).http2Handler();
+}

--- a/packages/restate-sdk/src/node.ts
+++ b/packages/restate-sdk/src/node.ts
@@ -17,7 +17,6 @@ import { withOptions } from "./endpoint/withOptions.js";
 
 /**
  * Create a new {@link RestateEndpoint}.
- * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): RestateEndpoint {
   return new NodeEndpoint();

--- a/packages/restate-sdk/src/node.ts
+++ b/packages/restate-sdk/src/node.ts
@@ -16,6 +16,14 @@ import type { EndpointOptions } from "./endpoint/types.js";
 import { withOptions } from "./endpoint/withOptions.js";
 
 /**
+ * Create a new {@link RestateEndpoint}.
+ * @deprecated Please use {@link createEndpointHandler}
+ */
+export function endpoint(): RestateEndpoint {
+  return new NodeEndpoint();
+}
+
+/**
  * Creates an HTTP/2 request handler for the provided services.
  *
  * @example

--- a/packages/restate-sdk/src/node.ts
+++ b/packages/restate-sdk/src/node.ts
@@ -41,7 +41,7 @@ export function createEndpointHandler(options: EndpointOptions) {
   ).http2Handler();
 }
 
-interface ServeOptions extends EndpointOptions {
+export interface ServeOptions extends EndpointOptions {
   port?: number;
 }
 

--- a/packages/restate-sdk/src/public_api.ts
+++ b/packages/restate-sdk/src/public_api.ts
@@ -10,14 +10,3 @@
  */
 
 export * from "./node.js";
-
-import type { RestateEndpoint } from "./endpoint.js";
-import { NodeEndpoint } from "./endpoint/node_endpoint.js";
-
-/**
- * Create a new {@link RestateEndpoint}.
- * @deprecated Please use {@link createEndpointHandler}
- */
-export function endpoint(): RestateEndpoint {
-  return new NodeEndpoint();
-}

--- a/packages/restate-sdk/src/public_api.ts
+++ b/packages/restate-sdk/src/public_api.ts
@@ -9,13 +9,14 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-export * from "./common_api.js";
+export * from "./node.js";
 
 import type { RestateEndpoint } from "./endpoint.js";
 import { NodeEndpoint } from "./endpoint/node_endpoint.js";
 
 /**
  * Create a new {@link RestateEndpoint}.
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): RestateEndpoint {
   return new NodeEndpoint();


### PR DESCRIPTION
This PR ~deprecates~ the old chained-style API based on `restate.endpoint().bind()...` and introduces a new, config-driven and runtime-explicit API based on `createEndpointHandler`.

- Introduced createEndpointHandler(config) as the new primary API for exposing services across all runtimes
- Added `serve(config)` as a convenience helper for fast development with Node.js
- Per-runtime entry points: 
  - `@restatedev/restate-sdk/node`
  - `@restatedev/restate-sdk/lambda`
  - `@restatedev/restate-sdk/fetch`
  - `@restatedev/restate-sdk-cloudflare-workers/fetch`
- The root package `@restatedev/restate-sdk` now defaults to Node-specific exports, for compatibility 
- The builder-style API in `RestateTestEnvironment.start` (from `@restatedev/restate-sdk-testcontainers`) has also been deprecated in favour of the new config-driven API.

```diff
// Node
import * as restate from '@restatedev/restate-sdk';

- restate
-  .endpoint()
-  .bind(myService)
-  .withIdentityV1(['some-key'])
-  .listen(9080);

+ restate.serve({
+  services: [myService],
+  identityKeys: ["some-key"],
+  port: 9080,
+ });
```

```ts
// Lambda
import { createEndpointHandler } from '@restatedev/restate-sdk/lambda';
export const handler = createEndpointHandler({ services: [...] });
```

```ts
// Bun
import { createEndpointHandler } from '@restatedev/restate-sdk/fetch';
Bun.serve({
  port: 8080,
  routes: {
    "/*": createEndpointHandler({ services: [...] }),
  },
});
```

```ts
// Deno
import { createEndpointHandler } from '@restatedev/restate-sdk/fetch';
Deno.serve({ handler: createEndpointHandler({ services: [...] }) });
```

```ts
// Cloudflare worker
import { createEndpointHandler } from '@restatedev/restate-sdk-cloudflare-workers/fetch';
export default { fetch: createEndpointHandler({ services: [...] }) };
```

```ts
// Node with custom server
import { createEndpointHandler } from '@restatedev/restate-sdk/node';
const handler = createEndpointHandler({ services: [...] });
http2.createServer(handler).listen(9080);
```
