### PR TITLE
Use WarpBuild runners for CI workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-node-services-docker-image:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,7 +24,10 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
 
       - name: Log into GitHub container registry
         uses: docker/login-action@v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -53,7 +53,7 @@ on:
 jobs:
   sdk-test-suite:
     if: github.repository_owner == 'restatedev'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     name: Features integration test
     permissions:
       contents: read
@@ -109,6 +109,9 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
 
       # Pre-emptively pull the test-services image, to avoid affecting execution time
       - name: Pull test services image
@@ -126,8 +129,8 @@ jobs:
           push: false
           load: true
           tags: restatedev/typescript-test-services
-          cache-from: type=gha,scope=${{ github.workflow }}
-          cache-to: type=gha,mode=max,scope=${{ github.workflow }}
+          cache-from: type=gha,url=http://127.0.0.1:49160/,version=1,scope=${{ github.workflow }}
+          cache-to: type=gha,url=http://127.0.0.1:49160/,mode=max,version=1,scope=${{ github.workflow }}
 
       - name: Run test tool
         uses: restatedev/sdk-test-suite@v4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     # prevent from running on forks
     if: github.repository_owner == 'restatedev'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     strategy:
       matrix:
         node-version: [20.x]


### PR DESCRIPTION
## Summary
- Migrate test, integration, and docker workflows from `ubuntu-latest` to `warp-ubuntu-latest-x64-4x`
- Update Docker Buildx setup with `network=host` driver-opts for WarpBuild compatibility
- Point Docker layer cache (`cache-from`/`cache-to`) at WarpBuild's cache proxy (`http://127.0.0.1:49160/`)
- Upgrade `docker/setup-buildx-action` from v2 to v3 in `docker.yml`
- Release, release-docs, template tests, and compatibility workflows are left on GitHub-hosted runners