### PR TITLE
Update `crazy-max/ghaction-setup-docker` to v4

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -69,8 +69,9 @@ jobs:
 
       # support importing oci-format restate.tar
       - name: Set up Docker containerd snapshotter
-        uses: crazy-max/ghaction-setup-docker@v3
+        uses: docker/setup-docker-action@v4
         with:
+          version: "v28.5.2"
           set-host: true
           daemon-config: |
             {


### PR DESCRIPTION
Update `crazy-max/ghaction-setup-docker` to v4

Summary:
This github action has moved to `docker/setup-docker-action`
