### PR TITLE
[restate-sdk-gen] Add contextLocal — ambient invocation-scoped storage

### DIFF
--- a/.changeset/spicy-context-local.md
+++ b/.changeset/spicy-context-local.md
@@ -1,0 +1,7 @@
+---
+"@restatedev/restate-sdk-gen": minor
+---
+
+Add `contextLocal<T>(default?)` — ambient, invocation-scoped key/value storage. A `contextLocal()` handle exposes `get()`/`set()` over a bag scoped to the current `execute()` call and shared by every fiber under it (the main routine, everything it `spawn`s, and combinator fallbacks). Use it to carry request-scoped context — a correlation id, a tenant, a logging prefix — through deeply nested helpers and spawned routines without threading a parameter. Define a slot once at module scope (minting touches no fiber); `get`/`set` it from inside the workflow body.
+
+The storage is **global per invocation** (one shared bag, no per-fiber inheritance or isolation) and **in-memory only** — never journaled. It is deterministic across replay/suspension as long as values are set by deterministic workflow code (route raw I/O through `run` first, as with any local). It is not durable state: for values that must outlive the invocation, use `state()` / `sharedState()`. Exposes `contextLocal` and the `ContextLocal<T>` type.

--- a/packages/libs/restate-sdk-gen/DESIGN.md
+++ b/packages/libs/restate-sdk-gen/DESIGN.md
@@ -550,6 +550,56 @@ journal source to the main-loop race.
 
 ---
 
