### PR TITLE
Add pnpm app script to run restate-e2e-services locally

### DIFF
--- a/packages/tests/restate-e2e-services/README.md
+++ b/packages/tests/restate-e2e-services/README.md
@@ -6,10 +6,32 @@ docker build . -f packages/tests/restate-e2e-services/Dockerfile -t restatedev/t
 
 ## Running the services locally
 
-The Node services can be run via:
+The Node services can be run directly from source (via `tsx`, no build required):
 
 ```shell
-SERVICES=<COMMA_SEPARATED_LIST_OF_SERVICES> gradle npm_run_app 
+# from this package directory
+pnpm app
+
+# or from the project root
+pnpm --filter @restatedev/restate-e2e-services app
+```
+
+By default all services are registered on port `9080`. The following environment
+variables are supported:
+
+| Variable                        | Default      | Purpose                                                       |
+| ------------------------------- | ------------ | ------------------------------------------------------------- |
+| `SERVICES`                      | all          | Comma-separated list of services to register, or `*` for all  |
+| `PORT`                          | `9080`       | HTTP/2 server port                                            |
+| `RESTATE_E2E_ENDPOINT_ADAPTER`  | `node-http2` | Endpoint implementation (`node-http2` or `fetch`)             |
+
+Examples:
+
+```shell
+SERVICES=Counter,EventHandler PORT=9080 pnpm app
+
+# run with the fetch-based endpoint adapter
+pnpm app:fetch
 ```
 
 For the list of supported services see [here](src/app.ts).

--- a/packages/tests/restate-e2e-services/package.json
+++ b/packages/tests/restate-e2e-services/package.json
@@ -16,6 +16,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "app": "tsx src/app.ts",
+    "app:fetch": "RESTATE_E2E_ENDPOINT_ADAPTER=fetch tsx src/app.ts",
     "build": "turbo run _build --filter={.}...",
     "_build": "tsc -b tsconfig.test.json",
     "testrunner": "vitest run --exclude \"**/memory_leak.test.ts\" && vitest run test/memory_leak.test.ts",


### PR DESCRIPTION
Adds `app` and `app:fetch` scripts to run the e2e test services directly from source via tsx, without building the Docker image. Updates the README to document the new commands and supported environment variables, replacing the stale `gradle npm_run_app` instruction.