### PR TITLE
Make ConstRestatePromise lazy so map fires only on await

### DIFF
--- a/packages/libs/restate-sdk/src/promises.ts
+++ b/packages/libs/restate-sdk/src/promises.ts
@@ -334,6 +334,9 @@ export class MappedRestatePromise<T, U> extends BaseRestatePromise<U> {
     value?: T,
     failure?: TerminalError
   ) => Promise<U>;
+  // Memoized so the mapper fires at most once regardless of how many times
+  // the promise is awaited / consumed via then/catch/finally/publicPromise.
+  private _mappedPromise?: Promise<U>;
 
   constructor(
     ctx: ContextImpl,
@@ -364,6 +367,10 @@ export class MappedRestatePromise<T, U> extends BaseRestatePromise<U> {
   }
 
   publicPromise(): Promise<U> {
+    return (this._mappedPromise ??= this.buildMappedPromise());
+  }
+
+  private buildMappedPromise(): Promise<U> {
     const promiseMapper = this.publicPromiseMapper;
     return this.inner.publicPromise().then(
       (t) => promiseMapper(t, undefined),

--- a/packages/libs/restate-sdk/src/promises.ts
+++ b/packages/libs/restate-sdk/src/promises.ts
@@ -387,7 +387,7 @@ export class ConstRestatePromise<T> extends InternalRestatePromise<T> {
   private constructor(
     // Factory for the underlying promise. Called at most once, memoized in
     // `_constPromise`.
-      //
+    //
     // This way `map` is lazy, making it deterministically invoked on await points.
     private readonly promiseFactory: () => Promise<T>,
     private readonly settled: boolean

--- a/packages/libs/restate-sdk/src/promises.ts
+++ b/packages/libs/restate-sdk/src/promises.ts
@@ -382,30 +382,40 @@ export class MappedRestatePromise<T, U> extends BaseRestatePromise<U> {
 }
 
 export class ConstRestatePromise<T> extends InternalRestatePromise<T> {
+  private _constPromise?: Promise<T>;
+
   private constructor(
-    private readonly constPromise: Promise<T>,
+    // Factory for the underlying promise. Called at most once, memoized in
+    // `_constPromise`.
+      //
+    // This way `map` is lazy, making it deterministically invoked on await points.
+    private readonly promiseFactory: () => Promise<T>,
     private readonly settled: boolean
   ) {
     super();
   }
 
+  private get constPromise(): Promise<T> {
+    return (this._constPromise ??= this.promiseFactory());
+  }
+
   static resolve<T>(value: T): ConstRestatePromise<Awaited<T>> {
-    return new ConstRestatePromise(Promise.resolve(value), true);
+    return new ConstRestatePromise(() => Promise.resolve(value), true);
   }
 
   static reject<T = never>(reason: TerminalError): ConstRestatePromise<T> {
-    return new ConstRestatePromise<T>(Promise.reject(reason), true);
+    return new ConstRestatePromise<T>(() => Promise.reject(reason), true);
   }
 
   static pending<T>(): ConstRestatePromise<T> {
-    return new ConstRestatePromise<T>(pendingPromise(), false);
+    return new ConstRestatePromise<T>(() => pendingPromise<T>(), false);
   }
 
   static fromPromise<T>(
     promise: Promise<T>,
     settled: boolean
   ): ConstRestatePromise<T> {
-    return new ConstRestatePromise(promise, settled);
+    return new ConstRestatePromise(() => promise, settled);
   }
 
   // --- Promise methods
@@ -435,11 +445,14 @@ export class ConstRestatePromise<T> extends InternalRestatePromise<T> {
   }
 
   map<U>(mapper: (value?: T, failure?: TerminalError) => U): RestatePromise<U> {
-    return ConstRestatePromise.fromPromise(
-      this.constPromise.then(
-        (value) => mapper(value, undefined),
-        (reason) => mapper(undefined, reason as TerminalError)
-      ),
+    if (!this.settled) return this as unknown as RestatePromise<U>;
+    const selfConstPromise = this.constPromise;
+    return new ConstRestatePromise<U>(
+      () =>
+        selfConstPromise.then(
+          (value) => mapper(value, undefined),
+          (reason) => mapper(undefined, reason as TerminalError)
+        ),
       this.settled
     );
   }

--- a/packages/tests/restate-e2e-services/src/promise_combinators.ts
+++ b/packages/tests/restate-e2e-services/src/promise_combinators.ts
@@ -158,6 +158,39 @@ const promiseCombinators = restate.service({
           return "unexpected";
         });
     },
+
+    verifyConstPromiseMapDeterministic: restate.handlers.handler(
+      {
+        inactivityTimeout: 0,
+      },
+      async (ctx: restate.Context, value: string): Promise<string> => {
+        // 1. Contract: the mapper runs ONLY when the RestatePromise is
+        //    awaited, never eagerly when `.map()` is called.
+        // 2. If violated: the mapper's `ctx.rand.uuidv4()` lands BETWEEN
+        //    the two outer `ctx.rand.uuidv4()` calls below (at .map() time).
+        // 3. If held: it lands AFTER both, when `mappedPromise` is awaited.
+        // 4. The two interleavings observe different RNG state, so the uuid
+        //    produced inside the mapper differs.
+        // 5. We feed that uuid as the journaled name of a `ctx.sleep`. Names
+        //    are checked for equality on replay; a mismatch fails the
+        //    invocation.
+        // 6. inactivityTimeout: 0 forces suspension at every journal entry,
+        //    so any divergence fails fast on the very next replay.
+
+        ctx.rand.uuidv4();
+        const mappedPromise = RestatePromise.resolve(undefined).map(() =>
+          ctx.rand.uuidv4()
+        );
+        ctx.rand.uuidv4();
+
+        await ctx.sleep({ milliseconds: 50 });
+        const shouldBeDeterministic = await mappedPromise;
+
+        await ctx.sleep({ milliseconds: 50 }, shouldBeDeterministic);
+
+        return value;
+      }
+    ),
   },
 });
 

--- a/packages/tests/restate-e2e-services/src/promise_combinators.ts
+++ b/packages/tests/restate-e2e-services/src/promise_combinators.ts
@@ -159,11 +159,55 @@ const promiseCombinators = restate.service({
         });
     },
 
-    verifyConstPromiseMapDeterministic: restate.handlers.handler(
+    verifyPromiseMapInterleaving: restate.handlers.handler(
       {
         inactivityTimeout: 0,
       },
-      async (ctx: restate.Context, value: string): Promise<string> => {
+      async (ctx: restate.Context) => {
+        // 1. Contract: the mapper runs ONLY when the RestatePromise is
+        //    awaited, never eagerly when `.map()` is called.
+        // 2. If violated: the mapper's `ctx.rand.uuidv4()` lands BETWEEN
+        //    the two outer `ctx.rand.uuidv4()` calls below (at .map() time).
+        // 3. If held: it lands AFTER both, when `mappedPromise` is awaited.
+        // 4. The two interleavings observe different RNG state, so the uuid
+        //    produced inside the mapper differs.
+        // 5. We feed that uuid as the journaled name of a `ctx.sleep`. Names
+        //    are checked for equality on replay; a mismatch fails the
+        //    invocation.
+        // 6. inactivityTimeout: 0 forces suspension at every journal entry,
+        //    so any divergence fails fast on the very next replay.
+
+        ctx.rand.uuidv4();
+        const mappedPromise = ctx
+          .sleep({ milliseconds: 50 })
+          .map(() => ctx.rand.uuidv4());
+        ctx.rand.uuidv4();
+
+        await ctx.sleep({ milliseconds: 50 });
+        const shouldBeDeterministic = await mappedPromise;
+
+        await ctx.sleep({ milliseconds: 50 }, shouldBeDeterministic);
+      }
+    ),
+
+    verifyPromiseMapGetsRunOnce: async (ctx: restate.Context) => {
+      let count = 0;
+      const mappedPromise = ctx.sleep({ milliseconds: 50 }).map(() => {
+        count++;
+      });
+
+      await mappedPromise;
+      await mappedPromise;
+      await mappedPromise;
+
+      return count;
+    },
+
+    verifyConstPromiseMapInterleaving: restate.handlers.handler(
+      {
+        inactivityTimeout: 0,
+      },
+      async (ctx: restate.Context) => {
         // 1. Contract: the mapper runs ONLY when the RestatePromise is
         //    awaited, never eagerly when `.map()` is called.
         // 2. If violated: the mapper's `ctx.rand.uuidv4()` lands BETWEEN
@@ -187,8 +231,6 @@ const promiseCombinators = restate.service({
         const shouldBeDeterministic = await mappedPromise;
 
         await ctx.sleep({ milliseconds: 50 }, shouldBeDeterministic);
-
-        return value;
       }
     ),
   },

--- a/packages/tests/restate-e2e-services/test/promise_combinators.test.ts
+++ b/packages/tests/restate-e2e-services/test/promise_combinators.test.ts
@@ -130,4 +130,9 @@ describe("PromiseCombinators", () => {
     const result = await client.raceEmptyOrTimeoutMapped();
     expect(result).toBe("timeout");
   });
+
+  it("map with sync ctx side effect produces expected mapped value deterministically", async () => {
+    const result = await client.verifyConstPromiseMapDeterministic("hello");
+    expect(result).toBe("hello");
+  });
 });

--- a/packages/tests/restate-e2e-services/test/promise_combinators.test.ts
+++ b/packages/tests/restate-e2e-services/test/promise_combinators.test.ts
@@ -131,8 +131,16 @@ describe("PromiseCombinators", () => {
     expect(result).toBe("timeout");
   });
 
-  it("map with sync ctx side effect produces expected mapped value deterministically", async () => {
-    const result = await client.verifyConstPromiseMapDeterministic("hello");
-    expect(result).toBe("hello");
+  it("map with sync ctx side effect and const promise produces expected mapped value deterministically", async () => {
+    await client.verifyConstPromiseMapInterleaving();
+  });
+
+  it("map with sync ctx side effect and non-const promise produces expected mapped value deterministically", async () => {
+    await client.verifyPromiseMapInterleaving();
+  });
+
+  it("map gets run once", async () => {
+    const result = await client.verifyPromiseMapGetsRunOnce();
+    expect(result).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two issues with `RestatePromise.map` that broke its contract ("the mapper runs ONLY when the promise is awaited") and caused nondeterministic replay behavior.

### 1. `ConstRestatePromise.map` fired eagerly

Calling `.map` on a settled const promise scheduled the mapper as a microtask immediately, even if nobody consumed the result.

**Fix:** the underlying promise is now built via a memoized factory and only materializes when `then`/`catch`/`finally`/`publicPromise` is first invoked. Pending const promises short-circuit `.map` to themselves.

### 2. `MappedRestatePromise.publicPromise` fired the mapper on every call

`publicPromise()` built a fresh `.then` chain on every invocation, so the mapper ran once per `await` / `then` / `catch` / `finally`.

**Fix:** memoize the built promise. The mapper's `.then` chain against `inner.publicPromise()` is constructed once, cached, and reused.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] Existing e2e promise combinator tests still pass
- [x] New e2e tests (`inactivityTimeout: 0`) cover:
  - `verifyConstPromiseMapInterleaving` / `verifyPromiseMapInterleaving` — the mapper's `ctx.rand.uuidv4()` must land at the same point in the RNG interleaving across replays; if the lazy contract is violated, the journaled sleep name diverges and the invocation fails
  - `verifyPromiseMapGetsRunOnce` — awaiting a mapped promise three times must invoke the mapper exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)