### PR TITLE
Don't set contentType for zod void/undefined types

### DIFF
--- a/packages/restate-sdk-zod/src/serde_api.ts
+++ b/packages/restate-sdk-zod/src/serde_api.ts
@@ -17,17 +17,20 @@
 
 import type { Serde } from "@restatedev/restate-sdk-core";
 
-import type { z } from "zod";
+import { z, ZodVoid } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export type { Serde } from "@restatedev/restate-sdk-core";
 
 class ZodSerde<T extends z.ZodType> implements Serde<z.infer<T>> {
-  contentType = "application/json";
+  contentType? = "application/json";
   jsonSchema?: object | undefined;
 
   constructor(private readonly schema: T) {
     this.jsonSchema = zodToJsonSchema(schema);
+    if (schema instanceof ZodVoid || schema instanceof z.ZodUndefined) {
+      this.contentType = undefined;
+    }
   }
 
   serialize(value: T): Uint8Array {

--- a/packages/restate-sdk/src/endpoint/components.ts
+++ b/packages/restate-sdk/src/endpoint/components.ts
@@ -50,8 +50,7 @@ function handlerInputDiscovery(handler: HandlerWrapper): d.InputPayload {
 
   if (handler.inputSerde.jsonSchema) {
     jsonSchema = handler.inputSerde.jsonSchema;
-    contentType =
-      handler.accept ?? handler.inputSerde.contentType ?? "application/json";
+    contentType = handler.accept ?? handler.inputSerde.contentType;
   } else if (handler.accept) {
     contentType = handler.accept;
   } else if (handler.inputSerde.contentType) {

--- a/packages/restate-sdk/src/types/rpc.ts
+++ b/packages/restate-sdk/src/types/rpc.ts
@@ -455,7 +455,7 @@ export class HandlerWrapper {
     public readonly enableLazyState?: boolean,
     public readonly asTerminalError?: (error: any) => TerminalError | undefined
   ) {
-    this.accept = accept ? accept : inputSerde.contentType;
+    this.accept = accept !== undefined ? accept : inputSerde.contentType;
     this.contentType = outputSerde.contentType;
   }
 


### PR DESCRIPTION
With this PR, it is possible to declare a `serde.zod(z.void())` for no-args handlers.