### PR TITLE
Expose cancellation signal on request

### DIFF
--- a/packages/libs/restate-sdk/src/context.ts
+++ b/packages/libs/restate-sdk/src/context.ts
@@ -76,6 +76,15 @@ export interface Request {
    * than cleanup any external resources that might be shared across attempts (e.g. database connections).
    */
   readonly attemptCompletedSignal: AbortSignal;
+
+  /**
+   * Signal that is aborted when the invocation is cancelled by the Restate runtime.
+   * Unlike {@link attemptCompletedSignal}, this signal specifically indicates cancellation
+   * and can be used to abort in-flight operations (e.g., fetch calls, database queries).
+   *
+   * The signal's reason will be a {@link CancelledError}.
+   */
+  readonly cancellationSignal: AbortSignal;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/libs/restate-sdk/src/context_impl.ts
+++ b/packages/libs/restate-sdk/src/context_impl.ts
@@ -145,6 +145,10 @@ export class ContextImpl implements ObjectContext, WorkflowContext {
           cancellationController.abort(new CancelledError());
         }
       });
+      invocationEndPromise.promise.then(
+        () => cancelWatcher.stop(),
+        () => cancelWatcher.stop()
+      );
       void cancelWatcher.then(
         () => {},
         () => {}

--- a/packages/libs/restate-sdk/src/promises.ts
+++ b/packages/libs/restate-sdk/src/promises.ts
@@ -394,6 +394,17 @@ export class CancellationWatcherPromise extends AbstractRestatePromise<void> {
     this.completablePromise.resolve();
   }
 
+  /**
+   * Stop watching without triggering the cancellation callback.
+   * Used to cleanly shut down the watcher when the invocation ends
+   * (for any reason), preventing interaction with a closed VM.
+   */
+  stop() {
+    if (this.completed) return;
+    this.completed = true;
+    this.completablePromise.resolve();
+  }
+
   publicPromise(): Promise<void> {
     return this.completablePromise.promise;
   }

--- a/packages/libs/restate-sdk/src/promises.ts
+++ b/packages/libs/restate-sdk/src/promises.ts
@@ -17,6 +17,7 @@ import type {
   InvocationPromise,
 } from "./context.js";
 import type * as vm from "./endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js";
+import { cancel_handle } from "./endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js";
 import {
   CancelledError,
   RestateError,
@@ -359,6 +360,45 @@ export class RestateMappedPromise<T, U> extends AbstractRestatePromise<U> {
   }
 
   readonly [Symbol.toStringTag] = "RestateMappedPromise";
+}
+
+export class CancellationWatcherPromise extends AbstractRestatePromise<void> {
+  private completed = false;
+  private readonly completablePromise = new CompletablePromise<void>();
+
+  constructor(
+    ctx: ContextImpl,
+    private readonly onCancellation: () => void
+  ) {
+    super(ctx);
+  }
+
+  uncompletedLeaves(): number[] {
+    return this.completed ? [] : [cancel_handle()];
+  }
+
+  tryComplete(): Promise<void> {
+    if (this.completed) return Promise.resolve();
+    if (this[RESTATE_CTX_SYMBOL].coreVm.is_completed(cancel_handle())) {
+      this.completed = true;
+      this.onCancellation();
+      this.completablePromise.resolve();
+    }
+    return Promise.resolve();
+  }
+
+  override tryCancel() {
+    if (this.completed) return;
+    this.completed = true;
+    this.onCancellation();
+    this.completablePromise.resolve();
+  }
+
+  publicPromise(): Promise<void> {
+    return this.completablePromise.promise;
+  }
+
+  readonly [Symbol.toStringTag] = "CancellationWatcherPromise";
 }
 
 /**

--- a/packages/libs/restate-sdk/test/cancellation_signal.test.ts
+++ b/packages/libs/restate-sdk/test/cancellation_signal.test.ts
@@ -126,4 +126,52 @@ describe("CancellationWatcherPromise", () => {
 
     expect(watcher[RESTATE_CTX_SYMBOL]).toBe(ctx);
   });
+
+  it("stop resolves publicPromise without firing callback", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => false);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.stop();
+    expect(callback).not.toHaveBeenCalled();
+
+    await expect(watcher.publicPromise()).resolves.toBeUndefined();
+    expect(watcher.uncompletedLeaves()).toEqual([]);
+  });
+
+  it("stop after tryCancel does not fire callback again", () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => false);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.tryCancel();
+    expect(callback).toHaveBeenCalledOnce();
+
+    watcher.stop();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("tryCancel after stop does not fire callback", () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => false);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.stop();
+    watcher.tryCancel();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("tryComplete after stop does not fire callback", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => true);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.stop();
+    await watcher.tryComplete();
+    expect(callback).not.toHaveBeenCalled();
+  });
 });

--- a/packages/libs/restate-sdk/test/cancellation_signal.test.ts
+++ b/packages/libs/restate-sdk/test/cancellation_signal.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023-2025 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  CancellationWatcherPromise,
+  RESTATE_CTX_SYMBOL,
+} from "../src/promises.js";
+import { cancel_handle } from "../src/endpoint/handlers/vm/sdk_shared_core_wasm_bindings.js";
+
+function createMockCtx(isCompletedFn: (handle: number) => boolean) {
+  return {
+    coreVm: {
+      is_completed: isCompletedFn,
+    },
+    promisesExecutor: {
+      doProgress: () => Promise.resolve(),
+    },
+  } as any;
+}
+
+describe("CancellationWatcherPromise", () => {
+  it("tryComplete fires callback when is_completed returns true", async () => {
+    const callback = vi.fn();
+    let completed = false;
+    const ctx = createMockCtx(() => completed);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    await watcher.tryComplete();
+    expect(callback).not.toHaveBeenCalled();
+
+    completed = true;
+    await watcher.tryComplete();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("tryCancel fires callback and resolves publicPromise", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => false);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.tryCancel();
+    expect(callback).toHaveBeenCalledOnce();
+
+    await expect(watcher.publicPromise()).resolves.toBeUndefined();
+  });
+
+  it("uncompletedLeaves returns [cancel_handle()] before completion and [] after", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => true);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    expect(watcher.uncompletedLeaves()).toEqual([cancel_handle()]);
+
+    await watcher.tryComplete();
+
+    expect(watcher.uncompletedLeaves()).toEqual([]);
+  });
+
+  it("callback is only fired once even if tryComplete is called multiple times", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => true);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    await watcher.tryComplete();
+    await watcher.tryComplete();
+    await watcher.tryComplete();
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("callback is only fired once even if tryCancel is called multiple times", () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => false);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.tryCancel();
+    watcher.tryCancel();
+    watcher.tryCancel();
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("tryComplete after tryCancel does not fire callback again", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => true);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    watcher.tryCancel();
+    expect(callback).toHaveBeenCalledOnce();
+
+    await watcher.tryComplete();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("publicPromise resolves after tryComplete detects completion", async () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => true);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    await watcher.tryComplete();
+
+    await expect(watcher.publicPromise()).resolves.toBeUndefined();
+  });
+
+  it("has correct RESTATE_CTX_SYMBOL reference", () => {
+    const callback = vi.fn();
+    const ctx = createMockCtx(() => false);
+
+    const watcher = new CancellationWatcherPromise(ctx, callback);
+
+    expect(watcher[RESTATE_CTX_SYMBOL]).toBe(ctx);
+  });
+});

--- a/packages/tests/restate-e2e-services/src/app.ts
+++ b/packages/tests/restate-e2e-services/src/app.ts
@@ -16,6 +16,7 @@ import "./event_handler.js";
 import "./list.js";
 import "./map.js";
 import "./cancel_test.js";
+import "./cancel_signal_test.js";
 import "./non_determinism.js";
 import "./failing.js";
 import "./side_effect.js";

--- a/packages/tests/restate-e2e-services/src/cancel_signal_test.ts
+++ b/packages/tests/restate-e2e-services/src/cancel_signal_test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import * as restate from "@restatedev/restate-sdk";
+import { type AwakeableHolder } from "./awakeable_holder.js";
+import { REGISTRY } from "./services.js";
+
+export const CancelSignalTestRunnerFQN = "CancelSignalTestRunner";
+export const CancelSignalBlockingServiceFQN = "CancelSignalBlockingService";
+const AwakeableHolder: AwakeableHolder = { name: "AwakeableHolder" };
+
+const cancelSignalTestRunner = restate.object({
+  name: CancelSignalTestRunnerFQN,
+  handlers: {
+    async verifyTest(ctx: restate.ObjectContext): Promise<boolean> {
+      return (await ctx.get<boolean>("signalObserved")) ?? false;
+    },
+
+    async startTest(ctx: restate.ObjectContext) {
+      try {
+        await ctx.objectClient(CancelSignalBlockingService, ctx.key).block();
+      } catch (e) {
+        if (e instanceof restate.TerminalError && e.code === 409) {
+          ctx.set("signalObserved", true);
+        } else {
+          throw e;
+        }
+      }
+    },
+  },
+});
+
+const cancelSignalBlockingService = restate.object({
+  name: CancelSignalBlockingServiceFQN,
+  handlers: {
+    async block(ctx: restate.ObjectContext) {
+      const { id, promise } = ctx.awakeable();
+      await ctx.objectClient(AwakeableHolder, ctx.key).hold(id);
+      await promise;
+
+      const signal = ctx.request().cancellationSignal;
+
+      await new Promise<void>((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(signal.reason as Error);
+          return;
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            reject(signal.reason as Error);
+          },
+          { once: true }
+        );
+      });
+    },
+
+    async isUnlocked() {},
+  },
+});
+
+REGISTRY.addObject(cancelSignalTestRunner);
+REGISTRY.addObject(cancelSignalBlockingService);
+
+const CancelSignalBlockingService: typeof cancelSignalBlockingService = {
+  name: CancelSignalBlockingServiceFQN,
+};


### PR DESCRIPTION
## Summary

This PR adds a `cancellationSignal: AbortSignal` property to the `Request` interface that aborts as soon as the Restate runtime sends a cancellation, rather than waiting for the next `ctx.run()` call.

This allows passing the signal to `fetch()`, database clients, or any API that accepts an `AbortSignal` for proactive cancellation of in-flight operations. The signal's reason is a `CancelledError`.

## Motivation

When an invocation is cancelled, the SDK currently only detects this at the next Restate operation. For handlers with long-running user code between operations (e.g., AI/LLM streaming), cancellation detection can be significantly delayed.

## Implementation

A new `CancellationWatcherPromise` hooks into the existing `PromisesExecutor` loop to monitor `is_completed(cancel_handle())` and abort an `AbortController` when cancellation is detected. The watcher is stopped via `invocationEndPromise` when the invocation ends, preventing interaction with a closed VM.

[Design document](https://gist.github.com/mcuelenaere/e1bb7390720aa3b4e0aa0c5973e71314)

## Notes

I've verified this change works correctly in my local setup. The added E2E tests I haven't run yet, I was hoping the CI could help with that.