### PR TITLE
Move response-head commit inside process()

### DIFF
--- a/packages/libs/restate-sdk/src/endpoint/handlers/fetch.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/fetch.ts
@@ -48,8 +48,9 @@ export function fetcher(handler: RestateHandler) {
           abortSignal: event.signal,
         })
         .catch((e) => {
-          // Framework wrapper guarantees writeHead is called and closes the
-          // output stream; anything reaching here is a post-commit error.
+          // wrapResponseWithSafety guarantees writeHead is called and
+          // closes the output stream; anything reaching here is a
+          // post-commit error.
           const error = ensureError(e);
           const logger =
             tryCreateContextualLogger(

--- a/packages/libs/restate-sdk/src/endpoint/handlers/fetch.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/fetch.ts
@@ -48,9 +48,8 @@ export function fetcher(handler: RestateHandler) {
           abortSignal: event.signal,
         })
         .catch((e) => {
-          // wrapResponseWithSafety guarantees writeHead is called and
-          // closes the output stream; anything reaching here is a
-          // post-commit error.
+          // Responses handle their own errors before rejecting; anything
+          // reaching here is an unexpected failure — just log.
           const error = ensureError(e);
           const logger =
             tryCreateContextualLogger(

--- a/packages/libs/restate-sdk/src/endpoint/handlers/fetch.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/fetch.ts
@@ -11,7 +11,11 @@
 
 import { ensureError } from "../../types/errors.js";
 import type { RestateHandler } from "./types.js";
-import { emptyInputReader, tryCreateContextualLogger } from "./utils.js";
+import {
+  captureHead,
+  emptyInputReader,
+  tryCreateContextualLogger,
+} from "./utils.js";
 
 export function fetcher(handler: RestateHandler) {
   return {
@@ -19,6 +23,7 @@ export function fetcher(handler: RestateHandler) {
       const url = event.url;
       const headers = Object.fromEntries(event.headers.entries());
 
+      // handle should never throw
       const response = handler.handle({
         url,
         headers,
@@ -33,15 +38,18 @@ export function fetcher(handler: RestateHandler) {
       const transformStream = new TransformStream<Uint8Array>();
       const outputWriter = transformStream.writable.getWriter();
 
-      // Start processing, then return back the response
+      const { writeHead, head } = captureHead();
+
       response
         .process({
           inputReader,
           outputWriter,
+          writeHead,
           abortSignal: event.signal,
         })
         .catch((e) => {
-          // handle should never throw
+          // Framework wrapper guarantees writeHead is called and closes the
+          // output stream; anything reaching here is a post-commit error.
           const error = ensureError(e);
           const logger =
             tryCreateContextualLogger(
@@ -52,11 +60,12 @@ export function fetcher(handler: RestateHandler) {
           logger.error("Unexpected error: " + (error.stack ?? error.message));
         });
 
-      return Promise.resolve(
-        new Response(transformStream.readable, {
-          status: response.statusCode,
-          headers: response.headers,
-        })
+      return head.then(
+        (h) =>
+          new Response(transformStream.readable, {
+            status: h.statusCode,
+            headers: h.headers,
+          })
       );
     },
   };

--- a/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
@@ -72,6 +72,16 @@ const HOOK_CONTEXT_IS_PROCESSING_SYMBOL = Symbol.for(
   "@restatedev/restate-sdk/hooks.isProcessing"
 );
 
+/**
+ * Builds the Restate handler for an endpoint.
+ *
+ * Responses returned by `handle()` are wrapped via
+ * {@link wrapResponseWithSafety}, which enforces exactly-once `writeHead`,
+ * emits a 500 fallback if `process()` fails before `writeHead` or resolves
+ * without committing a head, and closes the output stream on every path.
+ * Adapters (node, fetch, lambda) can therefore treat transport failures as
+ * logging concerns.
+ */
 export function createRestateHandler(
   endpoint: Endpoint,
   protocolMode: ProtocolMode,
@@ -82,6 +92,77 @@ export function createRestateHandler(
     protocolMode,
     additionalDiscoveryFields
   );
+}
+
+/**
+ * Framework-level safety net around a user-provided `RestateResponse`.
+ *
+ * Guarantees to adapters:
+ *   - `writeHead` is called exactly once on the success path.
+ *   - If `process()` rejects before `writeHead`, a 500 `errorResponse` is
+ *     written instead (including input drain).
+ *   - If `process()` resolves without calling `writeHead`, same recovery.
+ *   - Post-writeHead errors propagate to the adapter for logging — the head
+ *     is already committed to the transport and can't be changed.
+ *
+ * Mirrors the existing pattern where `handle()` wraps user errors via
+ * `errorResponse`; this extends that safety net to the `process()` phase.
+ */
+function wrapResponseWithSafety(inner: RestateResponse): RestateResponse {
+  return {
+    async process({ inputReader, outputWriter, writeHead, abortSignal }) {
+      let committed = false;
+      const safeWriteHead = (
+        statusCode: number,
+        headers: ResponseHeaders
+      ): void => {
+        if (committed) {
+          throw new Error("writeHead() called more than once");
+        }
+        committed = true;
+        writeHead(statusCode, headers);
+      };
+
+      try {
+        try {
+          await inner.process({
+            inputReader,
+            outputWriter,
+            writeHead: safeWriteHead,
+            abortSignal,
+          });
+        } catch (e) {
+          if (committed) {
+            // Head already on the wire — nothing structural the adapter can do.
+            throw e;
+          }
+          await errorResponse(500, ensureError(e).message).process({
+            inputReader,
+            outputWriter,
+            writeHead,
+            abortSignal,
+          });
+          return;
+        }
+
+        if (!committed) {
+          await errorResponse(
+            500,
+            "Handler did not produce a response head"
+          ).process({
+            inputReader,
+            outputWriter,
+            writeHead,
+            abortSignal,
+          });
+        }
+      } finally {
+        // Ensure the output stream closes on every path. If it was already
+        // closed (the usual case), close() rejects — which we swallow.
+        await outputWriter.close().catch(() => {});
+      }
+    },
+  };
 }
 
 /**
@@ -122,7 +203,7 @@ class RestateHandlerImpl implements RestateHandler {
     context?: AdditionalContext
   ): RestateResponse {
     try {
-      return this._handle(request, context);
+      return wrapResponseWithSafety(this._handle(request, context));
     } catch (e) {
       const error = ensureError(e);
       (
@@ -134,9 +215,11 @@ class RestateHandlerImpl implements RestateHandler {
       ).error(
         "Error while handling request: " + (error.stack ?? error.message)
       );
-      return errorResponse(
-        error instanceof RestateError ? error.code : 500,
-        error.message
+      return wrapResponseWithSafety(
+        errorResponse(
+          error instanceof RestateError ? error.code : 500,
+          error.message
+        )
       );
     }
   }
@@ -258,8 +341,8 @@ class RestateHandlerImpl implements RestateHandler {
 }
 
 class RestateInvokeResponse implements RestateResponse {
-  public headers: ResponseHeaders;
-  public statusCode: number;
+  private readonly headers: ResponseHeaders;
+  private readonly statusCode: number;
 
   private readonly loggerId: number;
   private vmLogger: Logger;
@@ -321,12 +404,18 @@ class RestateInvokeResponse implements RestateResponse {
   async process({
     inputReader,
     outputWriter,
+    writeHead,
     abortSignal,
   }: {
     inputReader: InputReader;
     outputWriter: OutputWriter;
+    writeHead: (statusCode: number, headers: ResponseHeaders) => void;
     abortSignal: AbortSignal;
   }): Promise<void> {
+    // Commit the response head immediately — the VM-determined head is known
+    // at construction time and never changes during processing.
+    writeHead(this.statusCode, this.headers);
+
     abortSignal.addEventListener(
       "abort",
       () => {

--- a/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
@@ -72,16 +72,6 @@ const HOOK_CONTEXT_IS_PROCESSING_SYMBOL = Symbol.for(
   "@restatedev/restate-sdk/hooks.isProcessing"
 );
 
-/**
- * Builds the Restate handler for an endpoint.
- *
- * Responses returned by `handle()` are wrapped via
- * {@link wrapResponseWithSafety}, which enforces exactly-once `writeHead`,
- * emits a 500 fallback if `process()` fails before `writeHead` or resolves
- * without committing a head, and closes the output stream on every path.
- * Adapters (node, fetch, lambda) can therefore treat transport failures as
- * logging concerns.
- */
 export function createRestateHandler(
   endpoint: Endpoint,
   protocolMode: ProtocolMode,
@@ -92,78 +82,6 @@ export function createRestateHandler(
     protocolMode,
     additionalDiscoveryFields
   );
-}
-
-/**
- * Safety net around a `RestateResponse` returned by `_handle()`, applied
- * in `RestateHandlerImpl.handle()` before the response reaches any adapter.
- *
- * Guarantees to adapters:
- *   - `writeHead` is called exactly once on the success path.
- *   - If `process()` rejects before `writeHead`, a 500 `errorResponse` is
- *     written instead (including input drain).
- *   - If `process()` resolves without calling `writeHead`, same recovery.
- *   - Post-writeHead errors propagate to the adapter for logging — the head
- *     is already committed to the transport and can't be changed.
- *
- * Mirrors the existing pattern where `handle()` wraps user errors via
- * `errorResponse`; this extends that safety net to the `process()` phase.
- */
-function wrapResponseWithSafety(inner: RestateResponse): RestateResponse {
-  return {
-    async process({ inputReader, outputWriter, writeHead, abortSignal }) {
-      let committed = false;
-      const safeWriteHead = (
-        statusCode: number,
-        headers: ResponseHeaders
-      ): void => {
-        if (committed) {
-          throw new Error("writeHead() called more than once");
-        }
-        committed = true;
-        writeHead(statusCode, headers);
-      };
-
-      try {
-        try {
-          await inner.process({
-            inputReader,
-            outputWriter,
-            writeHead: safeWriteHead,
-            abortSignal,
-          });
-        } catch (e) {
-          if (committed) {
-            // Head already on the wire — nothing structural the adapter can do.
-            throw e;
-          }
-          await errorResponse(500, ensureError(e).message).process({
-            inputReader,
-            outputWriter,
-            writeHead,
-            abortSignal,
-          });
-          return;
-        }
-
-        if (!committed) {
-          await errorResponse(
-            500,
-            "Handler did not produce a response head"
-          ).process({
-            inputReader,
-            outputWriter,
-            writeHead,
-            abortSignal,
-          });
-        }
-      } finally {
-        // Ensure the output stream closes on every path. If it was already
-        // closed (the usual case), close() rejects — which we swallow.
-        await outputWriter.close().catch(() => {});
-      }
-    },
-  };
 }
 
 /**
@@ -204,7 +122,7 @@ class RestateHandlerImpl implements RestateHandler {
     context?: AdditionalContext
   ): RestateResponse {
     try {
-      return wrapResponseWithSafety(this._handle(request, context));
+      return this._handle(request, context);
     } catch (e) {
       const error = ensureError(e);
       (
@@ -216,11 +134,9 @@ class RestateHandlerImpl implements RestateHandler {
       ).error(
         "Error while handling request: " + (error.stack ?? error.message)
       );
-      return wrapResponseWithSafety(
-        errorResponse(
-          error instanceof RestateError ? error.code : 500,
-          error.message
-        )
+      return errorResponse(
+        error instanceof RestateError ? error.code : 500,
+        error.message
       );
     }
   }

--- a/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/generic.ts
@@ -95,7 +95,8 @@ export function createRestateHandler(
 }
 
 /**
- * Framework-level safety net around a user-provided `RestateResponse`.
+ * Safety net around a `RestateResponse` returned by `_handle()`, applied
+ * in `RestateHandlerImpl.handle()` before the response reaches any adapter.
  *
  * Guarantees to adapters:
  *   - `writeHead` is called exactly once on the success path.

--- a/packages/libs/restate-sdk/src/endpoint/handlers/lambda.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/lambda.ts
@@ -21,7 +21,11 @@ import { X_RESTATE_SERVER } from "../../user_agent.js";
 import { ensureError } from "../../types/errors.js";
 import * as zlib from "node:zlib";
 import { InputReader, OutputWriter, RestateHandler } from "./types.js";
-import { emptyInputReader, tryCreateContextualLogger } from "./utils.js";
+import {
+  captureHead,
+  emptyInputReader,
+  tryCreateContextualLogger,
+} from "./utils.js";
 
 const RESPONSE_COMPRESSION_THRESHOLD = 3 * 1024 * 1024;
 
@@ -108,6 +112,9 @@ export class LambdaHandler {
         },
       };
 
+      const { writeHead, head: headPromise } = captureHead();
+
+      // handle should never throw
       const response = this.handler.handle(
         {
           headers: event.headers,
@@ -123,10 +130,12 @@ export class LambdaHandler {
         await response.process({
           inputReader,
           outputWriter,
+          writeHead,
           abortSignal: abortController.signal,
         });
       } catch (e) {
-        // handle should never throw
+        // Lambda always has to return a result object, so we convert
+        // process() failures into a 500 response here rather than log-only.
         const error = ensureError(e);
         const logger =
           tryCreateContextualLogger(
@@ -146,6 +155,10 @@ export class LambdaHandler {
         };
       }
 
+      // Framework wrapper guarantees writeHead was called, so this resolves
+      // synchronously on the next microtask.
+      const head = await headPromise;
+
       const responseBodyBuffer = Buffer.concat(chunks);
       let responseBody;
 
@@ -156,7 +169,7 @@ export class LambdaHandler {
         requestAcceptEncoding &&
         requestAcceptEncoding.includes("zstd")
       ) {
-        response.headers["content-encoding"] = "zstd";
+        head.headers["content-encoding"] = "zstd";
 
         responseBody = (
           zlib as unknown as { zstdCompressSync: (b: Buffer) => Buffer }
@@ -167,8 +180,8 @@ export class LambdaHandler {
         responseBody = responseBodyBuffer.toString("base64");
       }
       return {
-        headers: response.headers,
-        statusCode: response.statusCode,
+        headers: head.headers,
+        statusCode: head.statusCode,
         isBase64Encoded: true,
         body: responseBody,
       };

--- a/packages/libs/restate-sdk/src/endpoint/handlers/lambda.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/lambda.ts
@@ -155,8 +155,8 @@ export class LambdaHandler {
         };
       }
 
-      // wrapResponseWithSafety guarantees writeHead was called, so this
-      // resolves synchronously on the next microtask.
+      // Responses always call writeHead, so this resolves on the next
+      // microtask.
       const head = await headPromise;
 
       const responseBodyBuffer = Buffer.concat(chunks);

--- a/packages/libs/restate-sdk/src/endpoint/handlers/lambda.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/lambda.ts
@@ -155,8 +155,8 @@ export class LambdaHandler {
         };
       }
 
-      // Framework wrapper guarantees writeHead was called, so this resolves
-      // synchronously on the next microtask.
+      // wrapResponseWithSafety guarantees writeHead was called, so this
+      // resolves synchronously on the next microtask.
       const head = await headPromise;
 
       const responseBodyBuffer = Buffer.concat(chunks);

--- a/packages/libs/restate-sdk/src/endpoint/handlers/types.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/types.ts
@@ -31,15 +31,23 @@ export interface OutputWriter {
 }
 
 export interface RestateResponse {
-  readonly headers: ResponseHeaders;
-  readonly statusCode: number;
-
-  // Promise resolved when the request has been fully processed,
-  // the last message has been written out,
-  // and outputStream has been closed.
+  /**
+   * Drive the full response lifecycle.
+   *
+   * Implementations own the order of things: they must call {@link writeHead}
+   * exactly once before the first {@link outputWriter.write}, read any
+   * {@link inputReader} content they need, write the body, and finally call
+   * {@link outputWriter.close}.
+   *
+   * {@link RestateHandler.handle} returns responses wrapped in a safety layer
+   * that emits a 500 fallback if `process()` rejects before {@link writeHead}
+   * or resolves without committing a head, and closes the output stream on
+   * every path. Adapters can treat transport failures as logging concerns.
+   */
   process(value: {
     inputReader: InputReader;
     outputWriter: OutputWriter;
+    writeHead: (statusCode: number, headers: ResponseHeaders) => void;
     abortSignal: AbortSignal;
   }): Promise<void>;
 }

--- a/packages/libs/restate-sdk/src/endpoint/handlers/types.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/types.ts
@@ -36,13 +36,8 @@ export interface RestateResponse {
    *
    * Implementations own the order of things: they must call {@link writeHead}
    * exactly once before the first {@link outputWriter.write}, read any
-   * {@link inputReader} content they need, write the body, and finally call
-   * {@link outputWriter.close}.
-   *
-   * {@link RestateHandler.handle} returns responses wrapped in a safety layer
-   * that emits a 500 fallback if `process()` rejects before {@link writeHead}
-   * or resolves without committing a head, and closes the output stream on
-   * every path. Adapters can treat transport failures as logging concerns.
+   * {@link inputReader} content they need, write the body, and call
+   * {@link outputWriter.close} on every exit path (including error paths).
    */
   process(value: {
     inputReader: InputReader;

--- a/packages/libs/restate-sdk/src/endpoint/handlers/utils.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/utils.ts
@@ -12,6 +12,7 @@ import type {
 import { createLogger, Logger } from "../../logging/logger.js";
 import { parseUrlComponents } from "../components.js";
 import { X_RESTATE_SERVER } from "../../user_agent.js";
+import { CompletablePromise } from "../../utils/completable_promise.js";
 
 export function tryCreateContextualLogger(
   loggerTransport: LoggerTransport,
@@ -71,15 +72,13 @@ export function simpleResponse(
   body: Uint8Array
 ): RestateResponse {
   return {
-    headers,
-    statusCode,
-    async process({ inputReader, outputWriter }): Promise<void> {
-      if (inputReader !== undefined) {
-        // Drain the input stream
-        while (true) {
-          const { done } = await inputReader.next();
-          if (done) break;
-        }
+    async process({ inputReader, outputWriter, writeHead }): Promise<void> {
+      writeHead(statusCode, headers);
+
+      // Drain the input stream
+      while (true) {
+        const { done } = await inputReader.next();
+        if (done) break;
       }
 
       await outputWriter.write(body);
@@ -91,4 +90,28 @@ export function simpleResponse(
 
 export function emptyInputReader(): InputReader {
   return (async function* () {})()[Symbol.asyncIterator]();
+}
+
+/**
+ * Bundles a `writeHead` callback with a Promise that resolves once the head
+ * is committed. Used by adapters (fetch, lambda) that need to observe head
+ * commit from outside the `process()` call.
+ *
+ * `writeHead` is expected to be called exactly once — enforced by the
+ * safety layer in {@link RestateHandler.handle}, so there is no guard here.
+ */
+export function captureHead(): {
+  writeHead: (statusCode: number, headers: ResponseHeaders) => void;
+  head: Promise<{ statusCode: number; headers: ResponseHeaders }>;
+} {
+  const ready = new CompletablePromise<{
+    statusCode: number;
+    headers: ResponseHeaders;
+  }>();
+  return {
+    writeHead: (statusCode, headers) => {
+      ready.resolve({ statusCode, headers: { ...headers } });
+    },
+    head: ready.promise,
+  };
 }

--- a/packages/libs/restate-sdk/src/endpoint/handlers/utils.ts
+++ b/packages/libs/restate-sdk/src/endpoint/handlers/utils.ts
@@ -12,7 +12,6 @@ import type {
 import { createLogger, Logger } from "../../logging/logger.js";
 import { parseUrlComponents } from "../components.js";
 import { X_RESTATE_SERVER } from "../../user_agent.js";
-import { CompletablePromise } from "../../utils/completable_promise.js";
 
 export function tryCreateContextualLogger(
   loggerTransport: LoggerTransport,
@@ -94,24 +93,21 @@ export function emptyInputReader(): InputReader {
 
 /**
  * Bundles a `writeHead` callback with a Promise that resolves once the head
- * is committed. Used by adapters (fetch, lambda) that need to observe head
- * commit from outside the `process()` call.
- *
- * `writeHead` is expected to be called exactly once — enforced by the
- * safety layer in {@link RestateHandler.handle}, so there is no guard here.
+ * is committed. Used by adapters (fetch, lambda) that need to observe the
+ * head commit from outside the `process()` call.
  */
 export function captureHead(): {
   writeHead: (statusCode: number, headers: ResponseHeaders) => void;
   head: Promise<{ statusCode: number; headers: ResponseHeaders }>;
 } {
-  const ready = new CompletablePromise<{
+  const { promise, resolve } = Promise.withResolvers<{
     statusCode: number;
     headers: ResponseHeaders;
   }>();
   return {
     writeHead: (statusCode, headers) => {
-      ready.resolve({ statusCode, headers: { ...headers } });
+      resolve({ statusCode, headers: { ...headers } });
     },
-    head: ready.promise,
+    head: promise,
   };
 }

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -209,7 +209,7 @@ function nodeHandlerImpl(
         abortSignal: abortController.signal,
       })
       .catch((e) => {
-        // Framework wrapper guarantees writeHead is called; anything
+        // wrapResponseWithSafety guarantees writeHead is called; anything
         // reaching here is a post-commit error. Nothing to do but log.
         const error = ensureError(e);
         const logger =

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -209,8 +209,8 @@ function nodeHandlerImpl(
         abortSignal: abortController.signal,
       })
       .catch((e) => {
-        // wrapResponseWithSafety guarantees writeHead is called; anything
-        // reaching here is a post-commit error. Nothing to do but log.
+        // Responses handle their own errors before rejecting; anything
+        // reaching here is an unexpected failure — just log.
         const error = ensureError(e);
         const logger =
           tryCreateContextualLogger(

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -26,11 +26,7 @@ import { ensureError } from "../types/errors.js";
 import type { LoggerTransport } from "../logging/logger_transport.js";
 import type { DefaultServiceOptions } from "../endpoint.js";
 import { tryCreateContextualLogger } from "./handlers/utils.js";
-import type {
-  InputReader,
-  OutputWriter,
-  ResponseHeaders,
-} from "./handlers/types.js";
+import type { InputReader, OutputWriter } from "./handlers/types.js";
 import type { ProtocolMode } from "./discovery.js";
 
 export class NodeEndpoint implements RestateEndpoint {
@@ -190,9 +186,7 @@ function nodeHandlerImpl(
       abortController.abort();
     });
 
-    const writeHead = (statusCode: number, headers: ResponseHeaders): void => {
-      res.writeHead(statusCode, headers);
-    };
+    const writeHead = res.writeHead.bind(res);
 
     // handle should never throw
     const restateResponse = handler.handle({

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -26,7 +26,11 @@ import { ensureError } from "../types/errors.js";
 import type { LoggerTransport } from "../logging/logger_transport.js";
 import type { DefaultServiceOptions } from "../endpoint.js";
 import { tryCreateContextualLogger } from "./handlers/utils.js";
-import type { InputReader, OutputWriter } from "./handlers/types.js";
+import type {
+  InputReader,
+  OutputWriter,
+  ResponseHeaders,
+} from "./handlers/types.js";
 import type { ProtocolMode } from "./discovery.js";
 
 export class NodeEndpoint implements RestateEndpoint {
@@ -176,6 +180,9 @@ function nodeHandlerImpl(
 
   return (httpRequest, httpResponse) => {
     const url = httpRequest.url!;
+    const inputReader = inputReaderAdapter(httpRequest);
+    const outputWriter = outputWriterAdapter(httpResponse);
+    const res = httpResponse as NodeWritableResponse;
 
     // Abort controller used to cleanup resources at the end of this stream lifecycle
     const abortController = new AbortController();
@@ -183,22 +190,27 @@ function nodeHandlerImpl(
       abortController.abort();
     });
 
+    const writeHead = (statusCode: number, headers: ResponseHeaders): void => {
+      res.writeHead(statusCode, headers);
+    };
+
+    // handle should never throw
     const restateResponse = handler.handle({
       url,
       headers: httpRequest.headers,
       extraArgs: [],
     });
-    const res = httpResponse as NodeWritableResponse;
-    res.writeHead(restateResponse.statusCode, restateResponse.headers);
 
     restateResponse
       .process({
-        inputReader: inputReaderAdapter(httpRequest),
-        outputWriter: outputWriterAdapter(httpResponse),
+        inputReader,
+        outputWriter,
+        writeHead,
         abortSignal: abortController.signal,
       })
       .catch((e) => {
-        // handle should never throw
+        // Framework wrapper guarantees writeHead is called; anything
+        // reaching here is a post-commit error. Nothing to do but log.
         const error = ensureError(e);
         const logger =
           tryCreateContextualLogger(


### PR DESCRIPTION
## Problem
  `RestateResponse` exposed `statusCode` / `headers` as eager fields fixed at
  `handle()` time. That prevented adding routes whose response head depends on
  parsing the request body.

 ## Change
  `process()` now receives a `writeHead(statusCode, headers)` callback and
  commits the head at a point of its choosing. A safety layer in
  `RestateHandler.handle()` guarantees `writeHead` is called exactly once,
  emits a 500 fallback on pre-commit failures, and closes the output stream
  on every path. Adapters become pure transport glue; `/invoke`'s streaming
  flow is unchanged.