### PR TITLE
Fix flaky test

### DIFF
--- a/packages/tests/restate-e2e-services/package.json
+++ b/packages/tests/restate-e2e-services/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "turbo run _build --filter={.}...",
     "_build": "tsc -b tsconfig.test.json",
-    "testrunner": "vitest run",
+    "testrunner": "vitest run --exclude \"**/memory_leak.test.ts\" && vitest run test/memory_leak.test.ts",
     "testrunner:fetch": "vitest run test/memory_leak.test.ts",
     "clean": "rm -rf dist *.tsbuildinfo .turbo",
     "check:types": "turbo run _check:types --filter={.}...",

--- a/packages/tests/restate-e2e-services/src/hooks.ts
+++ b/packages/tests/restate-e2e-services/src/hooks.ts
@@ -510,7 +510,11 @@ function createHookLevelSuite(level: HookLevel) {
         }),
         ctx.run("run-2", async () => {
           await wait(100, signal);
-          if (attempt <= 2) {
+          if (attempt === 1) {
+            await wait(10_000, signal);
+            return "should not reach";
+          }
+          if (attempt === 2) {
             await wait(200, signal);
             throw new Error("run-2 fail");
           }


### PR DESCRIPTION
running the memory leak tests after other tests. the load of the memory leak tests, can starve the concurrency slots, and cause test failure in hooks tests that are time dependent.