+## Context-local storage
+
+`contextLocal()` mints an ambient key/value slot — set once, read
+anywhere downstream without threading a parameter. It's the in-memory
+counterpart to `state()`: where `state()` is durable and survives across
+invocations, a context-local lives only for the current invocation.
+
+**Scope: global per invocation, not per fiber.** The bag lives on the
+`Scheduler` (one per `execute()` call, like `fibers`/`ready`), so every
+fiber under that scheduler — main, spawns, and the synthetic fibers
+behind combinator fallbacks — reaches the same bag. There is no
+inheritance and no per-strand isolation.
+
+This was a deliberate choice over a per-fiber, spawn-tree-inherited model
+(the Kotlin-`CoroutineContext` / Go-`context.Context` flavor):
+
+- Within a single fiber you don't need ambient storage at all — a closure
+  variable already threads a value through any depth of nested `gen`
+  bodies, since the body runs synchronously between yields. The feature
+  only earns its keep across the spawn boundary, and the dominant
+  cross-fiber use ("set a correlation id / tenant at the top, read it in
+  helpers and workers") wants *sharing*, which global gives directly.
+- Global stays out of the delicate fiber/scheduler core: a `Map` on the
+  scheduler plus two accessors, touching none of the I1–I4 / S1–S3
+  invariants, the interrupt cascade, or the re-homing on `finish`. A
+  per-fiber model would re-open all of that (snapshot-vs-live, write
+  isolation, sibling isolation, interaction with re-homing) for semantics
+  the common case doesn't ask for.
+- It's forward-compatible: the `get`/`set` surface is identical whether
+  resolution reads one bag or walks the fiber tree, so a per-strand
+  variant could be added later (as a separate handle kind) without
+  changing existing call sites. Only one narrow behavior would differ —
+  a write made *after* a child is spawned, read back in that child, is
+  visible under global and would not be under a snapshot-inherited model.
+
+**Determinism.** The bag is in-memory and never journaled, which is safe
+because a value re-derived by deterministic workflow code is itself
+deterministic: on replay the body re-runs from the top and re-`set`s the
+same values, and fibers advance in a replay-stable order, so reads are
+stable. The same discipline as a plain local applies — don't store a
+non-deterministically-obtained value (a bare `Date.now()`, a raw network
+result) without routing it through `run`/the journal first.
+
+The one sharp edge, documented for users: because the bag is shared,
+concurrently-interleaving routines that write the *same* slot clobber
+each other (last writer as of the reader's advance wins). Fine for
+set-once-read-everywhere; not a substitute for per-routine scratch.
+
+---
+
 ## What's deliberately not in the design
 
 A few features that come up in cancellation discussions and aren't

--- a/packages/libs/restate-sdk-gen/README.md
+++ b/packages/libs/restate-sdk-gen/README.md
@@ -72,7 +72,8 @@ Imported directly from `@restatedev/restate-sdk-gen`:
 - **`sleep(duration)`** — journaled timer.
 - **`awakeable<T>()`** — journaled awakeable; returns `{ id, promise: Future<T> }`.
 - **`channel<T>()`** — single-shot in-memory `Channel<T>`.
-- **`state<T>()` / `sharedState<T>()`** — typed key-value store.
+- **`state<T>()` / `sharedState<T>()`** — typed key-value store (durable, survives across invocations).
+- **`contextLocal<T>(default?)`** — ambient, in-memory storage scoped to the current invocation and shared by every fiber under it. Set once near the top, read anywhere downstream without threading a parameter. Not durable — for state that must outlive the invocation, use `state()`.
 - **`serviceClient` / `objectClient` / `workflowClient`** (+ `*SendClient`) — typed RPC into other Restate services.
 - **`genericCall` / `genericSend`** — untyped RPC.
 - **`cancel(invocationId)`** — cancel another invocation.

--- a/packages/libs/restate-sdk-gen/e2e/context.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/context.e2e.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+// Context-local storage e2e: ambient invocation-scoped values against a
+// real Restate runtime.
+//
+// The properties under test that the unit tests can't fully show:
+//
+//   - A value set before a durable suspension point (`sleep`) is still
+//     readable after it. The workflow re-runs from the top on replay and
+//     re-`set`s the slot from journaled inputs, so the read is stable —
+//     exercised hard by alwaysReplay mode, which replays every entry.
+//   - The bag is shared with spawned routines and nested helpers under
+//     the same invocation.
+//   - It is scoped per invocation: a fresh invocation never sees a value
+//     a previous one set (no process-global leak).
+//
+// Both runtime modes: default + alwaysReplay.
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { RestateTestEnvironment } from "@restatedev/restate-sdk-testcontainers";
+import {
+  service,
+  gen,
+  run,
+  sleep,
+  spawn,
+  contextLocal,
+  clients,
+  type Operation,
+} from "@restatedev/restate-sdk-gen";
+
+// Defined once at module scope — each invocation gets its own bag.
+const requestId = contextLocal<string>();
+const tenant = contextLocal<string>("public");
+
+// A helper usable both inline (`yield*`) and as a spawned routine. It
+// reads the ambient slots — nothing is passed to it.
+const auditedStep = (label: string): Operation<string> =>
+  gen(function* () {
+    return `[${requestId.get()} | ${tenant.get()}] ${label}`;
+  });
+
+const ambient = service({
+  name: "ambient",
+  handlers: {
+    // Set context near the top (from a journaled value), cross a
+    // suspension point, then read it back from main, a nested helper,
+    // and a spawned routine.
+    *propagate(input: {
+      id: string;
+      tenant?: string;
+    }): Operation<{ afterSleep: string; nested: string; spawned: string }> {
+      requestId.set(
+        yield* run(async () => `req-${input.id}`, { name: "reqid" })
+      );
+      if (input.tenant) tenant.set(input.tenant);
+
+      yield* sleep(1); // durable suspension / replay boundary
+
+      const afterSleep = requestId.get() ?? "LOST";
+      const nested = yield* auditedStep("nested");
+      const spawned = yield* spawn(auditedStep("spawned"));
+      return { afterSleep, nested, spawned };
+    },
+
+    // A separate invocation that never sets requestId. Proves the slot
+    // is per-invocation: it must read the default, not a value some
+    // earlier `propagate` invocation set.
+    *whoami(): Operation<string> {
+      return requestId.get() ?? "unset";
+    },
+
+    // get/set must be called from the generator body, not from inside a
+    // `run` action closure (which resolves off the fiber's advance span).
+    // Doing so throws "outside an active fiber" — pinned here against the
+    // real SDK run path so a slot-lifetime change can't silently let a
+    // run closure read/write the bag.
+    *runBoundary(): Operation<string> {
+      return yield* run(
+        async () => {
+          try {
+            requestId.set("from-run-closure");
+            return "DID-NOT-THROW";
+          } catch (e) {
+            return (e as Error).message.includes("outside an active fiber")
+              ? "threw"
+              : "WRONG-ERROR";
+          }
+        },
+        { name: "probe" }
+      );
+    },
+  },
+});
+
+const modes = [
+  { name: "default", alwaysReplay: false },
+  { name: "alwaysReplay", alwaysReplay: true },
+] as const;
+
+describe.each(modes)("contextLocal — $name mode", ({ alwaysReplay }) => {
+  let env: RestateTestEnvironment;
+  let ingress: clients.GenIngress;
+
+  beforeAll(async () => {
+    env = await RestateTestEnvironment.start({
+      services: [ambient],
+      alwaysReplay,
+    });
+    ingress = clients.connect({ url: env.baseUrl() });
+  });
+
+  afterAll(async () => {
+    await env?.stop();
+  });
+
+  test("value set before a suspension is readable after, by main / nested / spawned", async () => {
+    const client = clients.client(ingress, ambient);
+    const out = await client.propagate({ id: "42", tenant: "acme" });
+    expect(out.afterSleep).toBe("req-42");
+    expect(out.nested).toBe("[req-42 | acme] nested");
+    expect(out.spawned).toBe("[req-42 | acme] spawned");
+  });
+
+  test("default applies when a slot is left unset within the invocation", async () => {
+    const client = clients.client(ingress, ambient);
+    const out = await client.propagate({ id: "7" }); // no tenant → default
+    expect(out.nested).toBe("[req-7 | public] nested");
+  });
+
+  test("scoped per invocation: a fresh invocation does not see a prior one's value", async () => {
+    const client = clients.client(ingress, ambient);
+    await client.propagate({ id: "999", tenant: "acme" });
+    // whoami is a brand-new invocation; it never set requestId.
+    expect(await client.whoami()).toBe("unset");
+  });
+
+  test("get/set inside a run closure throws (off the advance span)", async () => {
+    const client = clients.client(ingress, ambient);
+    expect(await client.runBoundary()).toBe("threw");
+  });
+});

--- a/packages/libs/restate-sdk-gen/examples/tutorial/src/12-context.ts
+++ b/packages/libs/restate-sdk-gen/examples/tutorial/src/12-context.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+// Tier 12: context-local storage — ambient values for the invocation.
+//
+// Maps to guide.md §"Context-local storage". A `contextLocal()` slot is
+// an in-memory bag scoped to the current invocation and shared by every
+// fiber under it (the main routine and everything it spawns). Use it to
+// carry request-scoped context — a correlation id, a tenant, a logging
+// prefix — without threading it as a parameter through every helper.
+//
+// Note this is NOT durable state: it lives only for the invocation. For
+// values that must outlive the invocation, use `state()` (tier 7).
+
+import {
+  service,
+  gen,
+  run,
+  spawn,
+  contextLocal,
+  Operation,
+} from "@restatedev/restate-sdk-gen";
+
+// Define the slots once, at module scope — minting a slot touches no
+// fiber, so this is safe outside a handler. Each invocation gets its own
+// bag keyed by these handles; concurrent invocations never collide.
+const requestId = contextLocal<string>(); // optional: string | undefined
+const tenant = contextLocal<string>("public"); // with a default
+
+// A deeply-nested step. It wants the request id and tenant for its audit
+// line, but nothing passed them down — it reads the ambient slots.
+const auditedStep = (label: string): Operation<string> =>
+  gen(function* () {
+    const line = `[req ${requestId.get()} | tenant ${tenant.get()}] ${label}`;
+    return yield* run(async () => line, { name: label });
+  });
+
+export const ambient = service({
+  name: "ambient",
+  handlers: {
+    // Resolve the ambient context once near the top, then read it
+    // everywhere downstream — in nested helpers and in spawned routines,
+    // none of which take it as a parameter.
+    *process(order: { id: string; tenant?: string }): Operation<string[]> {
+      // Set from a journaled value so it is deterministic across replay.
+      requestId.set(yield* run(async () => `r-${order.id}`, { name: "reqid" }));
+      if (order.tenant) tenant.set(order.tenant);
+
+      // Nested helpers read the slots directly.
+      const validated = yield* auditedStep("validate");
+      const persisted = yield* auditedStep("persist");
+
+      // A spawned routine shares the same bag — it sees what main set.
+      const notified = yield* spawn(auditedStep("notify"));
+
+      return [validated, persisted, notified];
+    },
+  },
+});

--- a/packages/libs/restate-sdk-gen/examples/tutorial/src/server.ts
+++ b/packages/libs/restate-sdk-gen/examples/tutorial/src/server.ts
@@ -25,6 +25,8 @@
 //   /clients           — typed service/object clients + awakeable cross-handler
 //                        (also: /greeter, /awakeableHolder)
 //   /blockAndWait      — workflow with a durable promise
+//   /ambient           — context-local storage: request-scoped ambient
+//                        values shared across helpers and spawned routines
 //
 // See ../README.md for curl invocations grouped by tier.
 
@@ -40,6 +42,7 @@ import { clientsSvc, greeter, awakeableHolder } from "./08-clients.js";
 import { blockAndWaitWorkflow } from "./09-workflows.js";
 import { ifaceServices } from "./10-ifaces.js";
 import { userService, echoService } from "./11-serdes.js";
+import { ambient } from "./12-context.js";
 
 restate.serve({
   services: [
@@ -57,5 +60,6 @@ restate.serve({
     ...ifaceServices,
     userService,
     echoService,
+    ambient,
   ],
 });

--- a/packages/libs/restate-sdk-gen/guide.md
+++ b/packages/libs/restate-sdk-gen/guide.md
@@ -612,6 +612,70 @@ receive Future is reused everywhere.
 
 ---
 
+## Context-local storage
+
+Sometimes a value is needed deep inside the call tree — a correlation
+id, a tenant, a logging prefix — but threading it through every helper
+as a parameter is noise. `contextLocal()` gives you an ambient slot:
+set it once near the top, read it anywhere downstream.
+
+```ts
+import { contextLocal, gen, run, spawn } from "@restatedev/restate-sdk-gen";
+
+// Define the slot once, at module scope — minting touches no fiber.
+const requestId = contextLocal<string>();           // string | undefined
+const tenant = contextLocal<string>("public");      // with a default
+
+const auditedStep = (label: string) =>
+  gen(function* () {
+    // Reads the ambient slots — nothing passed them down.
+    const line = `[req ${requestId.get()} | ${tenant.get()}] ${label}`;
+    return yield* run(async () => line, { name: label });
+  });
+
+const handler = gen(function* () {
+  requestId.set(yield* run(() => newRequestId(), { name: "reqid" }));
+  const a = yield* auditedStep("validate");        // sees requestId
+  const b = yield* spawn(auditedStep("notify"));    // so does a spawned routine
+  return [a, b];
+});
+```
+
+The slot is scoped to **one invocation** (`execute` call) and shared by
+**every fiber under it** — the main routine, everything it `spawn`s, and
+the combinator fallbacks. There is no per-routine isolation and no
+inheritance: it is one bag for the whole invocation. Concurrent
+invocations in the same process never see each other's bags.
+
+`get()` returns the value last `set()` this invocation, or the default
+passed to `contextLocal` (or `undefined` if none).
+
+A few things to keep in mind:
+
+- **It is in-memory, not durable.** The bag lives only for the
+  invocation; it is never journaled. For values that must outlive the
+  invocation (and be visible to later invocations of the same virtual
+  object) use `state()` / `sharedState()` instead.
+- **Set deterministically.** A value re-derived by deterministic
+  workflow code survives replay/suspension unchanged (the body re-runs
+  and re-`set`s it the same way). Don't stuff a raw `Date.now()` or an
+  un-journaled network result into a slot any more than you would into a
+  plain local — route it through `run` first.
+- **Shared means shared.** Because the bag is global to the invocation,
+  two concurrently-interleaving routines that write the *same* slot
+  clobber each other (a reader sees whichever advanced last). That's
+  fine for the common "set once, read everywhere" use; it just isn't
+  per-strand scratch space.
+- **Call from the body, not from a `run` closure.** `get`/`set` work on
+  the fiber's synchronous span — directly in the generator body or a
+  spawned routine's body. Calling them from inside an `ops.run` action
+  closure (or any async callback) runs off-advance and throws "outside
+  an active fiber", just like any other free function. To capture a
+  journaled value, set it in the body from the result:
+  `slot.set(yield* run(() => fetchTenant(), { name: "tenant" }))`.
+
+---
+
 ## Working with futures defensively
 
 ### Future yielded twice gives the same value
@@ -837,6 +901,8 @@ no `run` is invoked until the iterator runs inside `execute()`.
 | Cancel an in-flight HTTP call | pass `signal` to `fetch` in `run` |
 | React to invocation cancel | catch `CancelledError` at yield site |
 | Pass an event from outside | channel — `send` from outside, `receive` inside |
+| Ambient value for this invocation | `contextLocal()` — set once, read anywhere |
+| A value that must outlive the invocation | `state()` / `sharedState()` (durable) |
 
 ---
 

--- a/packages/libs/restate-sdk-gen/src/context.ts
+++ b/packages/libs/restate-sdk-gen/src/context.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+// Context-local storage
+// =============================================================================
+//
+// Ambient, invocation-scoped key/value storage — a typed bag carried by
+// the current invocation that generator code running under it (the main
+// body, nested `gen` helpers, and spawned routines) can read and write
+// without threading a parameter through every call.
+//
+// `get`/`set` must run on the fiber's synchronous advance span, i.e.
+// directly from generator code — NOT from inside an `ops.run` action
+// closure or any other async callback, which run off-advance (after the
+// fiber has parked) and throw "outside an active fiber". To capture a
+// journaled value into a slot, set it in the body from the run's result:
+// `slot.set(yield* run(() => fetchTenant(), { name: "tenant" }))`, not
+// `run(() => { slot.set(...) })`.
+//
+//   const tenant = contextLocal<string>();        // define once, anywhere
+//
+//   const handler = gen(function* () {
+//     tenant.set(yield* run(() => resolveTenant(), { name: "tenant" }));
+//     yield* doDeeplyNestedWork();   // reads tenant.get() without a param
+//   });
+//
+// Scope and lifetime: ONE bag per `execute()` call. Every fiber that
+// runs under that invocation — the main routine, everything it
+// `spawn`s, and the synthetic fibers behind combinator fallbacks —
+// shares the same bag (this is global-per-invocation, not per-fiber:
+// there is no inheritance or per-strand isolation). The bag lives only
+// in memory for the duration of the invocation; it is never journaled
+// or persisted.
+//
+// Determinism: a value re-derived by deterministic workflow code is
+// itself deterministic, so it survives replay/suspension unchanged —
+// the workflow re-runs from the top and re-`set`s the same values, in
+// the same order (fibers advance one at a time, in a replay-stable
+// order). The same rule as a plain local variable applies: do not store
+// a value you obtained non-deterministically (a bare `Date.now()`, a
+// raw network result) unless it came through `run`/the journal first.
+//
+// NOT durable state: `contextLocal` is in-memory scratch for the current
+// invocation. For values that must outlive the invocation (and be
+// readable by later invocations of the same virtual object), use
+// `state()` / `sharedState()`, which the SDK persists.
+//
+// Footgun: because the bag is shared, two concurrently-interleaving
+// fibers that write the *same* key clobber each other — a reader sees
+// whichever fiber advanced last. That is fine for the dominant use
+// (set once near the top, read everywhere); only reach past it if you
+// need per-strand isolation, which this global flavor does not provide.
+
+import { getCurrent } from "./current.js";
+
+/**
+ * The slice of the current-fiber slot that backs context-local storage.
+ * Both `Scheduler` (the slot in unit tests) and `RestateOperations` (the
+ * slot in production) satisfy it structurally — `RestateOperations`
+ * delegates to its scheduler, which owns the single per-invocation Map.
+ * Kept here, cast from the `unknown` slot, so this module stays free of a
+ * scheduler/operations import cycle (mirrors how `free.ts` reaches `ops`).
+ */
+interface ContextStore {
+  /** Read `key`'s value, or `fallback` if it has never been set. */
+  getLocal(key: symbol, fallback: unknown): unknown;
+  /** Write `key`'s value for the rest of the invocation. */
+  setLocal(key: symbol, value: unknown): void;
+}
+
+/**
+ * A handle to one invocation-scoped slot. Mint it once with
+ * {@link contextLocal} (at module scope is fine — minting touches no
+ * fiber), then `get`/`set` it from inside the workflow body.
+ */
+export interface ContextLocal<T> {
+  /**
+   * Read this slot's value for the current invocation. Returns the
+   * value previously {@link set} during this invocation, or the default
+   * passed to {@link contextLocal} (or `undefined` if none) when it has
+   * not been set. Must be called from generator code on the fiber's
+   * synchronous span (a `gen` body running under `execute`); calling it
+   * from an `ops.run` closure or other async callback throws.
+   */
+  // Arrow-property fields (not method shorthand) on purpose: method
+  // parameters are checked bivariantly, which would let `ContextLocal<Dog>`
+  // be treated as `ContextLocal<Animal>` and a widened `set` poison a `get`
+  // that still claims `Dog`. As function-typed properties, `set`'s
+  // parameter is contravariant, making the handle correctly invariant in T.
+  get: () => T;
+  /**
+   * Set this slot's value for the rest of the current invocation,
+   * visible to every fiber under it. Must be called from generator code
+   * on the fiber's synchronous span; calling it from an `ops.run`
+   * closure or other async callback throws.
+   */
+  set: (value: T) => void;
+}
+
+/**
+ * Create a context-local storage slot.
+ *
+ * The returned handle's `get`/`set` read and write a bag scoped to the
+ * current invocation (`execute` call) and shared by every fiber under
+ * it. Each `contextLocal()` call mints an independent slot — two handles
+ * never collide, even with the same value type.
+ *
+ * Minting is pure (it allocates a unique key and captures the default),
+ * so a slot can be defined at module scope and reused across
+ * invocations; only `get`/`set` touch the current fiber.
+ *
+ * @example A required value with a default
+ *   const region = contextLocal("us-east-1");   // ContextLocal<string>
+ *   // inside a handler:
+ *   region.set("eu-west-1");
+ *   const r = region.get();                       // string
+ *
+ * @example An optional value (no default)
+ *   const traceId = contextLocal<string>();      // ContextLocal<string | undefined>
+ *   const t = traceId.get();                       // string | undefined
+ */
+export function contextLocal<T>(defaultValue: T): ContextLocal<T>;
+export function contextLocal<T>(): ContextLocal<T | undefined>;
+export function contextLocal<T>(defaultValue?: T): ContextLocal<T | undefined> {
+  // Identity-only key: the bag is keyed by this symbol, never serialized,
+  // and lives only in-memory per invocation — so symbol identity (stable
+  // within a process, irrelevant across processes) is the right key.
+  const key = Symbol("restate.contextLocal");
+  return {
+    get: () =>
+      (getCurrent() as ContextStore).getLocal(key, defaultValue) as
+        | T
+        | undefined,
+    set: (value: T | undefined) =>
+      (getCurrent() as ContextStore).setLocal(key, value),
+  };
+}

--- a/packages/libs/restate-sdk-gen/src/index.ts
+++ b/packages/libs/restate-sdk-gen/src/index.ts
@@ -56,6 +56,7 @@ export type {
   FutureValues,
 } from "./future.js";
 export { gen, type Operation, select, type SelectResult } from "./operation.js";
+export { contextLocal, type ContextLocal } from "./context.js";
 export { type Task, InterruptedError } from "./task.js";
 export {
   execute,

--- a/packages/libs/restate-sdk-gen/src/restate-operations.ts
+++ b/packages/libs/restate-sdk-gen/src/restate-operations.ts
@@ -304,6 +304,19 @@ export class RestateOperations {
     return this.ctx.isProcessing();
   }
 
+  // ---- context-local storage ----
+  // Delegate to the scheduler, which owns the single per-invocation bag.
+  // Present here because `RestateOperations` is the current-fiber slot in
+  // production; `contextLocal()` handles cast the slot to this shape.
+
+  getLocal(key: symbol, fallback: unknown): unknown {
+    return this.sched.getLocal(key, fallback);
+  }
+
+  setLocal(key: symbol, value: unknown): void {
+    this.sched.setLocal(key, value);
+  }
+
   // ---- journal-backed Futures ----
 
   /**

--- a/packages/libs/restate-sdk-gen/src/scheduler.ts
+++ b/packages/libs/restate-sdk-gen/src/scheduler.ts
@@ -136,6 +136,17 @@ export class Scheduler implements SchedulerOps {
    */
   contextSlot: unknown;
 
+  /**
+   * Context-local storage: an ambient key/value bag scoped to this
+   * scheduler — i.e. to this one `execute()` call, since production
+   * builds a fresh scheduler per invocation (like `fibers` / `ready` /
+   * `abortController`, this is per-run state, not shared across runs).
+   * Every fiber under this scheduler reaches the same bag (global-per-
+   * invocation; see `context.ts`). Keyed by the opaque symbol a
+   * `contextLocal()` handle owns. In-memory only — never journaled.
+   */
+  private readonly localStore = new Map<symbol, unknown>();
+
   constructor(
     lib: AwaitableLib,
     parentSignal?: AbortSignal,
@@ -271,6 +282,23 @@ export class Scheduler implements SchedulerOps {
    */
   makeChannel<U>(): Channel<U> {
     return makeChannel<U>();
+  }
+
+  // ---- context-local storage (see context.ts) ----
+
+  /**
+   * Read a context-local value, or `fallback` if `key` was never set in
+   * this invocation. `has`-checked so an explicit `setLocal(key,
+   * undefined)` reads back as `undefined` rather than falling through to
+   * the handle's default.
+   */
+  getLocal(key: symbol, fallback: unknown): unknown {
+    return this.localStore.has(key) ? this.localStore.get(key) : fallback;
+  }
+
+  /** Write a context-local value for the rest of this invocation. */
+  setLocal(key: symbol, value: unknown): void {
+    this.localStore.set(key, value);
   }
 
   // ---- combinator helpers (used by RestateOperations) ----

--- a/packages/libs/restate-sdk-gen/test/context.test.ts
+++ b/packages/libs/restate-sdk-gen/test/context.test.ts
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  gen,
+  spawn,
+  all,
+  contextLocal,
+  type ContextLocal,
+} from "../src/index.js";
+import { Scheduler } from "../src/internal.js";
+import { deferred, testLib } from "./test-promise.js";
+
+describe("contextLocal — basics", () => {
+  test("set then get returns the value", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("default");
+    const op = gen(function* () {
+      slot.set("hello");
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBe("hello");
+  });
+
+  test("get before set returns the default", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("default");
+    const op = gen(function* () {
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBe("default");
+  });
+
+  test("get before set with no default returns undefined", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>();
+    const op = gen(function* () {
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBeUndefined();
+  });
+
+  test("set overrides default", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<number>(0);
+    const op = gen(function* () {
+      slot.set(42);
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBe(42);
+  });
+
+  test("explicit set(undefined) reads back undefined, not the default", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string | undefined>("default");
+    const op = gen(function* () {
+      slot.set(undefined);
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBeUndefined();
+  });
+
+  test("falsy values round-trip past a non-falsy default (has-check, not ??)", async () => {
+    // The store uses Map.has, not `?? default`, so an explicitly-set
+    // falsy value is returned rather than falling through to the default.
+    const num = contextLocal<number>(99);
+    const str = contextLocal<string>("x");
+    const bool = contextLocal<boolean>(true);
+    const nullable = contextLocal<string | null>("x");
+    const op = gen(function* () {
+      num.set(0);
+      str.set("");
+      bool.set(false);
+      nullable.set(null);
+      return [num.get(), str.get(), bool.get(), nullable.get()];
+    });
+    expect(await new Scheduler(testLib).run(op)).toEqual([0, "", false, null]);
+  });
+
+  test("a later set overwrites an earlier one", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>();
+    const op = gen(function* () {
+      slot.set("first");
+      slot.set("second");
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBe("second");
+  });
+
+  test("stores object values by reference", async () => {
+    const sched = new Scheduler(testLib);
+    const obj = { n: 1 };
+    const slot = contextLocal<{ n: number }>({ n: 0 });
+    const op = gen(function* () {
+      slot.set(obj);
+      const got = slot.get();
+      got.n = 2;
+      return slot.get().n;
+    });
+    expect(await sched.run(op)).toBe(2);
+    expect(obj.n).toBe(2); // same reference, not a copy
+  });
+
+  test("distinct handles do not collide, even with the same value type", async () => {
+    const sched = new Scheduler(testLib);
+    const a = contextLocal<string>();
+    const b = contextLocal<string>();
+    const c = contextLocal<string>("c-default");
+    const op = gen(function* () {
+      a.set("A");
+      b.set("B");
+      // c left unset
+      return [a.get(), b.get(), c.get()];
+    });
+    expect(await sched.run(op)).toEqual(["A", "B", "c-default"]);
+  });
+});
+
+describe("contextLocal — sharing across fibers (global per invocation)", () => {
+  test("main sets, a spawned child reads the same value", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("default");
+    const op = gen(function* () {
+      slot.set("from-main");
+      const child = spawn(
+        gen(function* () {
+          return slot.get();
+        })
+      );
+      return yield* child;
+    });
+    expect(await sched.run(op)).toBe("from-main");
+  });
+
+  test("a child's write is visible to main after the child runs", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("default");
+    const op = gen(function* () {
+      const child = spawn(
+        gen(function* () {
+          slot.set("from-child");
+          return 1;
+        })
+      );
+      yield* child; // join — ensures the child advanced
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBe("from-child");
+  });
+
+  test("one sibling's write is visible to another (shared bag)", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>();
+    const op = gen(function* () {
+      const a = spawn(
+        gen(function* () {
+          slot.set("a-wrote-this");
+          return 1;
+        })
+      );
+      yield* a; // ensure A ran before B reads
+      const b = spawn(
+        gen(function* () {
+          return slot.get();
+        })
+      );
+      return yield* b;
+    });
+    expect(await sched.run(op)).toBe("a-wrote-this");
+  });
+
+  test("a later cross-fiber write overwrites an earlier one (last write wins)", async () => {
+    // The documented sharp edge: writers to the same slot clobber each
+    // other; a reader sees whichever advanced last. Sequencing the two
+    // writers with joins pins which write lands last, deterministically.
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("init");
+    const op = gen(function* () {
+      const a = spawn(
+        gen(function* () {
+          slot.set("from-A");
+          return 1;
+        })
+      );
+      yield* a; // A advanced and wrote
+      const b = spawn(
+        gen(function* () {
+          slot.set("from-B");
+          return 1;
+        })
+      );
+      yield* b; // B advanced last
+      return slot.get();
+    });
+    expect(await sched.run(op)).toBe("from-B");
+  });
+
+  test("value set in main is shared by concurrent spawned routines combined via all", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("default");
+    const op = gen(function* () {
+      slot.set("shared");
+      const f1 = spawn(
+        gen(function* () {
+          return slot.get();
+        })
+      );
+      const f2 = spawn(
+        gen(function* () {
+          return slot.get();
+        })
+      );
+      const [a, b] = yield* all([f1, f2]);
+      return `${a}+${b}`;
+    });
+    expect(await sched.run(op)).toBe("shared+shared");
+  });
+});
+
+describe("contextLocal — invocation isolation", () => {
+  test("two schedulers have independent stores", async () => {
+    const slot = contextLocal<string>("default");
+    const sched1 = new Scheduler(testLib);
+    const sched2 = new Scheduler(testLib);
+
+    const r1 = await sched1.run(
+      gen(function* () {
+        slot.set("one");
+        return slot.get();
+      })
+    );
+    const r2 = await sched2.run(
+      gen(function* () {
+        return slot.get(); // never set in this invocation
+      })
+    );
+    expect(r1).toBe("one");
+    expect(r2).toBe("default"); // sched1's write did not leak across
+  });
+
+  test("two interleaved schedulers each read only their own slot value", async () => {
+    // Not sequential: both invocations advance to a suspension point
+    // before either is awaited, then resume out of order. Validates that
+    // the module-level CURRENT slot (set/cleared around each advance) is
+    // re-installed per fiber, so neither invocation sees the other's bag.
+    const slot = contextLocal<string>("default");
+    const s1 = new Scheduler(testLib);
+    const s2 = new Scheduler(testLib);
+    const d1 = deferred<void>();
+    const d2 = deferred<void>();
+    const f1 = s1.makeJournalFuture(d1.promise);
+    const f2 = s2.makeJournalFuture(d2.promise);
+    const mk = (name: string, f: typeof f1) =>
+      gen(function* () {
+        slot.set(name);
+        yield* f; // suspend
+        return slot.get();
+      });
+    const p1 = s1.run(mk("one", f1));
+    const p2 = s2.run(mk("two", f2));
+    d2.resolve(); // resume in reverse start order
+    d1.resolve();
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe("one");
+    expect(r2).toBe("two");
+  });
+
+  test("the store is fresh per execute — a prior run's value does not survive", async () => {
+    const slot = contextLocal<number>(0);
+    const op = gen(function* () {
+      const before = slot.get();
+      slot.set(before + 1);
+      return slot.get();
+    });
+    // A fresh scheduler each run = a fresh bag, so each run starts from 0.
+    expect(await new Scheduler(testLib).run(op)).toBe(1);
+    expect(await new Scheduler(testLib).run(op)).toBe(1);
+  });
+});
+
+describe("contextLocal — usage errors", () => {
+  test("get outside an active fiber throws", () => {
+    const slot = contextLocal<string>();
+    expect(() => slot.get()).toThrow(/outside an active fiber/);
+  });
+
+  test("set outside an active fiber throws", () => {
+    const slot = contextLocal<string>();
+    expect(() => slot.set("x")).toThrow(/outside an active fiber/);
+  });
+
+  test("get/set off the advance span (e.g. inside a run closure) throws while a scheduler is live", async () => {
+    // The boundary the synchronous-slot design rests on: CURRENT is only
+    // installed during a fiber's advance. A callback that runs after the
+    // fiber parks (here, a microtask draining at the scheduler await —
+    // the same point an `ops.run` closure resolves) sees CURRENT === null
+    // and must throw, not read/write a bag. A future change to slot
+    // lifetime (e.g. AsyncLocalStorage) would break this test rather than
+    // silently leak the bag into off-advance code.
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("default");
+    const d = deferred<void>();
+    const f = sched.makeJournalFuture(d.promise);
+    let captured: unknown = null;
+    const op = gen(function* () {
+      slot.set("from-fiber");
+      queueMicrotask(() => {
+        try {
+          slot.set("from-callback");
+        } catch (e) {
+          captured = e;
+        }
+        d.resolve(); // let the fiber resume after the callback ran
+      });
+      yield* f; // park; the microtask runs while CURRENT is cleared
+      return slot.get();
+    });
+    const result = await sched.run(op);
+    expect((captured as Error | null)?.message).toMatch(
+      /outside an active fiber/
+    );
+    expect(result).toBe("from-fiber"); // the failed callback write left the bag untouched
+  });
+});
+
+describe("contextLocal — type invariance", () => {
+  test("ContextLocal<T> is invariant in T (a subtype slot is not a supertype slot)", () => {
+    type Animal = { name: string };
+    type Dog = { name: string; bark(): void };
+    const dogSlot = contextLocal<Dog>();
+    // If `set` were checked bivariantly (method syntax), this widening
+    // would be wrongly accepted, letting set() store a bare Animal while
+    // get() still claims Dog. Arrow-property fields make it a type error.
+    // @ts-expect-error ContextLocal is invariant in T — no unsound widening.
+    const animalSlot: ContextLocal<Animal> = dogSlot;
+    void animalSlot;
+  });
+});
+
+describe("contextLocal — determinism", () => {
+  test("a value derived from a journaled result flows through deterministically", async () => {
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>();
+    const d = deferred<string>();
+    const f = sched.makeJournalFuture(d.promise);
+    const op = gen(function* () {
+      const v = yield* f; // journal source (replays identically)
+      slot.set(v);
+      return slot.get();
+    });
+    d.resolve("journaled");
+    expect(await sched.run(op)).toBe("journaled");
+  });
+
+  test("a value set before a suspension point is re-derived the same way", async () => {
+    // Models replay: the body re-runs from the top and re-sets the slot
+    // from the same (journaled) inputs, so the read after the await is
+    // stable. Here the deferred stands in for the journal entry.
+    const sched = new Scheduler(testLib);
+    const slot = contextLocal<string>("unset");
+    const gate = deferred<void>();
+    const f = sched.makeJournalFuture(gate.promise);
+    const op = gen(function* () {
+      slot.set("set-before-await");
+      yield* f; // suspension point
+      return slot.get();
+    });
+    gate.resolve();
+    expect(await sched.run(op)).toBe("set-before-await");
+  });
+});


### PR DESCRIPTION
## What

Adds `contextLocal<T>(default?)` to `@restatedev/restate-sdk-gen`: an ambient key/value slot whose `get`/`set` read and write a bag scoped to the current `execute()` call and shared by **every fiber under it** (the main routine, everything it `spawn`s, and the synthetic fibers behind combinator fallbacks). It lets request-scoped context — a correlation id, a tenant, a logging prefix — flow through deeply nested helpers and spawned routines without threading a parameter through every call.

```ts
const requestId = contextLocal<string>();         // define once, at module scope
const tenant = contextLocal<string>("public");     // with a default

const auditedStep = (label: string) =>
  gen(function* () {
    const line = `[${requestId.get()} | ${tenant.get()}] ${label}`;  // ambient read
    return yield* run(async () => line, { name: label });
  });

const handler = gen(function* () {
  requestId.set(yield* run(() => newRequestId(), { name: "reqid" }));
  const a = yield* auditedStep("validate");        // sees requestId
  const b = yield* spawn(auditedStep("notify"));    // so does a spawned routine
  return [a, b];
});
```

## Design: global per invocation, not per-fiber

We deliberately chose the global-per-invocation flavor over a per-fiber, spawn-tree-inherited model (the Kotlin-`CoroutineContext` / Go-`context.Context` flavor):

- Within a single fiber a closure variable already threads a value through any depth of nested `gen` bodies (the body runs synchronously between yields). The feature only earns its keep **across the spawn boundary**, where the dominant use ("set a correlation id at the top, read it in helpers and workers") wants **sharing**, which global gives directly.
- The bag lives on the `Scheduler` (one per `execute()`, like `fibers`/`ready`), so the change is **a `Map` plus two accessors** — it touches **none** of the fiber/scheduler invariants (I1–I4 / S1–S3), the interrupt cascade, or `finish` re-homing.
- **In-memory only, never journaled.** Deterministic across replay/suspension because the body re-runs from the top and re-`set`s the same values in a replay-stable order (route raw I/O through `run` first, as with any local).
- Forward-compatible: the `get`/`set` surface is identical whether resolution reads one bag or walks the fiber tree, so a per-strand variant could be added later as a separate handle kind without changing call sites.

For state that must **outlive** the invocation, `state()`/`sharedState()` remain the durable option. `DESIGN.md` records the full rationale.

## Notes from the adversarial review

A multi-lens gap-hunt (determinism, isolation, types, edges, coverage, docs) surfaced and I addressed:

- **Type soundness:** `ContextLocal<T>` uses **arrow-property fields**, not method shorthand — method params are bivariant, which would let `ContextLocal<Dog>` be treated as `ContextLocal<Animal>` and a widened `set` poison a `get` that still claims `Dog`. A `@ts-expect-error` test locks the invariance in.
- **`ops.run`-closure boundary:** `get`/`set` run on the fiber's synchronous advance span; calling them from inside a `run` closure runs **off-advance** and throws. Verified against the SDK (`ctx.run` *registers* the closure and returns, so it executes after the fiber has parked and `CURRENT` is cleared). Documented + pinned by both a unit test and an e2e handler.

## Tests / docs

- **23 unit tests:** basics, falsy round-trip (`0`/`""`/`false`/`null` past a default), sharing across fibers, last-write-wins, invocation isolation (incl. two **interleaved** schedulers validating the module-global `CURRENT` design), off-advance throws, type invariance.
- **e2e** (default + `alwaysReplay`): value survives a `sleep`/replay boundary, shared into nested + spawned, per-invocation isolation, run-closure boundary.
- Tutorial tier `12-context.ts` (wired into the server), `guide.md` / `DESIGN.md` / `README.md` sections, changeset (minor).

Local verification: typecheck, `eslint .`, prettier, full unit suite (335), `tsdown` build, API Extractor, ATTW — all green. (e2e runs in CI; it needs Docker.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)