### PR TITLE
FIX #573: Adds `zod` v4 support for `serde`. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "1.8.0",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "workspaces": [
         "packages/restate-sdk-core",
@@ -10228,7 +10228,9 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10237,6 +10239,7 @@
       "version": "3.24.3",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz",
       "integrity": "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
@@ -10244,11 +10247,11 @@
     },
     "packages/restate-e2e-services": {
       "name": "@restatedev/restate-e2e-services",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk": "^1.8.0",
-        "@restatedev/restate-sdk-clients": "^1.8.0",
+        "@restatedev/restate-sdk": "^1.8.3",
+        "@restatedev/restate-sdk-clients": "^1.8.3",
         "heapdump": "^0.3.15",
         "uuid": "^9.0.0"
       },
@@ -10264,10 +10267,10 @@
     },
     "packages/restate-sdk": {
       "name": "@restatedev/restate-sdk",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk-core": "^1.8.0"
+        "@restatedev/restate-sdk-core": "^1.8.3"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.115"
@@ -10278,10 +10281,10 @@
     },
     "packages/restate-sdk-clients": {
       "name": "@restatedev/restate-sdk-clients",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk-core": "^1.8.0"
+        "@restatedev/restate-sdk-core": "^1.8.3"
       },
       "engines": {
         "node": ">= 18.13"
@@ -10289,10 +10292,10 @@
     },
     "packages/restate-sdk-cloudflare-workers": {
       "name": "@restatedev/restate-sdk-cloudflare-workers",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk-core": "^1.8.0"
+        "@restatedev/restate-sdk-core": "^1.8.3"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.115"
@@ -10303,7 +10306,7 @@
     },
     "packages/restate-sdk-core": {
       "name": "@restatedev/restate-sdk-core",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "engines": {
         "node": ">= 18.13"
@@ -10311,14 +10314,14 @@
     },
     "packages/restate-sdk-examples": {
       "name": "@restatedev/restate-sdk-examples",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk": "^1.8.0",
-        "@restatedev/restate-sdk-clients": "^1.8.0"
+        "@restatedev/restate-sdk": "^1.8.3",
+        "@restatedev/restate-sdk-clients": "^1.8.3"
       },
       "devDependencies": {
-        "@restatedev/restate-sdk-testcontainers": "^1.8.0",
+        "@restatedev/restate-sdk-testcontainers": "^1.8.3",
         "tsx": "^4.15.7"
       },
       "engines": {
@@ -10327,11 +10330,11 @@
     },
     "packages/restate-sdk-testcontainers": {
       "name": "@restatedev/restate-sdk-testcontainers",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@restatedev/restate-sdk": "^1.8.0",
-        "@restatedev/restate-sdk-clients": "^1.8.0",
+        "@restatedev/restate-sdk": "^1.8.3",
+        "@restatedev/restate-sdk-clients": "^1.8.3",
         "apache-arrow": "^18.0.0",
         "testcontainers": "^10.24.1"
       },
@@ -10470,17 +10473,30 @@
     },
     "packages/restate-sdk-zod": {
       "name": "@restatedev/restate-sdk-zod",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
-      "dependencies": {
-        "zod": "^3.24.1",
-        "zod-to-json-schema": "3.24.3"
-      },
       "devDependencies": {
-        "@restatedev/restate-sdk-core": "^1.8.0"
+        "@restatedev/restate-sdk-core": "^1.8.3",
+        "vitest": "^3.0.9",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "3.24.3"
       },
       "engines": {
         "node": ">= 18.13"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "3.24.3"
+      }
+    },
+    "packages/restate-sdk-zod/node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/restate-sdk-zod/README.md
+++ b/packages/restate-sdk-zod/README.md
@@ -55,6 +55,15 @@ To use this library, add the dependency to your project:
 
 ```shell
 npm install --save-dev @restatedev/restate-sdk-zod
+npm install zod # optional if zod isn't already installed
+```
+
+# Zod v3 Users
+As a minimum requirement, `zod` must be at `v3.25.0`. Also, `zod-to-json-schema` is required.
+Add the following additional dependencies to your project:
+
+```shell
+npm install zod-to-json-schema zod@^3.25.0
 ```
 
 ## Versions

--- a/packages/restate-sdk-zod/package.json
+++ b/packages/restate-sdk-zod/package.json
@@ -34,10 +34,13 @@
     "dist"
   ],
   "devDependencies": {
-    "@restatedev/restate-sdk-core": "^1.8.3"
+    "@restatedev/restate-sdk-core": "^1.8.3",
+    "vitest": "^3.0.9",
+    "zod": "^3.25.0 || ^4.0.0",
+    "zod-to-json-schema": "3.24.3"
   },
-  "dependencies": {
-    "zod": "^3.24.1",
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0",
     "zod-to-json-schema": "3.24.3"
   },
   "scripts": {

--- a/packages/restate-sdk-zod/test/serde_api.test.ts
+++ b/packages/restate-sdk-zod/test/serde_api.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import * as z3 from "zod/v3";
+import * as z4 from "zod/v4";
+import { serde } from "../src/serde_api.js";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+const validData = {
+    id: 1,
+    name: "test",
+    isActive: true,
+}
+const validDataSerialized = new TextEncoder().encode(JSON.stringify(validData));
+const invalidData = {
+    id: -1, // not positive
+    name: "a", // less than 3 characters
+    isActive: "not a boolean",
+}
+const invalidDataSerialized = new TextEncoder().encode(JSON.stringify(invalidData));
+
+
+const z3Schema = z3.object({
+    id: z3.number().int().positive(),
+    name: z3.string().min(3, { message: "Name must be at least 3 characters long" }),
+    isActive: z3.boolean(),
+});
+const z3Serde = serde.zod(z3Schema);
+const z3JsonSchema = zodToJsonSchema(z3Schema as never);
+
+const z4Schema = z4.object({
+    id: z4.number().int().positive(),
+    name: z4.string().min(3, { message: "Name must be at least 3 characters long" }),
+    isActive: z4.boolean(),
+});
+const z4Serde = serde.zod(z4Schema);
+const z4JsonSchema = z4.toJSONSchema(z4Schema);
+
+describe('serde_api', () => {
+    describe.each([
+        {ver: 'v3', srd: z3Serde, jsonSchema: z3JsonSchema},
+        {ver: 'v4', srd: z4Serde, jsonSchema: z4JsonSchema},
+    ])("zod $ver", ({ srd, jsonSchema }) => {
+        describe('constructor', () => {
+            it('converts a valid schema to json', () => {
+                expect(srd.jsonSchema).not.to.be.null;
+                expect(srd.jsonSchema).to.deep.equal(jsonSchema);
+            });
+        })
+        describe('serialize', () => {
+            it('serializes a valid object', () => {
+                expect(srd.serialize(validData)).to.deep.equal(validDataSerialized);
+            });
+            it('gives an empty response for undefined', () => {
+                expect(srd.serialize(undefined)).to.be.empty;
+            })
+        })
+        describe('deserialize', () => {
+            it('deserializes a valid object', () => {
+                expect(srd.deserialize(validDataSerialized)).to.deep.equal(validData);
+            });
+            it('throws an error on an invalid object', () => {
+                expect(() => srd.deserialize(invalidDataSerialized)).throws();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds `zod` v4.0.0 support while maintaining backwards compatibility with `v3` per the Zod guide: https://zod.dev/library-authors.