### PR TITLE
Add support for configuring `setOutputContentTypeIfEmpty` in handler options

### DIFF
--- a/packages/libs/restate-sdk/src/endpoint/components.ts
+++ b/packages/libs/restate-sdk/src/endpoint/components.ts
@@ -97,6 +97,8 @@ function handlerOutputDiscovery(
   defaultSerde: Serde<any>
 ): d.OutputPayload {
   const serde = handler.options?.output ?? defaultSerde;
+  const setContentTypeIfEmpty =
+    handler.options?.setOutputContentTypeIfEmpty ?? false;
 
   let contentType = undefined;
   let jsonSchema = undefined;
@@ -108,11 +110,11 @@ function handlerOutputDiscovery(
     contentType = serde.contentType;
   } else {
     // no input information
-    return { setContentTypeIfEmpty: false };
+    return { setContentTypeIfEmpty };
   }
 
   return {
-    setContentTypeIfEmpty: false,
+    setContentTypeIfEmpty,
     jsonSchema,
     contentType,
   };

--- a/packages/libs/restate-sdk/src/types/rpc.ts
+++ b/packages/libs/restate-sdk/src/types/rpc.ts
@@ -312,6 +312,18 @@ export type ServiceHandlerOpts<I, O> = {
   output?: Serde<O>;
 
   /**
+   * If `true`, the output `Content-Type` declared by the output `Serde` is set
+   * on the response even when the serialized output is an empty byte array.
+   *
+   * This is needed for serialization formats where an empty byte array is a
+   * valid value (for example Protobuf, where an empty message serializes to
+   * zero bytes).
+   *
+   * Defaults to `false`: when the serialized output is empty, no `Content-Type` header is sent.
+   */
+  setOutputContentTypeIfEmpty?: boolean;
+
+  /**
    * Human-readable description of the handler, shown in documentation/admin tools.
    */
   description?: string;


### PR DESCRIPTION
Adds a new handler-level option `setOutputContentTypeIfEmpty`.

If `true`, the output `Content-Type` declared by the output `Serde` is set on the response even when the serialized output is an empty byte array. This is needed for serialization formats where an empty byte array is a valid value (for example Protobuf, where an empty message serializes to zero bytes).

Defaults to `false`: when the serialized output is empty, no `Content-Type` header is sent.