### PR TITLE
Add support for metadata in TerminalError

### DIFF
--- a/packages/libs/restate-sdk/src/context_impl.ts
+++ b/packages/libs/restate-sdk/src/context_impl.ts
@@ -1032,7 +1032,10 @@ function SuccessWithSerde<T>(
 const Failure: Completer = (value, prom) => {
   if (typeof value === "object" && "Failure" in value) {
     const metadata = (value.Failure.metadata ?? []).reduce(
-      (acc: Record<string, string>, { key, value: v }: { key: string; value: string }) => {
+      (
+        acc: Record<string, string>,
+        { key, value: v }: { key: string; value: string }
+      ) => {
         acc[key] = v;
         return acc;
       },

--- a/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
@@ -516,9 +516,9 @@ async function startUserHandler(
         ctx.coreVm.sys_write_output_failure({
           code: error.code,
           message: error.message,
-            metadata: Object.entries(error.metadata ?? {}).map(
-                ([key, value]) => ({ key, value })
-            ),
+          metadata: Object.entries(error.metadata ?? {}).map(
+            ([key, value]) => ({ key, value })
+          ),
         });
         ctx.coreVm.sys_end();
         return;

--- a/packages/libs/restate-sdk/src/types/errors.ts
+++ b/packages/libs/restate-sdk/src/types/errors.ts
@@ -107,8 +107,8 @@ export class TerminalError extends RestateError {
       cause?: any;
       /**
        * Metadata key-value pairs to attach to the terminal error.
-       * These will be recorded together with error message and code. 
-       * 
+       * These will be recorded together with error message and code.
+       *
        * **Note **: requires Restate 1.6+.
        */
       metadata?: Record<string, string>;


### PR DESCRIPTION
From my understanding - the Restate runtime has supported attaching metadata to errors since this [commit](https://github.com/restatedev/restate/pull/3764), but I don't see any of that functionality exposed in the Typescript SDK. 

I worked with Claude Code to implement a patch for our own application that would allow attaching metadata to Terminal Errors, and thought I would try to upstream. In our own application this functionality is super useful since we add context to errors when we throw them and it gets lost when being converted to TerminalErrors through `ctx.run` calls.

Since it is a small fix, I hope it isn't a pain to review - I don't want this to be an AI slop hit and run PR. Let me know if you want me to close this.