### PR TITLE
restate-sdk-gen: add support for date/rand/console

### DIFF
--- a/packages/libs/restate-sdk-gen/src/free.ts
+++ b/packages/libs/restate-sdk-gen/src/free.ts
@@ -47,6 +47,7 @@ import type { Channel } from "./channel.js";
 import type { State, SharedState, TypedState, UntypedState } from "./state.js";
 import type { GenDurablePromise } from "./durable-promise.js";
 import type {
+  GenContextDate,
   RestateOperations,
   RunAction,
   RunOpts,
@@ -71,16 +72,14 @@ export function currentOps(): RestateOperations {
   return getCurrent() as RestateOperations;
 }
 
-// ---- journal-backed Futures ----
+// ---- context properties (rand / date / console) ----
 
-/**
- * Run a side-effecting closure as a journal entry. See
- * `RestateOperations.run` for full semantics.
- *
- * `name` is derived from `action.name` (works for named functions and
- * arrow functions assigned to a `const`) or specified explicitly via
- * `opts.name`. If neither resolves, throws.
- */
+export const rand = (): restate.Rand => currentOps().rand;
+
+export const date = (): GenContextDate => currentOps().date;
+
+export const logger = (): Console => currentOps().console;
+
 // ---- context accessor ----
 
 /**
@@ -93,6 +92,14 @@ export const handlerRequest = (): HandlerRequest =>
 
 // ---- journal-backed Futures ----
 
+/**
+ * Run a side-effecting closure as a journal entry. See
+ * `RestateOperations.run` for full semantics.
+ *
+ * `name` is derived from `action.name` (works for named functions and
+ * arrow functions assigned to a `const`) or specified explicitly via
+ * `opts.name`. If neither resolves, throws.
+ */
 export const run = <T>(action: RunAction<T>, opts?: RunOpts<T>): Future<T> =>
   currentOps().run(action, opts);
 

--- a/packages/libs/restate-sdk-gen/src/index.ts
+++ b/packages/libs/restate-sdk-gen/src/index.ts
@@ -28,9 +28,12 @@ export {
   cancel,
   channel,
   client,
+  date,
   handlerRequest,
   invocation,
+  logger,
   race,
+  rand,
   rejectAwakeable,
   resolveAwakeable,
   run,
@@ -54,6 +57,7 @@ export type {
 } from "./future.js";
 export { gen, type Operation, select, type SelectResult } from "./operation.js";
 export {
+  type GenContextDate,
   type RetryOptions,
   type RunAction,
   type RunActionOpts,
@@ -112,6 +116,8 @@ export type {
   Duration,
   StandardTypedV1,
 } from "@restatedev/restate-sdk-core";
+
+export type { ContextDate, Rand } from "@restatedev/restate-sdk";
 
 // Internal types exposed only for API Extractor traceability — not part of the public API
 /** @internal */

--- a/packages/libs/restate-sdk-gen/src/restate-operations.ts
+++ b/packages/libs/restate-sdk-gen/src/restate-operations.ts
@@ -253,6 +253,16 @@ function asTerminalError(reason: unknown): restate.TerminalError {
   return new restate.CancelledError();
 }
 
+/**
+ * Deterministic date methods that return journal-backed Futures.
+ * Wraps the SDK's `ContextDate` (which returns Promises via internal
+ * `ctx.run()` calls) so that gen-SDK user code can `yield*` them.
+ */
+export interface GenContextDate {
+  now(): Future<number>;
+  toJSON(): Future<string>;
+}
+
 export class RestateOperations {
   private readonly ctx: restate.internal.ContextInternal;
   private readonly sched: Scheduler;
@@ -269,6 +279,24 @@ export class RestateOperations {
   // stays in one place.
   private toFuture<T>(p: restate.RestatePromise<T>): Future<T> {
     return this.sched.makeJournalFuture(adapt(p));
+  }
+
+  // ---- context properties (rand / date / console) ----
+
+  get rand(): restate.Rand {
+    return this.ctx.rand;
+  }
+
+  get date(): GenContextDate {
+    return {
+      now: () => this.run(async () => Date.now(), { name: "date.now" }),
+      toJSON: () =>
+        this.run(async () => new Date().toJSON(), { name: "date.toJSON" }),
+    };
+  }
+
+  get console(): Console {
+    return this.ctx.console;
   }
 
   // ---- journal-backed Futures ----

--- a/packages/libs/restate-sdk-gen/src/restate-operations.ts
+++ b/packages/libs/restate-sdk-gen/src/restate-operations.ts
@@ -59,7 +59,7 @@ import {
   type SignalReference,
 } from "./invocation-reference.js";
 import { defaultLib } from "./default-lib.js";
-import { InvocationId, Target } from "@restatedev/restate-sdk";
+import { InvocationId, RestatePromise, Target } from "@restatedev/restate-sdk";
 
 // Adapt a real RestatePromise to our Awaitable interface. RestatePromise
 // already has `.map((v, e) => U)` and is thenable, so the adapter is a
@@ -289,9 +289,9 @@ export class RestateOperations {
 
   get date(): GenContextDate {
     return {
-      now: () => this.run(async () => Date.now(), { name: "date.now" }),
+      now: () => this.toFuture(this.ctx.date.now() as RestatePromise<number>),
       toJSON: () =>
-        this.run(async () => new Date().toJSON(), { name: "date.toJSON" }),
+        this.toFuture(this.ctx.date.toJSON() as RestatePromise<string>),
     };
   }
 


### PR DESCRIPTION
This exposes ctx.date, ctx.rand, and ctx.console. Console is named logger so it does not conflict with the global console.