### PR TITLE
tunnel: accept multi-label (BYOC) regions in connectTunnel

### DIFF
--- a/packages/libs/restate-sdk-tunnel/src/options.ts
+++ b/packages/libs/restate-sdk-tunnel/src/options.ts
@@ -185,7 +185,10 @@ export function resolveOptions(options: ConnectTunnelOptions): ResolvedOptions {
       "tunnel: specify exactly one of `region`, `tunnelServersSrv` or `tunnelServers`"
     );
   }
-  if (hasRegion && !/^[a-z0-9-]+$/.test(region!)) {
+  // A region becomes DNS labels in `tunnel.{region}.restate.cloud`, so it may be
+  // multi-label (e.g. a BYOC region like "inl4edhpbxasp9yuz1n0yvvkme.byoc") —
+  // each label lowercase [a-z0-9-], dot-separated, no empty labels.
+  if (hasRegion && !/^[a-z0-9-]+(\.[a-z0-9-]+)*$/.test(region!)) {
     throw new Error(`tunnel: invalid region ${JSON.stringify(region)}`);
   }
   if (hasSrv && !/^[A-Za-z0-9._-]+$/.test(options.tunnelServersSrv!)) {

--- a/packages/libs/restate-sdk-tunnel/test/options.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/options.test.ts
@@ -79,6 +79,24 @@ describe("resolveOptions — validation", () => {
     expect(r.tls).toBe(true);
   });
 
+  test("accepts a multi-label (BYOC) region", () => {
+    const r = resolveOptions({
+      ...valid,
+      region: "inl4edhpbxasp9yuz1n0yvvkme.byoc",
+    });
+    expect(r.srvName).toBe(
+      "tunnel.inl4edhpbxasp9yuz1n0yvvkme.byoc.restate.cloud"
+    );
+  });
+
+  test("rejects a malformed region", () => {
+    for (const region of ["US", "us/extra", ".us", "us.", "us..eu"]) {
+      expect(() => resolveOptions({ ...valid, region })).toThrow(
+        /invalid region/
+      );
+    }
+  });
+
   test("rejects neither region nor tunnelServers", () => {
     expect(() => resolveOptions({ ...valid, region: undefined })).toThrow(
       new RegExp(`specify one of .*${CLOUD_REGION_ENV}`)


### PR DESCRIPTION
## What

`resolveOptions` validated `region` as a single DNS label (`/^[a-z0-9-]+$/`), so `connectTunnel` threw `tunnel: invalid region` for a multi-label BYOC region like `inl4edhpbxasp9yuz1n0yvvkme.byoc` — even though `region` only ever forms DNS labels in `tunnel.{region}.restate.cloud`, and `tunnelServersSrv`/`tunnelName` already allow dots.

Accept dot-separated multi-label regions (`/^[a-z0-9-]+(\.[a-z0-9-]+)*$/`, no empty labels). Malformed regions (`US`, `us/extra`, `.us`, `us.`, `us..eu`) still reject.

## Tests

Adds a multi-label-region acceptance test (asserts the resolved `srvName`) and a malformed-region reject test. `vitest run options` → 33 passed.

## Validation

Validated end-to-end against a live BYOC env via the restate-operator's in-process tunnel mode: pods connect to `tunnel.inl4edhpbxasp9yuz1n0yvvkme.byoc.restate.cloud` and the deployment auto-registers (invocations route, 200s).

Companion change: **restate-operator** had the identical region check (`RestateCloudEnvironment` in-process validation) — see its PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)