### PR TITLE
Deprecate `endpoint()` API

### DIFF
--- a/packages/restate-sdk-cloudflare-workers/patches/fetch.js
+++ b/packages/restate-sdk-cloudflare-workers/patches/fetch.js
@@ -15,6 +15,7 @@ import { cloudflareWorkersBundlerPatch } from "./endpoint/handlers/vm/sdk_shared
 /**
  * Create a new {@link RestateEndpoint} in request response protocol mode.
  * Bidirectional mode (must be served over http2) can be enabled with .enableHttp2()
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint() {
   cloudflareWorkersBundlerPatch();

--- a/packages/restate-sdk-testcontainers/src/restate_test_environment.ts
+++ b/packages/restate-sdk-testcontainers/src/restate_test_environment.ts
@@ -173,6 +173,7 @@ export class RestateTestEnvironment {
 
   /**
    *
+   * @deprecated Please use {@link EndpointOptions} instead of this.
    * @example
    * ```
    * RestateTestEnvironment.start({ services: [mysService] })

--- a/packages/restate-sdk/src/fetch.ts
+++ b/packages/restate-sdk/src/fetch.ts
@@ -21,6 +21,7 @@ import { withOptions } from "./endpoint/withOptions.js";
 /**
  * Create a new {@link RestateEndpoint} in request response protocol mode.
  * Bidirectional mode (must be served over http2) can be enabled with .enableHttp2()
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): FetchEndpoint {
   return new FetchEndpointImpl("REQUEST_RESPONSE");

--- a/packages/restate-sdk/src/lambda.ts
+++ b/packages/restate-sdk/src/lambda.ts
@@ -20,6 +20,7 @@ import { withOptions } from "./endpoint/withOptions.js";
 
 /**
  * Create a new {@link LambdaEndpoint}.
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): LambdaEndpoint {
   return new LambdaEndpointImpl();

--- a/packages/restate-sdk/src/node.ts
+++ b/packages/restate-sdk/src/node.ts
@@ -17,6 +17,7 @@ import { withOptions } from "./endpoint/withOptions.js";
 
 /**
  * Create a new {@link RestateEndpoint}.
+ * @deprecated Please use {@link createEndpointHandler}
  */
 export function endpoint(): RestateEndpoint {
   return new NodeEndpoint();


### PR DESCRIPTION
We should not merge/publish this, until we updated docs and examples.