### PR TITLE
Drain in-process tunnel on client shutdown

### DIFF
--- a/packages/libs/restate-sdk-tunnel/README.md
+++ b/packages/libs/restate-sdk-tunnel/README.md
@@ -80,6 +80,36 @@ connection failure, not a crash). Mount the Secret as a whole volume rather
 than via `subPath` — Kubernetes does not update `subPath` mounts in place, so
 a rotated token would never reach the file.
 
+### Kubernetes shutdown and eviction
+
+Client-side graceful shutdown is on by default. On `SIGTERM`,
+`connectTunnel` calls `shutdown()`: each established tunnel session sends an
+HTTP/2 GOAWAY immediately so Restate Cloud stops opening new streams on that
+connection, any raced streams are refused with
+`x-restate-tunnel-draining: true`, in-flight invocations are allowed to finish
+for `drainGraceMs` (default 120s), then the session is closed gracefully. If
+the grace expires first, the session/socket is force-closed.
+
+Set the pod's `terminationGracePeriodSeconds` to at least
+`ceil(drainGraceMs / 1000)` plus the longest handler drain slack you are
+prepared to allow. Kubernetes sends `SIGTERM` first and sends `SIGKILL` when
+the pod grace period expires; a too-short pod grace period will cut off the
+SDK's drain.
+
+On managed Kubernetes platforms, also account for the effective grace window
+the platform grants for the specific eviction event. The SDK can only drain for
+the smaller of `drainGraceMs`, the pod's `terminationGracePeriodSeconds`, and
+the grace the platform actually grants. Some providers document event-specific
+limits; for example,
+[GKE Autopilot documents bounded grace for GKE-initiated evictions](https://cloud.google.com/kubernetes-engine/docs/how-to/extended-duration-pods#about_gke-initiated_pod_eviction).
+Validate this path in your deployment environment by confirming `SIGTERM`
+reaches Node and the process remains alive long enough to complete the drain.
+
+Run the Node process as the container's main process with an exec-form
+`ENTRYPOINT`/`CMD`, or use a small init wrapper such as `tini`/`dumb-init` if
+your image starts through a shell or spawns child processes. The SDK installs
+the `SIGTERM` handler, but wrappers still need to forward signals to Node.
+
 ## How it works
 
 `connectTunnel` is the in-process analog of Restate Cloud's standalone
@@ -114,6 +144,12 @@ a rotated token would never reach the file.
    immediately dials a replacement while the old connection keeps serving
    its in-flight invocations (up to `drainGraceMs`, default 120s) — zero
    dropped requests across cloud rollovers.
+8. **Shut down gracefully:** the engine advertises `supports-client-drain`.
+   On `shutdown()` or the default `SIGTERM` handler, each live connection
+   sends HTTP/2 GOAWAY proactively, refuses any raced streams with the drain
+   sentinel, drains in-flight invocations up to `drainGraceMs`, and then
+   closes the h2 session gracefully. The final forced close is only used after
+   the grace window expires.
 
 ## API
 
@@ -122,6 +158,7 @@ function connectTunnel(options: ConnectTunnelOptions): TunnelConnection;
 
 interface TunnelConnection {
   close(): Promise<void>; // stop reconnecting + close
+  shutdown(opts?: { graceMs?: number }): Promise<void>; // graceful drain + close
   readonly ready: Promise<void>; // first successful handshake (rejects on fatal)
   readonly connectionCount: number;
   readonly tunnelName: string | undefined; // learned from the handshake
@@ -147,6 +184,7 @@ Key options (see `ConnectTunnelOptions` for the full surface and defaults):
 | `connectTimeoutMs`                              | TCP+TLS dial deadline (5s, mirrors the standalone client)                   |
 | `reconnectInitialMs/MaxMs/Factor`               | Jittered exponential backoff (10ms → 120s, reset after a stable connection) |
 | `supportsDrain` / `drainGraceMs`                | Graceful-drain handover on cloud rollovers (on, 120s grace)                 |
+| `supportsClientDrain` / `gracefulShutdown`      | Client shutdown drain with h2 GOAWAY and default `SIGTERM` handling         |
 | `pingIntervalMs/TimeoutMs/MaxMissed`            | Liveness watchdog (75s cadence)                                             |
 | `maxConcurrentStreams` etc.                     | HTTP/2 tuning for high-concurrency serving                                  |
 

--- a/packages/libs/restate-sdk-tunnel/README.md
+++ b/packages/libs/restate-sdk-tunnel/README.md
@@ -69,9 +69,13 @@ also gets a generated `tunnel-connection-id`; both ids are sent during the
 tunnel handshake for diagnostics only.
 
 If your process has asynchronous startup work before it can safely execute
-handlers, pass `startupReady`. The tunnel supervisor waits for that promise or
-callback before it dials any tunnel server, so the tunnel-server cannot select
-the pod before the in-process handler is ready.
+handlers, pass `startupReady` or call `connectTunnel` only after that work has
+completed. Without `startupReady`, the tunnel dials immediately. With it, the
+tunnel supervisor waits for the promise or callback before it dials any tunnel
+server, so the tunnel-server cannot select the pod before the in-process
+handler is ready. A stuck startup gate fails fatally after
+`startupReadyTimeoutMs` (default 120s), making a broken worker visible instead
+of silently absent from the fleet.
 
 The [restate-operator](https://github.com/restatedev/restate-operator)
 injects the first four into the pods of a `tunnelMode: in-process`
@@ -195,6 +199,7 @@ Key options (see `ConnectTunnelOptions` for the full surface and defaults):
 | `tunnelName`                                    | The deployment's identity — unique per deployment, shared by its replicas   |
 | `tunnelWorkerId`                                | Stable SDK worker/process diagnostic id; defaults to `RESTATE_TUNNEL_WORKER_ID` or hostname-based |
 | `startupReady`                                  | One-shot startup readiness gate; no tunnel connections are dialed until it completes |
+| `startupReadyTimeoutMs`                         | Fatal deadline for `startupReady` (120s; only used when `startupReady` is set) |
 | `services`                                      | Same shape `restate.serve` accepts                                          |
 | `tls`                                           | Default on (system trust, ALPN `h2`); object form for CA/mTLS               |
 | `connectTimeoutMs`                              | TCP+TLS dial deadline (5s, mirrors the standalone client)                   |

--- a/packages/libs/restate-sdk-tunnel/README.md
+++ b/packages/libs/restate-sdk-tunnel/README.md
@@ -62,6 +62,12 @@ environment variables when not given (option > environment > throw):
 | `signingPublicKey` | `RESTATE_INPROC_SIGNING_PUBLIC_KEY`                            |
 | `authToken`        | the file named by `RESTATE_INPROC_AUTH_TOKEN_FILE` (see below) |
 
+For operator log attribution, set `tunnelWorkerId` or
+`RESTATE_TUNNEL_WORKER_ID` to a stable worker/pod identifier. When omitted,
+the SDK derives a process-stable, hostname-based id. Each h2 tunnel connection
+also gets a generated `tunnel-connection-id`; both ids are sent during the
+tunnel handshake for diagnostics only.
+
 The [restate-operator](https://github.com/restatedev/restate-operator)
 injects the first four into the pods of a `tunnelMode: in-process`
 RestateDeployment — with a per-revision `tunnelName` — and registers the
@@ -125,8 +131,9 @@ the `SIGTERM` handler, but wrappers still need to forward signals to Node.
 2. **Role-flip:** Restate Cloud drives HTTP/2 as the _client_ over the
    connection we dialed; the deployment becomes the HTTP/2 _server_ on it.
 3. **Handshake:** the cloud opens `GET /_/start-tunnel`; we answer with the
-   environment credentials and receive the tunnel confirmation (including
-   the public `proxy-url`) as HTTP/2 trailers.
+   environment credentials plus advisory diagnostic ids
+   (`tunnel-worker-id` and `tunnel-connection-id`) and receive the tunnel
+   confirmation (including the public `proxy-url`) as HTTP/2 trailers.
 4. **Serve:** each invocation arrives as one HTTP/2 stream. The tunnel's
    `/<scheme>/<host>/<port>` destination prefix is stripped and the request
    is handed to the SDK's own endpoint handler (full-duplex streaming —
@@ -179,6 +186,7 @@ Key options (see `ConnectTunnelOptions` for the full surface and defaults):
 | `authToken`                                     | Cloud API key (`key_...`, Full role) presented in the handshake             |
 | `signingPublicKey`                              | `publickeyv1_...` — request-identity verification (required)                |
 | `tunnelName`                                    | The deployment's identity — unique per deployment, shared by its replicas   |
+| `tunnelWorkerId`                                | Stable SDK worker/process diagnostic id; defaults to `RESTATE_TUNNEL_WORKER_ID` or hostname-based |
 | `services`                                      | Same shape `restate.serve` accepts                                          |
 | `tls`                                           | Default on (system trust, ALPN `h2`); object form for CA/mTLS               |
 | `connectTimeoutMs`                              | TCP+TLS dial deadline (5s, mirrors the standalone client)                   |

--- a/packages/libs/restate-sdk-tunnel/README.md
+++ b/packages/libs/restate-sdk-tunnel/README.md
@@ -103,7 +103,15 @@ HTTP/2 GOAWAY immediately so Restate Cloud stops opening new streams on that
 connection, any raced streams are refused with
 `x-restate-tunnel-draining: true`, in-flight invocations are allowed to finish
 for `drainGraceMs` (default 120s), then the session is closed gracefully. If
-the grace expires first, the session/socket is force-closed.
+the grace expires first, the session/socket is force-closed. Once the
+registered tunnels in the process finish draining, the default signal handler
+calls `process.exit(0)`.
+
+If a process creates multiple tunnels with default signal handling, one shared
+process-level signal handler drains all tunnels registered for that signal
+before exiting. Embedded applications that need to coordinate other shutdown
+work should pass `gracefulShutdown: false`, handle signals themselves, call
+`shutdown()` on every tunnel, and exit only after their own cleanup is complete.
 
 Set the pod's `terminationGracePeriodSeconds` to at least
 `ceil(drainGraceMs / 1000)` plus the longest handler drain slack you are

--- a/packages/libs/restate-sdk-tunnel/README.md
+++ b/packages/libs/restate-sdk-tunnel/README.md
@@ -68,6 +68,11 @@ the SDK derives a process-stable, hostname-based id. Each h2 tunnel connection
 also gets a generated `tunnel-connection-id`; both ids are sent during the
 tunnel handshake for diagnostics only.
 
+If your process has asynchronous startup work before it can safely execute
+handlers, pass `startupReady`. The tunnel supervisor waits for that promise or
+callback before it dials any tunnel server, so the tunnel-server cannot select
+the pod before the in-process handler is ready.
+
 The [restate-operator](https://github.com/restatedev/restate-operator)
 injects the first four into the pods of a `tunnelMode: in-process`
 RestateDeployment — with a per-revision `tunnelName` — and registers the
@@ -137,7 +142,9 @@ the `SIGTERM` handler, but wrappers still need to forward signals to Node.
 4. **Serve:** each invocation arrives as one HTTP/2 stream. The tunnel's
    `/<scheme>/<host>/<port>` destination prefix is stripped and the request
    is handed to the SDK's own endpoint handler (full-duplex streaming —
-   `BIDI_STREAM`), exactly as if it had arrived on a local listener.
+   `BIDI_STREAM`), exactly as if it had arrived on a local listener. For
+   `connectTunnel`, the `/http/in-process/9080/` deployment URL segment is
+   vestigial: this package does not dial a local `:9080` socket.
 5. **Verify:** every forwarded request carries Restate's request-identity
    JWT (`x-restate-jwt-v1`). Verification is delegated to the SDK against
    `signingPublicKey`, so only requests signed by _your_ environment are
@@ -187,6 +194,7 @@ Key options (see `ConnectTunnelOptions` for the full surface and defaults):
 | `signingPublicKey`                              | `publickeyv1_...` — request-identity verification (required)                |
 | `tunnelName`                                    | The deployment's identity — unique per deployment, shared by its replicas   |
 | `tunnelWorkerId`                                | Stable SDK worker/process diagnostic id; defaults to `RESTATE_TUNNEL_WORKER_ID` or hostname-based |
+| `startupReady`                                  | One-shot startup readiness gate; no tunnel connections are dialed until it completes |
 | `services`                                      | Same shape `restate.serve` accepts                                          |
 | `tls`                                           | Default on (system trust, ALPN `h2`); object form for CA/mTLS               |
 | `connectTimeoutMs`                              | TCP+TLS dial deadline (5s, mirrors the standalone client)                   |

--- a/packages/libs/restate-sdk-tunnel/src/connect.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connect.ts
@@ -76,22 +76,22 @@ class InflightTracker {
     }
   }
 
-  /** Resolve once nothing is in flight, or after `graceMs` — whichever first.
+  /** Resolve true once nothing is in flight, or false after `graceMs`.
    * Only one shutdown runs at a time, so a single waiter suffices. */
-  whenDrained(graceMs: number): Promise<void> {
+  whenDrained(graceMs: number): Promise<boolean> {
     return new Promise((resolve) => {
       if (this.count === 0) {
-        resolve();
+        resolve(true);
         return;
       }
       const timer = setTimeout(() => {
         this.notifyDrained = undefined;
-        resolve();
+        resolve(false);
       }, graceMs);
       timer.unref();
       this.notifyDrained = () => {
         clearTimeout(timer);
-        resolve();
+        resolve(true);
       };
     });
   }
@@ -184,8 +184,18 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
     activeConnections,
     onEstablished: (info) => {
       if (state.kind === "closed") return;
+      const firstConnection = output.connectionCount === 0;
       output.connectionCount++;
       output.lastInfo = info;
+      if (firstConnection) {
+        log(
+          `tunnel: service ready (name=${info.tunnelName}, proxy=${info.proxyUrl}, tunnel=${info.tunnelUrl})`
+        );
+      } else {
+        log(
+          `tunnel: additional connection ready (connections=${output.connectionCount}, name=${info.tunnelName})`
+        );
+      }
       ready.resolve();
     },
     isShuttingDown: () => state.kind === "draining",
@@ -252,8 +262,17 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
     log(
       `tunnel: graceful shutdown — refusing new invocations, draining ${inflight.inFlight} in-flight`
     );
-    await inflight.whenDrained(graceMs);
-    // In-flight drained (or grace elapsed): tear the now-idle connections down.
+    const drained = await inflight.whenDrained(graceMs);
+    // In-flight drained: ask h2 to close cleanly. Grace elapsed: force the
+    // still-open sessions down, which tears down any stuck streams.
+    await Promise.all(
+      [...activeConnections].map((c) =>
+        c.finishClientDrain({ force: !drained })
+      )
+    );
+    // Now tear down the supervisor and any idle retry loops. For the graceful
+    // case the live h2 sessions have already closed; for the forced case this
+    // is idempotent cleanup.
     teardown();
     await done;
   };

--- a/packages/libs/restate-sdk-tunnel/src/connect.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connect.ts
@@ -154,6 +154,17 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
   const log = resolvedOptions.logger;
   const logWithWorker = (message: string) =>
     log(`${message} (worker_id=${resolvedOptions.tunnelWorkerId})`);
+  let startupReady = resolvedOptions.startupReady === undefined;
+  const opts = {
+    ...resolvedOptions,
+    startupReady:
+      resolvedOptions.startupReady === undefined
+        ? undefined
+        : async () => {
+            await resolvedOptions.startupReady!();
+            startupReady = true;
+          },
+  };
 
   // Injected infrastructure: the per-connection layer reads these via deps.
   const activeSockets = new Set<net.Socket>();
@@ -183,7 +194,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
   const signalHandlers: Array<[NodeJS.Signals, () => void]> = [];
 
   const connectionDeps: ConnectionDeps = {
-    opts: resolvedOptions,
+    opts,
     sdkHandler,
     draining,
     activeSockets,
@@ -205,12 +216,13 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
       ready.resolve();
     },
     isShuttingDown: () => state.kind === "draining",
+    isStartupReady: () => startupReady,
     inflightStarted: () => inflight.started(),
     inflightEnded: () => inflight.ended(),
   };
 
   const supervisor = new Supervisor(
-    resolvedOptions,
+    opts,
     connectionDeps,
     {
       onFatal: (err) => {

--- a/packages/libs/restate-sdk-tunnel/src/connect.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connect.ts
@@ -126,6 +126,66 @@ type EngineState =
     }
   | { readonly kind: "closed" };
 
+interface SignalShutdownParticipant {
+  shutdown(signal: NodeJS.Signals): Promise<void>;
+}
+
+const signalShutdownRegistrations = new Map<
+  NodeJS.Signals,
+  Set<SignalShutdownParticipant>
+>();
+const signalShutdownHandlers = new Map<NodeJS.Signals, () => void>();
+let signalShutdownInProgress = false;
+
+async function runGracefulShutdownSignal(
+  signal: NodeJS.Signals
+): Promise<void> {
+  if (signalShutdownInProgress) return;
+  signalShutdownInProgress = true;
+  const registrations = [
+    ...(signalShutdownRegistrations.get(signal) ?? []),
+  ];
+  await Promise.allSettled(registrations.map((entry) => entry.shutdown(signal)));
+  try {
+    process.exit(0);
+  } finally {
+    // Tests stub process.exit(); real process.exit() does not return.
+    signalShutdownInProgress = false;
+  }
+}
+
+function registerGracefulShutdownSignals(
+  signals: NodeJS.Signals[],
+  participant: SignalShutdownParticipant
+): () => void {
+  const unregisters = signals.map((signal) => {
+    let registrations = signalShutdownRegistrations.get(signal);
+    if (registrations === undefined) {
+      registrations = new Set();
+      signalShutdownRegistrations.set(signal, registrations);
+    }
+    registrations.add(participant);
+    if (!signalShutdownHandlers.has(signal)) {
+      const handler = () => void runGracefulShutdownSignal(signal);
+      signalShutdownHandlers.set(signal, handler);
+      process.once(signal, handler);
+    }
+    return () => {
+      const current = signalShutdownRegistrations.get(signal);
+      if (current === undefined) return;
+      current.delete(participant);
+      if (current.size > 0) return;
+      const handler = signalShutdownHandlers.get(signal);
+      if (handler !== undefined) process.removeListener(signal, handler);
+      signalShutdownHandlers.delete(signal);
+      signalShutdownRegistrations.delete(signal);
+    };
+  });
+  return () => {
+    for (const unregister of unregisters) unregister();
+  };
+}
+
 /**
  * Connect this deployment to a Restate Cloud tunnel and serve `services`
  * over it. Returns immediately; connection management runs in the
@@ -154,7 +214,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
   const log = resolvedOptions.logger;
   const logWithWorker = (message: string) =>
     log(`${message} (worker_id=${resolvedOptions.tunnelWorkerId})`);
-  let startupReady = resolvedOptions.startupReady === undefined;
+  let startupGatePassed = resolvedOptions.startupReady === undefined;
   const opts = {
     ...resolvedOptions,
     startupReady:
@@ -162,7 +222,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
         ? undefined
         : async () => {
             await resolvedOptions.startupReady!();
-            startupReady = true;
+            startupGatePassed = true;
           },
   };
 
@@ -189,9 +249,9 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
   // closures only read it at runtime, long after.
   let state: EngineState;
 
-  // Opt-in process-signal handlers, removed on teardown so a closed connection
-  // can never later intercept a signal and exit the host process.
-  const signalHandlers: Array<[NodeJS.Signals, () => void]> = [];
+  // Opt-in process-signal registrations, removed on teardown so a closed
+  // connection can never later intercept a signal and exit the host process.
+  const signalUnregisters: Array<() => void> = [];
 
   const connectionDeps: ConnectionDeps = {
     opts,
@@ -216,7 +276,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
       ready.resolve();
     },
     isShuttingDown: () => state.kind === "draining",
-    isStartupReady: () => startupReady,
+    isStartupReady: () => startupGatePassed,
     inflightStarted: () => inflight.started(),
     inflightEnded: () => inflight.ended(),
   };
@@ -245,10 +305,8 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
     if (state.kind === "closed") return;
     const { supervisor, keepAlive } = state.active;
     state = { kind: "closed" };
-    for (const [signal, handler] of signalHandlers) {
-      process.removeListener(signal, handler);
-    }
-    signalHandlers.length = 0;
+    for (const unregister of signalUnregisters) unregister();
+    signalUnregisters.length = 0;
     supervisor.abortAll();
     for (const socket of activeSockets) socket.destroy();
     activeSockets.clear();
@@ -328,14 +386,14 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
   // connection that is already closed.
   if (resolvedOptions.gracefulShutdown !== undefined) {
     const { signals, graceMs } = resolvedOptions.gracefulShutdown;
-    for (const signal of signals) {
-      const handler = () => {
-        logWithWorker(`tunnel: received ${signal} — shutting down gracefully`);
-        void shutdown({ graceMs }).finally(() => process.exit(0));
-      };
-      signalHandlers.push([signal, handler]);
-      process.once(signal, handler);
-    }
+    signalUnregisters.push(
+      registerGracefulShutdownSignals(signals, {
+        async shutdown(signal) {
+          logWithWorker(`tunnel: received ${signal} — shutting down gracefully`);
+          await shutdown({ graceMs });
+        },
+      })
+    );
   }
 
   if (options.signal?.aborted) {

--- a/packages/libs/restate-sdk-tunnel/src/connect.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connect.ts
@@ -44,7 +44,11 @@ import { createEndpointHandler } from "@restatedev/restate-sdk";
 import type { ConnectTunnelOptions, TunnelConnection } from "./types.js";
 import { resolveOptions } from "./options.js";
 import type { HandshakeInfo } from "./handshake.js";
-import { type ConnectionDeps, type DrainableConnection } from "./connection.js";
+import {
+  type ConnectionDeps,
+  type ConnectionIdentity,
+  type DrainableConnection,
+} from "./connection.js";
 import { DrainingRegistry } from "./draining.js";
 import { Supervisor } from "./supervisor.js";
 import { Deferred } from "./util.js";
@@ -148,6 +152,8 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
 
   // Logger used for debugging the tunnel
   const log = resolvedOptions.logger;
+  const logWithWorker = (message: string) =>
+    log(`${message} (worker_id=${resolvedOptions.tunnelWorkerId})`);
 
   // Injected infrastructure: the per-connection layer reads these via deps.
   const activeSockets = new Set<net.Socket>();
@@ -182,18 +188,18 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
     draining,
     activeSockets,
     activeConnections,
-    onEstablished: (info) => {
+    onEstablished: (info, identity: ConnectionIdentity) => {
       if (state.kind === "closed") return;
       const firstConnection = output.connectionCount === 0;
       output.connectionCount++;
       output.lastInfo = info;
       if (firstConnection) {
         log(
-          `tunnel: service ready (name=${info.tunnelName}, proxy=${info.proxyUrl}, tunnel=${info.tunnelUrl})`
+          `tunnel: service ready (name=${info.tunnelName}, proxy=${info.proxyUrl}, tunnel=${info.tunnelUrl}, worker_id=${identity.workerId}, connection_id=${identity.connectionId}, target=${identity.target})`
         );
       } else {
         log(
-          `tunnel: additional connection ready (connections=${output.connectionCount}, name=${info.tunnelName})`
+          `tunnel: additional connection ready (connections=${output.connectionCount}, name=${info.tunnelName}, worker_id=${identity.workerId}, connection_id=${identity.connectionId}, target=${identity.target})`
         );
       }
       ready.resolve();
@@ -212,7 +218,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
         ready.reject(err);
       },
     },
-    log
+    logWithWorker
   );
 
   const keepAlive = setInterval(() => {}, 0x7fffffff);
@@ -259,7 +265,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
     // Snapshot — beginClientDrain may settle a connection, removing it.
     supervisor.stopResolving();
     for (const c of [...activeConnections]) c.beginClientDrain();
-    log(
+    logWithWorker(
       `tunnel: graceful shutdown — refusing new invocations, draining ${inflight.inFlight} in-flight`
     );
     const drained = await inflight.whenDrained(graceMs);
@@ -312,7 +318,7 @@ export function connectTunnel(options: ConnectTunnelOptions): TunnelConnection {
     const { signals, graceMs } = resolvedOptions.gracefulShutdown;
     for (const signal of signals) {
       const handler = () => {
-        log(`tunnel: received ${signal} — shutting down gracefully`);
+        logWithWorker(`tunnel: received ${signal} — shutting down gracefully`);
         void shutdown({ graceMs }).finally(() => process.exit(0));
       };
       signalHandlers.push([signal, handler]);

--- a/packages/libs/restate-sdk-tunnel/src/connection.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connection.ts
@@ -44,6 +44,7 @@
 import * as net from "node:net";
 import * as tls from "node:tls";
 import * as http2 from "node:http2";
+import { randomBytes } from "node:crypto";
 
 import type { ResolvedOptions } from "./options.js";
 import { buildTlsConnectOptions } from "./options.js";
@@ -74,6 +75,28 @@ export type ConnectionOutcome =
 export type DrainTrigger = "server" | "client";
 
 const CLIENT_DRAIN_SESSION_CLOSE_TIMEOUT_MS = 1_000;
+const CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function encodeBase32(value: bigint, length: number): string {
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out = CROCKFORD_BASE32.charAt(Number(value & 31n)) + out;
+    value >>= 5n;
+  }
+  return out;
+}
+
+function newTunnelConnectionId(): string {
+  let random = 0n;
+  for (const byte of randomBytes(10)) {
+    random = (random << 8n) | BigInt(byte);
+  }
+  return `${encodeBase32(BigInt(Date.now()), 10)}${encodeBase32(random, 16)}`;
+}
+
+function formatIdentity(workerId: string, connectionId: string): string {
+  return `worker_id=${workerId} connection_id=${connectionId}`;
+}
 
 function targetLabel(target: Target): string {
   return `${target.host}:${target.port}`;
@@ -116,6 +139,12 @@ export interface DrainableConnection {
   finishClientDrain(opts: { force: boolean }): Promise<void>;
 }
 
+export interface ConnectionIdentity {
+  workerId: string;
+  connectionId: string;
+  target: string;
+}
+
 /** What a connection attempt needs from the engine. */
 export interface ConnectionDeps {
   opts: ResolvedOptions;
@@ -128,7 +157,7 @@ export interface ConnectionDeps {
   /** Live connections the engine can ask to drain on shutdown(). */
   activeConnections: Set<DrainableConnection>;
   /** Called once per successful handshake (count, learned info, ready). */
-  onEstablished: (info: HandshakeInfo) => void;
+  onEstablished: (info: HandshakeInfo, identity: ConnectionIdentity) => void;
   /**
    * True once the engine is gracefully shutting down: new forwarded
    * invocations are refused with the drain sentinel instead of dispatched, so
@@ -283,9 +312,11 @@ function dial(
   target: Target,
   deps: ConnectionDeps,
   plaintext: boolean,
-  signal: AbortSignal
+  signal: AbortSignal,
+  connectionId: string
 ): Promise<DialResult> {
   const log = deps.opts.logger;
+  const identity = formatIdentity(deps.opts.tunnelWorkerId, connectionId);
   const tlsOptions = plaintext
     ? undefined
     : buildTlsConnectOptions(deps.opts.tls, target.servername);
@@ -313,7 +344,7 @@ function dial(
       if (done) return;
       done = true;
       cleanup();
-      log(`tunnel: failed to connect to ${label}: ${reason}`);
+      log(`tunnel: failed to connect to ${label}: ${reason} (${identity})`);
       socket.destroy();
       resolve({ ok: false, outcome: { kind: "retryable", reason } });
     }
@@ -337,7 +368,7 @@ function dial(
       }
       done = true;
       cleanup();
-      log(`tunnel: connected socket to ${label} (${alpn})`);
+      log(`tunnel: connected socket to ${label} (${alpn}, ${identity})`);
       resolve({ ok: true, socket });
     });
   });
@@ -376,6 +407,7 @@ class ConnectionAttempt implements DrainableConnection {
 
   private readonly plaintext: boolean;
   private readonly log: (message: string) => void;
+  private readonly connectionId = newTunnelConnectionId();
 
   constructor(
     private readonly target: Target,
@@ -385,6 +417,22 @@ class ConnectionAttempt implements DrainableConnection {
   ) {
     this.log = deps.opts.logger;
     this.plaintext = target.plaintext ?? deps.opts.tls === false;
+  }
+
+  private get identity(): ConnectionIdentity {
+    return {
+      workerId: this.deps.opts.tunnelWorkerId,
+      connectionId: this.connectionId,
+      target: targetLabel(this.target),
+    };
+  }
+
+  private identityLog(): string {
+    return formatIdentity(this.deps.opts.tunnelWorkerId, this.connectionId);
+  }
+
+  private logWithIdentity(message: string): void {
+    this.log(`${message} (${this.identityLog()})`);
   }
 
   run(): Promise<ConnectionOutcome> {
@@ -400,7 +448,8 @@ class ConnectionAttempt implements DrainableConnection {
       this.target,
       this.deps,
       this.plaintext,
-      this.slotSignal
+      this.slotSignal,
+      this.connectionId
     );
     // A client-drain (shutdown) or abort may have settled us mid-dial.
     if (this.completion.settled) {
@@ -498,7 +547,7 @@ class ConnectionAttempt implements DrainableConnection {
     session?.destroy();
     this.socket?.destroy();
     const firstOutcome = this.completion.resolve(outcome);
-    this.log(
+    this.logWithIdentity(
       `tunnel: connection to ${targetLabel(this.target)} closed (phase=${phase}, outcome=${formatConnectionOutcome(outcome)}${
         detail === undefined ? "" : `, detail=${detail}`
       }${firstOutcome ? "" : ", already reported"})`
@@ -543,11 +592,11 @@ class ConnectionAttempt implements DrainableConnection {
     if (session.closed || session.destroyed) return;
     try {
       session.goaway(http2.constants.NGHTTP2_NO_ERROR);
-      this.log(
+      this.logWithIdentity(
         `tunnel: sent client-drain GOAWAY to ${targetLabel(this.target)}`
       );
     } catch (err) {
-      this.log(
+      this.logWithIdentity(
         `tunnel: failed to send client-drain GOAWAY to ${targetLabel(this.target)}: ${
           err instanceof Error ? err.message : String(err)
         }`
@@ -560,7 +609,7 @@ class ConnectionAttempt implements DrainableConnection {
   // ---- establish: role-flip ----
 
   private establish(socket: net.Socket): void {
-    this.log(
+    this.logWithIdentity(
       `tunnel: connected to ${this.target.host}:${this.target.port}, starting handshake`
     );
 
@@ -578,18 +627,18 @@ class ConnectionAttempt implements DrainableConnection {
     );
 
     h2.on("session", (s) => {
-      this.log(
+      this.logWithIdentity(
         `tunnel: h2 session established to ${targetLabel(this.target)} (localSettings=${formatSettings(
           s.localSettings
         )}, remoteSettings=${formatSettings(s.remoteSettings)})`
       );
       s.on("localSettings", (settings: http2.Settings) =>
-        this.log(
+        this.logWithIdentity(
           `tunnel: h2 local settings acknowledged by ${targetLabel(this.target)}: ${formatSettings(settings)}`
         )
       );
       s.on("remoteSettings", (settings: http2.Settings) =>
-        this.log(
+        this.logWithIdentity(
           `tunnel: h2 remote settings from ${targetLabel(this.target)}: ${formatSettings(settings)}`
         )
       );
@@ -731,6 +780,8 @@ class ConnectionAttempt implements DrainableConnection {
         authToken: this.authToken,
         environmentId: this.deps.opts.environmentId,
         tunnelName: this.deps.opts.tunnelName,
+        tunnelWorkerId: this.deps.opts.tunnelWorkerId,
+        tunnelConnectionId: this.connectionId,
         supportsDrain: this.deps.opts.supportsDrain,
         supportsClientDrain: this.deps.opts.supportsClientDrain,
       },
@@ -747,10 +798,10 @@ class ConnectionAttempt implements DrainableConnection {
         this.state = this.deps.isShuttingDown()
           ? { kind: "draining", session, openedAt, trigger: "client", watchdog }
           : { kind: "serving", session, openedAt, watchdog };
-        this.log(
+        this.logWithIdentity(
           `tunnel: established (name=${outcome.info.tunnelName}, proxy=${outcome.info.proxyUrl})`
         );
-        this.deps.onEstablished(outcome.info);
+        this.deps.onEstablished(outcome.info, this.identity);
         return { ok: true };
       }
       this.settle(outcome);
@@ -772,6 +823,9 @@ class ConnectionAttempt implements DrainableConnection {
     const clientDraining =
       this.state.kind === "draining" && this.state.trigger === "client";
     if (clientDraining || this.deps.isShuttingDown()) {
+      this.logWithIdentity(
+        `tunnel: refused forwarded stream ${res.stream.id ?? "?"} during client drain`
+      );
       res.writeHead(503, { "x-restate-tunnel-draining": "true" });
       res.end();
       return;
@@ -788,7 +842,7 @@ class ConnectionAttempt implements DrainableConnection {
     res.stream.once("close", () => this.deps.inflightEnded());
     const streamId = res.stream.id ?? "?";
     res.stream.once("error", (err: Error) =>
-      this.log(
+      this.logWithIdentity(
         `tunnel: forwarded stream ${streamId} ${req.method ?? "?"} ${
           req.url ?? "?"
         } failed: ${err.message}`
@@ -797,7 +851,7 @@ class ConnectionAttempt implements DrainableConnection {
     try {
       this.deps.sdkHandler(req, res);
     } catch (err) {
-      this.log(
+      this.logWithIdentity(
         `tunnel: SDK handler threw for forwarded stream ${streamId} ${
           req.method ?? "?"
         } ${req.url ?? "?"}: ${err instanceof Error ? err.message : String(err)}`
@@ -811,13 +865,13 @@ class ConnectionAttempt implements DrainableConnection {
   private handleDrainRequest(res: http2.Http2ServerResponse): void {
     res.writeHead(200);
     res.end();
-    this.log(
+    this.logWithIdentity(
       `tunnel: received server drain notification from ${targetLabel(this.target)}`
     );
     if (!this.deps.opts.supportsDrain) {
       // Not advertised, so unexpected — acknowledge and let the server
       // close on us; the slot's redial loop re-establishes.
-      this.log(
+      this.logWithIdentity(
         "tunnel: received /_/drain-tunnel (drain not advertised) — acknowledging"
       );
       return;
@@ -850,7 +904,7 @@ class ConnectionAttempt implements DrainableConnection {
   private beginServerDrain(): void {
     if (this.state.kind !== "serving") return;
     const { session, openedAt, watchdog } = this.state;
-    this.log(
+    this.logWithIdentity(
       "tunnel: server drain notification accepted — opening a replacement connection"
     );
     watchdog.stop(); // the registry owns the session now; stop pinging it
@@ -912,7 +966,7 @@ class ConnectionAttempt implements DrainableConnection {
 
   private startWatchdog(session: http2.Http2Session): Watchdog {
     const watchdog = new Watchdog(session, this.deps.opts, () => {
-      this.log("tunnel: pings missed — reconnecting");
+      this.logWithIdentity("tunnel: pings missed — reconnecting");
       this.settle(
         { kind: "served", uptimeMs: this.uptimeMs() },
         "ping watchdog missed too many acknowledgements"

--- a/packages/libs/restate-sdk-tunnel/src/connection.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connection.ts
@@ -68,9 +68,39 @@ export type ConnectionOutcome =
  *  - `server`: the cloud sent `/_/drain-tunnel` (it is rotating this tunnel
  *    node). We detach + redial; the old session keeps serving in-flight.
  *  - `client`: this process is shutting down (SIGTERM / `shutdown()`). We
- *    refuse new invocations and finish in-flight in place, with no redial.
+ *    send GOAWAY, refuse raced invocations, and finish in-flight in place,
+ *    with no redial.
  */
 export type DrainTrigger = "server" | "client";
+
+const CLIENT_DRAIN_SESSION_CLOSE_TIMEOUT_MS = 1_000;
+
+function targetLabel(target: Target): string {
+  return `${target.host}:${target.port}`;
+}
+
+function formatConnectionOutcome(outcome: ConnectionOutcome): string {
+  switch (outcome.kind) {
+    case "served":
+      return `served uptimeMs=${outcome.uptimeMs}`;
+    case "drained":
+      return `drained uptimeMs=${outcome.uptimeMs}`;
+    case "retryable":
+      return `retryable reason=${outcome.reason}`;
+    case "fatal":
+      return `fatal reason=${outcome.reason}`;
+  }
+}
+
+function formatSettings(settings: http2.Settings): string {
+  const entries = Object.entries(settings).filter(
+    ([, value]) => value !== undefined
+  );
+  if (entries.length === 0) return "{}";
+  return `{${entries
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(", ")}}`;
+}
 
 /** The Node request handler produced by the SDK's createEndpointHandler. */
 type SdkHandler = ReturnType<
@@ -79,10 +109,11 @@ type SdkHandler = ReturnType<
 
 /**
  * The engine's handle on a live connection: lets `shutdown()` ask each one to
- * begin a client-initiated drain (refuse new, finish in-flight in place).
+ * begin and finish a client-initiated drain.
  */
 export interface DrainableConnection {
   beginClientDrain(): void;
+  finishClientDrain(opts: { force: boolean }): Promise<void>;
 }
 
 /** What a connection attempt needs from the engine. */
@@ -254,6 +285,7 @@ function dial(
   plaintext: boolean,
   signal: AbortSignal
 ): Promise<DialResult> {
+  const log = deps.opts.logger;
   const tlsOptions = plaintext
     ? undefined
     : buildTlsConnectOptions(deps.opts.tls, target.servername);
@@ -263,6 +295,7 @@ function dial(
 
   return new Promise<DialResult>((resolve) => {
     let done = false;
+    const label = targetLabel(target);
     const onError = (err: Error) => fail(`socket error: ${err.message}`);
     const onAbort = () => fail("tunnel closed");
     const timer = setTimeout(
@@ -280,6 +313,7 @@ function dial(
       if (done) return;
       done = true;
       cleanup();
+      log(`tunnel: failed to connect to ${label}: ${reason}`);
       socket.destroy();
       resolve({ ok: false, outcome: { kind: "retryable", reason } });
     }
@@ -289,6 +323,9 @@ function dial(
     socket.once(plaintext ? "connect" : "secureConnect", () => {
       if (done) return;
       socket.setNoDelay(true);
+      const alpn = plaintext
+        ? "plaintext"
+        : `tls alpn=${JSON.stringify((socket as tls.TLSSocket).alpnProtocol)}`;
       // Node's http2 requires ALPN to have negotiated h2 before it will run a
       // server session over a TLS socket. A server that doesn't negotiate is
       // too old for this client (see the README's server-version note).
@@ -300,6 +337,7 @@ function dial(
       }
       done = true;
       cleanup();
+      log(`tunnel: connected socket to ${label} (${alpn})`);
       resolve({ ok: true, socket });
     });
   });
@@ -378,11 +416,15 @@ class ConnectionAttempt implements DrainableConnection {
     this.deps.activeSockets.add(dialed.socket);
     this.slotSignal.addEventListener("abort", this.onAbort, { once: true });
     dialed.socket.on("error", (err: Error) =>
-      this.settle(this.endOutcome(`socket error: ${err.message}`))
+      this.settle(
+        this.endOutcome(`socket error: ${err.message}`),
+        `socket error: ${err.message}`
+      )
     );
     dialed.socket.on("close", () =>
       this.settle(
-        this.endOutcome("connection closed before handshake completed")
+        this.endOutcome("connection closed before handshake completed"),
+        "socket closed"
       )
     );
     this.establish(dialed.socket);
@@ -446,15 +488,73 @@ class ConnectionAttempt implements DrainableConnection {
    * funnel through here for teardown: it detaches via {@link beginServerDrain}
    * and lets the DrainingRegistry destroy the session later.
    */
-  private settle(outcome: ConnectionOutcome): void {
+  private settle(outcome: ConnectionOutcome, detail?: string): void {
     if (this.closed) return;
+    const phase = this.state.kind;
     const session = this.session();
     this.stopPhaseResources();
     this.deregister();
     this.state = { kind: "closed" };
     session?.destroy();
     this.socket?.destroy();
-    this.completion.resolve(outcome);
+    const firstOutcome = this.completion.resolve(outcome);
+    this.log(
+      `tunnel: connection to ${targetLabel(this.target)} closed (phase=${phase}, outcome=${formatConnectionOutcome(outcome)}${
+        detail === undefined ? "" : `, detail=${detail}`
+      }${firstOutcome ? "" : ", already reported"})`
+    );
+  }
+
+  private closeSessionGracefully(session: http2.Http2Session): Promise<void> {
+    return new Promise((resolve) => {
+      if (session.closed || session.destroyed) {
+        resolve();
+        return;
+      }
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        this.settle(
+          { kind: "served", uptimeMs: this.uptimeMs() },
+          "session.close() timed out"
+        );
+        finish();
+      }, CLIENT_DRAIN_SESSION_CLOSE_TIMEOUT_MS);
+      timer.unref();
+      session.once("close", finish);
+      try {
+        session.close();
+      } catch {
+        this.settle(
+          this.endOutcome("session close failed"),
+          "session close failed"
+        );
+        finish();
+      }
+    });
+  }
+
+  private sendClientDrainGoaway(session: http2.Http2Session): void {
+    if (session.closed || session.destroyed) return;
+    try {
+      session.goaway(http2.constants.NGHTTP2_NO_ERROR);
+      this.log(
+        `tunnel: sent client-drain GOAWAY to ${targetLabel(this.target)}`
+      );
+    } catch (err) {
+      this.log(
+        `tunnel: failed to send client-drain GOAWAY to ${targetLabel(this.target)}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      // The session may be closing under us. dispatchForwarded still refuses
+      // any raced streams once the state flips to client-draining.
+    }
   }
 
   // ---- establish: role-flip ----
@@ -478,6 +578,21 @@ class ConnectionAttempt implements DrainableConnection {
     );
 
     h2.on("session", (s) => {
+      this.log(
+        `tunnel: h2 session established to ${targetLabel(this.target)} (localSettings=${formatSettings(
+          s.localSettings
+        )}, remoteSettings=${formatSettings(s.remoteSettings)})`
+      );
+      s.on("localSettings", (settings: http2.Settings) =>
+        this.log(
+          `tunnel: h2 local settings acknowledged by ${targetLabel(this.target)}: ${formatSettings(settings)}`
+        )
+      );
+      s.on("remoteSettings", (settings: http2.Settings) =>
+        this.log(
+          `tunnel: h2 remote settings from ${targetLabel(this.target)}: ${formatSettings(settings)}`
+        )
+      );
       // Role-flip complete: the cloud is now our h2 client. connecting →
       // handshaking, arming the timer that fires if the server never opens
       // /_/start-tunnel.
@@ -512,15 +627,22 @@ class ConnectionAttempt implements DrainableConnection {
       }
       s.on("close", () =>
         this.settle(
-          this.endOutcome("session closed before handshake completed")
+          this.endOutcome("session closed before handshake completed"),
+          "session closed"
         )
       );
       s.on("error", (err: Error) =>
-        this.settle(this.endOutcome(`session error: ${err.message}`))
+        this.settle(
+          this.endOutcome(`session error: ${err.message}`),
+          `session error: ${err.message}`
+        )
       );
     });
     h2.on("sessionError", (err: Error) =>
-      this.settle(this.endOutcome(`session error: ${err.message}`))
+      this.settle(
+        this.endOutcome(`session error: ${err.message}`),
+        `session error: ${err.message}`
+      )
     );
 
     h2.emit("connection", socket);
@@ -664,7 +786,24 @@ class ConnectionAttempt implements DrainableConnection {
     // Count this invocation as in-flight so shutdown() waits for it to finish.
     this.deps.inflightStarted();
     res.stream.once("close", () => this.deps.inflightEnded());
-    this.deps.sdkHandler(req, res);
+    const streamId = res.stream.id ?? "?";
+    res.stream.once("error", (err: Error) =>
+      this.log(
+        `tunnel: forwarded stream ${streamId} ${req.method ?? "?"} ${
+          req.url ?? "?"
+        } failed: ${err.message}`
+      )
+    );
+    try {
+      this.deps.sdkHandler(req, res);
+    } catch (err) {
+      this.log(
+        `tunnel: SDK handler threw for forwarded stream ${streamId} ${
+          req.method ?? "?"
+        } ${req.url ?? "?"}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      throw err;
+    }
   }
 
   // ---- drain ----
@@ -672,6 +811,9 @@ class ConnectionAttempt implements DrainableConnection {
   private handleDrainRequest(res: http2.Http2ServerResponse): void {
     res.writeHead(200);
     res.end();
+    this.log(
+      `tunnel: received server drain notification from ${targetLabel(this.target)}`
+    );
     if (!this.deps.opts.supportsDrain) {
       // Not advertised, so unexpected — acknowledge and let the server
       // close on us; the slot's redial loop re-establishes.
@@ -708,7 +850,9 @@ class ConnectionAttempt implements DrainableConnection {
   private beginServerDrain(): void {
     if (this.state.kind !== "serving") return;
     const { session, openedAt, watchdog } = this.state;
-    this.log("tunnel: drain requested — opening a replacement connection");
+    this.log(
+      "tunnel: server drain notification accepted — opening a replacement connection"
+    );
     watchdog.stop(); // the registry owns the session now; stop pinging it
     this.deregister();
     this.deps.draining.add(session, this.socket!, this.deps.opts.drainGraceMs);
@@ -738,6 +882,7 @@ class ConnectionAttempt implements DrainableConnection {
           trigger: "client",
           watchdog: s.watchdog,
         };
+        this.sendClientDrainGoaway(s.session);
         return;
       case "connecting":
       case "handshaking":
@@ -750,12 +895,28 @@ class ConnectionAttempt implements DrainableConnection {
     }
   }
 
+  async finishClientDrain(opts: { force: boolean }): Promise<void> {
+    const s = this.state;
+    if (s.kind !== "draining" || s.trigger !== "client") return;
+    if (opts.force) {
+      this.settle(
+        { kind: "served", uptimeMs: this.uptimeMs() },
+        "client drain grace expired"
+      );
+      return;
+    }
+    await this.closeSessionGracefully(s.session);
+  }
+
   // ---- liveness ----
 
   private startWatchdog(session: http2.Http2Session): Watchdog {
     const watchdog = new Watchdog(session, this.deps.opts, () => {
       this.log("tunnel: pings missed — reconnecting");
-      this.settle({ kind: "served", uptimeMs: this.uptimeMs() });
+      this.settle(
+        { kind: "served", uptimeMs: this.uptimeMs() },
+        "ping watchdog missed too many acknowledgements"
+      );
     });
     watchdog.start();
     return watchdog;

--- a/packages/libs/restate-sdk-tunnel/src/connection.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connection.ts
@@ -126,6 +126,12 @@ function formatSettings(settings: http2.Settings): string {
     .join(", ")}}`;
 }
 
+function pathWithoutQuery(url: string | undefined): string {
+  if (url === undefined) return "?";
+  const queryStart = url.indexOf("?");
+  return queryStart === -1 ? url : url.slice(0, queryStart);
+}
+
 /** The Node request handler produced by the SDK's createEndpointHandler. */
 type SdkHandler = ReturnType<
   typeof import("@restatedev/restate-sdk").createEndpointHandler
@@ -834,6 +840,8 @@ class ConnectionAttempt implements DrainableConnection {
     const clientDraining =
       this.state.kind === "draining" && this.state.trigger === "client";
     if (!this.deps.isStartupReady()) {
+      // Defensive fallback: the supervisor gates dialing until startupReady
+      // passes, so normal protocol traffic should not reach this state.
       this.logWithIdentity(
         `tunnel: refused forwarded stream ${res.stream.id ?? "?"} before startup readiness gate completed`
       );
@@ -859,11 +867,12 @@ class ConnectionAttempt implements DrainableConnection {
     this.deps.inflightStarted();
     res.stream.once("close", () => this.deps.inflightEnded());
     const streamId = res.stream.id ?? "?";
+    const logPath = pathWithoutQuery(req.url);
     res.stream.once("error", (err: Error) =>
       this.logWithIdentity(
-        `tunnel: forwarded stream ${streamId} ${req.method ?? "?"} ${
-          req.url ?? "?"
-        } failed: ${err.message}`
+        `tunnel: forwarded stream ${streamId} ${req.method ?? "?"} ${logPath} failed: ${
+          err.message
+        }`
       )
     );
     try {
@@ -872,7 +881,7 @@ class ConnectionAttempt implements DrainableConnection {
       this.logWithIdentity(
         `tunnel: SDK handler threw for forwarded stream ${streamId} ${
           req.method ?? "?"
-        } ${req.url ?? "?"}: ${err instanceof Error ? err.message : String(err)}`
+        } ${logPath}: ${err instanceof Error ? err.message : String(err)}`
       );
       throw err;
     }

--- a/packages/libs/restate-sdk-tunnel/src/connection.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connection.ts
@@ -132,6 +132,15 @@ function pathWithoutQuery(url: string | undefined): string {
   return queryStart === -1 ? url : url.slice(0, queryStart);
 }
 
+function endInternalError(res: http2.Http2ServerResponse): void {
+  try {
+    if (!res.headersSent) res.writeHead(500);
+    if (!res.writableEnded) res.end("tunnel: SDK handler error");
+  } catch {
+    // The stream may already be closing; keep the session lifecycle contained.
+  }
+}
+
 /** The Node request handler produced by the SDK's createEndpointHandler. */
 type SdkHandler = ReturnType<
   typeof import("@restatedev/restate-sdk").createEndpointHandler
@@ -866,24 +875,26 @@ class ConnectionAttempt implements DrainableConnection {
     // Count this invocation as in-flight so shutdown() waits for it to finish.
     this.deps.inflightStarted();
     res.stream.once("close", () => this.deps.inflightEnded());
-    const streamId = res.stream.id ?? "?";
-    const logPath = pathWithoutQuery(req.url);
-    res.stream.once("error", (err: Error) =>
+    res.stream.once("error", (err: Error) => {
+      const streamId = res.stream.id ?? "?";
+      const logPath = pathWithoutQuery(req.url);
       this.logWithIdentity(
         `tunnel: forwarded stream ${streamId} ${req.method ?? "?"} ${logPath} failed: ${
           err.message
         }`
-      )
-    );
+      );
+    });
     try {
       this.deps.sdkHandler(req, res);
     } catch (err) {
+      const streamId = res.stream.id ?? "?";
+      const logPath = pathWithoutQuery(req.url);
       this.logWithIdentity(
         `tunnel: SDK handler threw for forwarded stream ${streamId} ${
           req.method ?? "?"
         } ${logPath}: ${err instanceof Error ? err.message : String(err)}`
       );
-      throw err;
+      endInternalError(res);
     }
   }
 

--- a/packages/libs/restate-sdk-tunnel/src/connection.ts
+++ b/packages/libs/restate-sdk-tunnel/src/connection.ts
@@ -75,6 +75,7 @@ export type ConnectionOutcome =
 export type DrainTrigger = "server" | "client";
 
 const CLIENT_DRAIN_SESSION_CLOSE_TIMEOUT_MS = 1_000;
+const TUNNEL_DRAINING_HEADER = "x-restate-tunnel-draining";
 const CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 function encodeBase32(value: bigint, length: number): string {
@@ -166,6 +167,8 @@ export interface ConnectionDeps {
    * this connection's own `draining{client}` state.
    */
   isShuttingDown: () => boolean;
+  /** True once the startup readiness gate has passed. */
+  isStartupReady: () => boolean;
   /** A forwarded invocation began executing (counts toward the drain wait). */
   inflightStarted: () => void;
   /** A forwarded invocation finished (its stream closed). */
@@ -749,7 +752,12 @@ class ConnectionAttempt implements DrainableConnection {
         if (this.closed || res.stream.destroyed) return;
         try {
           if (ok) this.dispatchForwarded(req, res);
-          else this.notReady(res);
+          else {
+            this.logWithIdentity(
+              `tunnel: refused forwarded stream ${res.stream.id ?? "?"} before tunnel handshake completed`
+            );
+            this.notReady(res);
+          }
         } catch {
           // The session may be tearing down under us.
         }
@@ -758,11 +766,14 @@ class ConnectionAttempt implements DrainableConnection {
     }
     // Before /_/start-tunnel was even opened (or already gone) — not a tunnel
     // server speaking the protocol.
+    this.logWithIdentity(
+      `tunnel: refused forwarded stream ${res.stream.id ?? "?"} before tunnel handshake completed`
+    );
     this.notReady(res);
   }
 
   private notReady(res: http2.Http2ServerResponse): void {
-    res.writeHead(503);
+    res.writeHead(503, { [TUNNEL_DRAINING_HEADER]: "true" });
     res.end("tunnel: not ready");
   }
 
@@ -822,11 +833,18 @@ class ConnectionAttempt implements DrainableConnection {
     // detached session keeps serving (the zero-drop property).
     const clientDraining =
       this.state.kind === "draining" && this.state.trigger === "client";
+    if (!this.deps.isStartupReady()) {
+      this.logWithIdentity(
+        `tunnel: refused forwarded stream ${res.stream.id ?? "?"} before startup readiness gate completed`
+      );
+      this.notReady(res);
+      return;
+    }
     if (clientDraining || this.deps.isShuttingDown()) {
       this.logWithIdentity(
         `tunnel: refused forwarded stream ${res.stream.id ?? "?"} during client drain`
       );
-      res.writeHead(503, { "x-restate-tunnel-draining": "true" });
+      res.writeHead(503, { [TUNNEL_DRAINING_HEADER]: "true" });
       res.end();
       return;
     }

--- a/packages/libs/restate-sdk-tunnel/src/handshake.ts
+++ b/packages/libs/restate-sdk-tunnel/src/handshake.ts
@@ -65,9 +65,9 @@ export interface HandshakeCredentials {
   supportsDrain: boolean;
   /**
    * Advertise `supports-client-drain: true`. Tells the server that on
-   * shutdown we refuse new invocations with the `x-restate-tunnel-draining`
-   * sentinel (rather than dropping them); only then does the server trust
-   * that sentinel to deselect this connection.
+   * shutdown we proactively send GOAWAY and refuse any raced streams with the
+   * `x-restate-tunnel-draining` sentinel (rather than dropping them); only
+   * then does the server trust that sentinel to deselect this connection.
    */
   supportsClientDrain: boolean;
 }

--- a/packages/libs/restate-sdk-tunnel/src/handshake.ts
+++ b/packages/libs/restate-sdk-tunnel/src/handshake.ts
@@ -18,9 +18,10 @@
 //
 //   1. We answer immediately: `200` whose RESPONSE HEADERS carry our
 //      credentials — `authorization: Bearer <token>`,
-//      `environment-id: env_<id>`, `tunnel-name: <name>`, and
-//      `supports-drain: true` when the drain handover is enabled (the
-//      default — see the /_/drain-tunnel handling in connect.ts).
+//      `environment-id: env_<id>`, `tunnel-name: <name>`, advisory diagnostic
+//      ids (`tunnel-worker-id`, `tunnel-connection-id`), and `supports-drain:
+//      true` when the drain handover is enabled (the default — see the
+//      /_/drain-tunnel handling in connect.ts).
 //   2. The server validates the credentials, then completes the handshake
 //      by sending TRAILERS on its still-open request body:
 //      `tunnel-status: ok | unauthorized | bad-tunnel-name | too-many-tunnels`
@@ -57,6 +58,10 @@ export interface HandshakeCredentials {
   authToken: string;
   environmentId: string;
   tunnelName: string;
+  /** Stable-ish per SDK worker/process, for cross-side diagnostics. */
+  tunnelWorkerId: string;
+  /** Unique per h2 tunnel connection attempt, for cross-side diagnostics. */
+  tunnelConnectionId: string;
   /**
    * Advertise `supports-drain: true`. Only set this when the engine
    * actually implements the `/_/drain-tunnel` handover — advertising it
@@ -172,6 +177,8 @@ export function performHandshake(
       authorization: `Bearer ${creds.authToken}`,
       "environment-id": creds.environmentId,
       "tunnel-name": creds.tunnelName,
+      "tunnel-worker-id": creds.tunnelWorkerId,
+      "tunnel-connection-id": creds.tunnelConnectionId,
       ...(creds.supportsDrain && { "supports-drain": "true" }),
       ...(creds.supportsClientDrain && { "supports-client-drain": "true" }),
     });

--- a/packages/libs/restate-sdk-tunnel/src/options.ts
+++ b/packages/libs/restate-sdk-tunnel/src/options.ts
@@ -12,6 +12,8 @@
 // Option validation and TLS construction.
 
 import * as fs from "node:fs";
+import * as os from "node:os";
+import { randomBytes } from "node:crypto";
 import type * as tls from "node:tls";
 import type { ConnectTunnelOptions, TunnelTlsOptions } from "./types.js";
 import { parseServerAddress } from "./targets.js";
@@ -26,6 +28,7 @@ export const ENVIRONMENT_ID_ENV = "RESTATE_INPROC_ENVIRONMENT_ID";
 export const CLOUD_REGION_ENV = "RESTATE_INPROC_CLOUD_REGION";
 export const SIGNING_PUBLIC_KEY_ENV = "RESTATE_INPROC_SIGNING_PUBLIC_KEY";
 export const AUTH_TOKEN_FILE_ENV = "RESTATE_INPROC_AUTH_TOKEN_FILE";
+export const TUNNEL_WORKER_ID_ENV = "RESTATE_TUNNEL_WORKER_ID";
 
 export interface ResolvedOptions {
   /** The SRV name to discover tunnel servers from (region-derived or given). */
@@ -42,6 +45,7 @@ export interface ResolvedOptions {
   authToken: () => string;
   signingPublicKey: string;
   tunnelName: string;
+  tunnelWorkerId: string;
   bidirectional: boolean;
   resolveIntervalMs: number;
   supportsDrain: boolean;
@@ -137,6 +141,34 @@ function resolveAuthToken(option: string | undefined): () => string {
   // misconfiguration, not look like a transient failure mid-redial.
   readToken();
   return readToken;
+}
+
+function sanitizeDefaultWorkerIdSegment(value: string): string {
+  const sanitized = value
+    .replace(/[^A-Za-z0-9._:-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return (sanitized === "" ? "worker" : sanitized).slice(0, 96);
+}
+
+function makeDefaultTunnelWorkerId(): string {
+  const host = fromEnv("HOSTNAME") ?? os.hostname() ?? "worker";
+  const suffix = randomBytes(4).toString("hex");
+  return `${sanitizeDefaultWorkerIdSegment(host)}-${suffix}`;
+}
+
+// Stable for the process lifetime. Multiple connectTunnel() calls in the same
+// process get the same default worker id unless explicitly overridden.
+const DEFAULT_TUNNEL_WORKER_ID = makeDefaultTunnelWorkerId();
+
+function resolveTunnelWorkerId(option: string | undefined): string {
+  const value =
+    option !== undefined && option !== ""
+      ? option
+      : fromEnv(TUNNEL_WORKER_ID_ENV);
+  return requireHeaderSafe(
+    value ?? DEFAULT_TUNNEL_WORKER_ID,
+    "tunnelWorkerId"
+  );
 }
 
 function positive(
@@ -238,6 +270,7 @@ export function resolveOptions(options: ConnectTunnelOptions): ResolvedOptions {
       `tunnel: invalid tunnelName ${JSON.stringify(tunnelName)} — use letters, digits, '.', '_' or '-'`
     );
   }
+  const tunnelWorkerId = resolveTunnelWorkerId(options.tunnelWorkerId);
   const pingIntervalMs = positive(
     options.pingIntervalMs,
     75_000,
@@ -261,6 +294,7 @@ export function resolveOptions(options: ConnectTunnelOptions): ResolvedOptions {
     authToken,
     signingPublicKey,
     tunnelName,
+    tunnelWorkerId,
     bidirectional: options.bidirectional ?? true,
     resolveIntervalMs: positive(
       options.resolveIntervalMs,

--- a/packages/libs/restate-sdk-tunnel/src/options.ts
+++ b/packages/libs/restate-sdk-tunnel/src/options.ts
@@ -47,6 +47,7 @@ export interface ResolvedOptions {
   tunnelName: string;
   tunnelWorkerId: string;
   bidirectional: boolean;
+  startupReady?: () => Promise<void>;
   resolveIntervalMs: number;
   supportsDrain: boolean;
   drainGraceMs: number;
@@ -169,6 +170,22 @@ function resolveTunnelWorkerId(option: string | undefined): string {
     value ?? DEFAULT_TUNNEL_WORKER_ID,
     "tunnelWorkerId"
   );
+}
+
+function resolveStartupReady(
+  option: ConnectTunnelOptions["startupReady"]
+): (() => Promise<void>) | undefined {
+  if (option === undefined) return undefined;
+  if (typeof option === "function") {
+    return async () => {
+      await option();
+    };
+  }
+  const ready = Promise.resolve(option);
+  ready.catch(() => {});
+  return async () => {
+    await ready;
+  };
 }
 
 function positive(
@@ -296,6 +313,7 @@ export function resolveOptions(options: ConnectTunnelOptions): ResolvedOptions {
     tunnelName,
     tunnelWorkerId,
     bidirectional: options.bidirectional ?? true,
+    startupReady: resolveStartupReady(options.startupReady),
     resolveIntervalMs: positive(
       options.resolveIntervalMs,
       30_000,

--- a/packages/libs/restate-sdk-tunnel/src/options.ts
+++ b/packages/libs/restate-sdk-tunnel/src/options.ts
@@ -48,6 +48,7 @@ export interface ResolvedOptions {
   tunnelWorkerId: string;
   bidirectional: boolean;
   startupReady?: () => Promise<void>;
+  startupReadyTimeoutMs: number;
   resolveIntervalMs: number;
   supportsDrain: boolean;
   drainGraceMs: number;
@@ -314,6 +315,11 @@ export function resolveOptions(options: ConnectTunnelOptions): ResolvedOptions {
     tunnelWorkerId,
     bidirectional: options.bidirectional ?? true,
     startupReady: resolveStartupReady(options.startupReady),
+    startupReadyTimeoutMs: positive(
+      options.startupReadyTimeoutMs,
+      120_000,
+      "startupReadyTimeoutMs"
+    ),
     resolveIntervalMs: positive(
       options.resolveIntervalMs,
       30_000,

--- a/packages/libs/restate-sdk-tunnel/src/supervisor.ts
+++ b/packages/libs/restate-sdk-tunnel/src/supervisor.ts
@@ -114,6 +114,28 @@ export class Supervisor {
     this.slots.set(key, slot);
   }
 
+  private async waitForStartupReady(): Promise<boolean> {
+    if (this.opts.startupReady === undefined) return true;
+    this.log("tunnel: waiting for startup readiness gate");
+    try {
+      const ready = this.opts.startupReady();
+      ready.catch(() => {}); // a late rejection after abort must not be unhandled
+      const raced = await raceAbortable(ready, this.wake.signal);
+      if (raced === null) return false;
+      this.log("tunnel: startup readiness gate passed");
+      return true;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.fatal = new Error(`tunnel: startup readiness gate failed: ${reason}`);
+      this.log(
+        `tunnel: FATAL — startup readiness gate failed: ${reason}; stopping all connections`
+      );
+      this.hooks.onFatal(this.fatal);
+      this.stopSignal.abort();
+      return false;
+    }
+  }
+
   /** The per-server loop: dial → serve → classify outcome → backoff → redial. */
   private async runSlot(target: Target, ctl: AbortController): Promise<void> {
     const backoff = new Backoff(
@@ -159,6 +181,7 @@ export class Supervisor {
   /** Resolve the server set, reconcile slots, repeat. For SRV discovery the
    * set is re-resolved every resolveIntervalMs; an explicit set is fixed. */
   private async supervise(): Promise<void> {
+    if (!(await this.waitForStartupReady())) return;
     while (!this.stopping && this.fatal === undefined) {
       let targets: Target[];
       try {

--- a/packages/libs/restate-sdk-tunnel/src/supervisor.ts
+++ b/packages/libs/restate-sdk-tunnel/src/supervisor.ts
@@ -141,6 +141,7 @@ export class Supervisor {
       this.log("tunnel: startup readiness gate passed");
       return true;
     } catch (err) {
+      if (this.stopping || this.wake.signal.aborted) return false;
       const reason = err instanceof Error ? err.message : String(err);
       this.fatal = new Error(`tunnel: startup readiness gate failed: ${reason}`);
       this.log(

--- a/packages/libs/restate-sdk-tunnel/src/supervisor.ts
+++ b/packages/libs/restate-sdk-tunnel/src/supervisor.ts
@@ -43,6 +43,10 @@ interface Slot {
   done: Promise<void>;
 }
 
+function formatTargetList(keys: string[]): string {
+  return keys.length === 0 ? "<none>" : keys.join(", ");
+}
+
 export interface SupervisorHooks {
   /** A slot hit a non-retryable failure; the whole tunnel must stop (E1). */
   onFatal: (err: Error) => void;
@@ -56,6 +60,7 @@ export class Supervisor {
   private readonly wake = new AbortController();
   private stopping = false;
   private fatal: Error | undefined;
+  private lastResolvedKeys: string[] | undefined;
 
   /** Resolves when the resolve loop has exited AND every slot has settled. */
   readonly done: Promise<void>;
@@ -82,12 +87,14 @@ export class Supervisor {
    */
   stopResolving(): void {
     this.stopping = true;
+    this.log("tunnel: supervisor stopping target resolution");
     this.wake.abort();
   }
 
   /** Abort every slot and the resolve loop (engine teardown). */
   abortAll(): void {
     this.stopping = true;
+    this.log("tunnel: supervisor aborting all connections");
     this.stopSignal.abort();
   }
 
@@ -158,7 +165,7 @@ export class Supervisor {
         // E3: race the (un-abortable) DNS work against the wake signal so
         // teardown/fatal don't block on a slow resolver — a late result is
         // discarded by the stopping/fatal check below.
-        const resolution = resolveTargets(this.opts);
+        const resolution = resolveTargets({ ...this.opts, logger: this.log });
         resolution.catch(() => {}); // a late rejection must not be unhandled
         const raced = await raceAbortable(resolution, this.wake.signal);
         if (raced === null) break; // woken: stopping or fatal
@@ -178,6 +185,39 @@ export class Supervisor {
       if (this.stopping || this.fatal !== undefined) break;
 
       const desired = new Map(targets.map((t) => [targetKey(t), t] as const));
+      const desiredKeys = [...desired.keys()].sort();
+      if (
+        this.lastResolvedKeys === undefined ||
+        desiredKeys.length !== this.lastResolvedKeys.length ||
+        desiredKeys.some((key, i) => key !== this.lastResolvedKeys![i])
+      ) {
+        const source =
+          this.opts.srvName === undefined
+            ? "configured tunnel targets"
+            : `SRV ${this.opts.srvName}`;
+        this.log(
+          `tunnel: target set from ${source}: ${formatTargetList(desiredKeys)}`
+        );
+        if (this.lastResolvedKeys !== undefined) {
+          const previous = new Set(this.lastResolvedKeys);
+          const current = new Set(desiredKeys);
+          const added = desiredKeys.filter((key) => !previous.has(key));
+          const removed = this.lastResolvedKeys.filter(
+            (key) => !current.has(key)
+          );
+          if (added.length > 0) {
+            this.log(
+              `tunnel: discovered new tunnel target(s): ${formatTargetList(added)}`
+            );
+          }
+          if (removed.length > 0) {
+            this.log(
+              `tunnel: tunnel target(s) disappeared: ${formatTargetList(removed)}`
+            );
+          }
+        }
+        this.lastResolvedKeys = desiredKeys;
+      }
       for (const [key, target] of desired) {
         if (!this.slots.has(key)) {
           this.log(`tunnel: starting connection to ${key}`);

--- a/packages/libs/restate-sdk-tunnel/src/supervisor.ts
+++ b/packages/libs/restate-sdk-tunnel/src/supervisor.ts
@@ -116,11 +116,27 @@ export class Supervisor {
 
   private async waitForStartupReady(): Promise<boolean> {
     if (this.opts.startupReady === undefined) return true;
-    this.log("tunnel: waiting for startup readiness gate");
+    this.log(
+      `tunnel: waiting for startup readiness gate (timeoutMs=${this.opts.startupReadyTimeoutMs})`
+    );
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
       const ready = this.opts.startupReady();
       ready.catch(() => {}); // a late rejection after abort must not be unhandled
-      const raced = await raceAbortable(ready, this.wake.signal);
+      const readyOrTimeout = Promise.race([
+        ready,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => {
+            reject(
+              new Error(
+                `startup readiness gate timed out after ${this.opts.startupReadyTimeoutMs}ms`
+              )
+            );
+          }, this.opts.startupReadyTimeoutMs);
+        }),
+      ]);
+      readyOrTimeout.catch(() => {});
+      const raced = await raceAbortable(readyOrTimeout, this.wake.signal);
       if (raced === null) return false;
       this.log("tunnel: startup readiness gate passed");
       return true;
@@ -133,6 +149,8 @@ export class Supervisor {
       this.hooks.onFatal(this.fatal);
       this.stopSignal.abort();
       return false;
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
     }
   }
 

--- a/packages/libs/restate-sdk-tunnel/src/targets.ts
+++ b/packages/libs/restate-sdk-tunnel/src/targets.ts
@@ -31,6 +31,12 @@ export interface Target {
   plaintext?: boolean;
 }
 
+type DiagnosticLogger = (message: string) => void;
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /**
  * Parse one explicit tunnel-server address: `"host:port"`, or a URL whose
  * scheme picks TLS (`https`) / plaintext (`http`) for that server.
@@ -102,17 +108,28 @@ export function parseServerAddress(address: string): Target {
 export async function resolveTargets(spec: {
   srvName?: string;
   tunnelServers?: string[];
+  logger?: DiagnosticLogger;
 }): Promise<Target[]> {
+  const log: DiagnosticLogger = spec.logger ?? (() => {});
   if (spec.tunnelServers !== undefined) {
     const targets = spec.tunnelServers.map(parseServerAddress);
     if (targets.length === 0) {
       throw new Error("tunnel: tunnelServers is empty");
     }
+    log(
+      `tunnel: using configured tunnel target(s): ${targets.map(targetKey).join(", ")}`
+    );
     return targets;
   }
   const srvName = spec.srvName!;
+  log(`tunnel: resolving tunnel targets from SRV ${srvName}`);
   const records = await dns.promises.resolveSrv(srvName);
   records.sort((a, b) => a.priority - b.priority || b.weight - a.weight);
+  log(
+    `tunnel: SRV ${srvName} returned ${records.length} record(s): ${
+      records.map((r) => `${r.name}:${r.port}`).join(", ") || "<none>"
+    }`
+  );
   // Expand each SRV target to its addresses: the tunnel connects to EVERY
   // resolved address (one connection per IP), exactly like the Rust client,
   // which flat-maps SRV targets through A/AAAA lookups into per-IP URIs.
@@ -131,10 +148,16 @@ export async function resolveTargets(spec: {
     if (result.status === "rejected") {
       const code = (result.reason as NodeJS.ErrnoException | undefined)?.code;
       if (code === "ENOTFOUND" || code === "ENODATA") {
+        log(
+          `tunnel: SRV target ${r.name}:${r.port} has no address (${code})`
+        );
         continue; // negative answer: this SRV target genuinely has no address
       }
       // Transport error — fail the whole resolution so the supervisor
       // keeps existing slots and retries.
+      log(
+        `tunnel: address lookup for SRV target ${r.name}:${r.port} failed: ${formatError(result.reason)}`
+      );
       throw result.reason;
     }
     for (const a of result.value) {
@@ -144,6 +167,11 @@ export async function resolveTargets(spec: {
       targets.push({ host: a.address, port: r.port, servername: srvName });
     }
   }
+  log(
+    `tunnel: SRV ${srvName} expanded to ${targets.length} target(s): ${
+      targets.map(targetKey).join(", ") || "<none>"
+    }`
+  );
   return targets;
 }
 

--- a/packages/libs/restate-sdk-tunnel/src/types.ts
+++ b/packages/libs/restate-sdk-tunnel/src/types.ts
@@ -169,11 +169,12 @@ export interface ConnectTunnelOptions extends Omit<
   /**
    * Advertise client-initiated graceful drain (`supports-client-drain: true`)
    * in the handshake. Default `true`. When enabled, {@link
-   * TunnelConnection.shutdown} (or the opt-in {@link gracefulShutdown} signal
-   * handler) refuses new invocations with a drain sentinel so Restate Cloud
-   * stops routing new work to this process while its in-flight invocations
-   * finish — the basis for zero-dropped-invocation rollouts. Specific to this
-   * in-process client; the standalone Rust client does not implement it.
+   * TunnelConnection.shutdown} (or the default {@link gracefulShutdown} signal
+   * handler) proactively sends HTTP/2 GOAWAY and refuses any raced streams
+   * with a drain sentinel, so Restate Cloud stops routing new work to this
+   * process while its in-flight invocations finish — the basis for
+   * zero-dropped-invocation rollouts. Specific to this in-process client; the
+   * standalone Rust client does not implement it.
    */
   supportsClientDrain?: boolean;
   /**
@@ -181,8 +182,10 @@ export interface ConnectTunnelOptions extends Omit<
    * engine installs a one-shot handler for each signal (default `SIGTERM`)
    * that calls {@link TunnelConnection.shutdown} and then `process.exit(0)`
    * once draining completes (or the grace elapses) — so an operator-managed
-   * deployment gets zero-dropped-invocation rollouts with no wiring. The
-   * handlers are removed when the connection closes.
+   * deployment gets zero-dropped-invocation rollouts with no wiring. In
+   * Kubernetes, set `terminationGracePeriodSeconds` to at least the drain
+   * grace plus the handler slack you want to preserve. The handlers are
+   * removed when the connection closes.
    *
    * Pass `false` to opt out entirely — e.g. to manage signals and process
    * exit yourself and call {@link TunnelConnection.shutdown} by hand. Pass an
@@ -261,12 +264,13 @@ export interface TunnelConnection {
   /** Stop reconnecting, close the current connection, and wait for teardown. */
   close(): Promise<void>;
   /**
-   * Gracefully drain, then stop. Stops accepting new invocations (Restate
-   * Cloud deselects this process via the drain sentinel), lets in-flight
-   * invocations finish — bounded by `graceMs` (default {@link
-   * ConnectTunnelOptions.drainGraceMs}) — and then tears down. Resolves once
-   * drained or the grace elapsed. Wire this to `SIGTERM` for
-   * zero-dropped-invocation rollouts; {@link close} is the abrupt alternative.
+   * Gracefully drain, then stop. Proactively sends HTTP/2 GOAWAY so Restate
+   * Cloud stops opening new streams, refuses any raced streams with a drain
+   * sentinel, lets in-flight invocations finish — bounded by `graceMs`
+   * (default {@link ConnectTunnelOptions.drainGraceMs}) — and then closes the
+   * session gracefully. If the grace elapses first, the session/socket are
+   * force-closed. The default {@link ConnectTunnelOptions.gracefulShutdown}
+   * handler wires this to `SIGTERM`; {@link close} is the abrupt alternative.
    * Requires {@link ConnectTunnelOptions.supportsClientDrain} (the default) to
    * have been advertised; otherwise it degrades to an abrupt {@link close}.
    */

--- a/packages/libs/restate-sdk-tunnel/src/types.ts
+++ b/packages/libs/restate-sdk-tunnel/src/types.ts
@@ -159,17 +159,25 @@ export interface ConnectTunnelOptions extends Omit<
    */
   bidirectional?: boolean;
   /**
-   * Optional one-shot startup readiness gate. When supplied, the tunnel
-   * supervisor waits for this promise or callback to complete before dialing
-   * any tunnel server, so the server cannot select this worker until the local
-   * in-process handler is ready. If the gate rejects or throws, the tunnel
-   * stops and {@link TunnelConnection.ready} rejects.
+   * Optional one-shot startup readiness gate. Without this option the tunnel
+   * dials immediately, preserving the previous behavior. When supplied, the
+   * tunnel supervisor waits for this promise or callback to complete before
+   * dialing any tunnel server, so the server cannot select this worker until
+   * the local in-process handler is ready. If the gate rejects, throws, or does
+   * not complete within {@link startupReadyTimeoutMs}, the tunnel stops and
+   * {@link TunnelConnection.ready} rejects.
    *
    * This is the startup counterpart to {@link supportsClientDrain}: startup
    * gates traffic until the handler is ready; shutdown drain removes the
    * connection from selection before the handler stops.
    */
   startupReady?: PromiseLike<void> | (() => void | PromiseLike<void>);
+  /**
+   * Deadline for {@link startupReady}. Default 120_000. Only used when
+   * `startupReady` is supplied; a stuck startup gate is treated as fatal so a
+   * broken worker is visible instead of silently absent from the tunnel fleet.
+   */
+  startupReadyTimeoutMs?: number;
   /**
    * Advertise graceful-drain support (`supports-drain: true`) in the
    * handshake. Default `true`. When Restate Cloud rolls a tunnel node it

--- a/packages/libs/restate-sdk-tunnel/src/types.ts
+++ b/packages/libs/restate-sdk-tunnel/src/types.ts
@@ -159,6 +159,18 @@ export interface ConnectTunnelOptions extends Omit<
    */
   bidirectional?: boolean;
   /**
+   * Optional one-shot startup readiness gate. When supplied, the tunnel
+   * supervisor waits for this promise or callback to complete before dialing
+   * any tunnel server, so the server cannot select this worker until the local
+   * in-process handler is ready. If the gate rejects or throws, the tunnel
+   * stops and {@link TunnelConnection.ready} rejects.
+   *
+   * This is the startup counterpart to {@link supportsClientDrain}: startup
+   * gates traffic until the handler is ready; shutdown drain removes the
+   * connection from selection before the handler stops.
+   */
+  startupReady?: PromiseLike<void> | (() => void | PromiseLike<void>);
+  /**
    * Advertise graceful-drain support (`supports-drain: true`) in the
    * handshake. Default `true`. When Restate Cloud rolls a tunnel node it
    * sends `/_/drain-tunnel` to drain-capable connections: the engine then

--- a/packages/libs/restate-sdk-tunnel/src/types.ts
+++ b/packages/libs/restate-sdk-tunnel/src/types.ts
@@ -145,6 +145,15 @@ export interface ConnectTunnelOptions extends Omit<
    */
   tunnelName?: string;
   /**
+   * Stable diagnostic identifier for this SDK worker/process. The tunnel
+   * server can include it in routing and failure logs so operators can grep
+   * server-side events against SDK-side logs. Defaults to
+   * `RESTATE_TUNNEL_WORKER_ID` when set, otherwise a hostname-based id with a
+   * short random suffix that is stable for this process. Advisory only: it is
+   * sent in the tunnel handshake for diagnostics, not used for authentication.
+   */
+  tunnelWorkerId?: string;
+  /**
    * Protocol mode for the SDK handler. Default `true` (`BIDI_STREAM`) —
    * the tunnel is always HTTP/2, so full-duplex streaming is available.
    */

--- a/packages/libs/restate-sdk-tunnel/src/types.ts
+++ b/packages/libs/restate-sdk-tunnel/src/types.ts
@@ -16,11 +16,10 @@ import type { EndpointOptions } from "@restatedev/restate-sdk";
 /**
  * TLS options for the outbound tunnel connection.
  *
- * Note: unlike a regular HTTP/2 client, the tunnel deliberately negotiates
- * NO ALPN protocol ("tunnel is not normal h2" — the server clears its ALPN
- * list); both sides speak HTTP/2 with prior knowledge after the TLS
- * handshake. There is therefore no ALPN field here, and the package never
- * sets one.
+ * The tunnel always offers ALPN `h2` and requires TLS peers to negotiate it;
+ * omit these options to use the system trust store and SNI for the dialed
+ * host. There is no user-facing ALPN option because the tunnel protocol
+ * requires HTTP/2.
  */
 export interface TunnelTlsOptions {
   /**
@@ -274,8 +273,8 @@ export interface ConnectTunnelOptions extends Omit<
   maxSessionMemory?: number;
   /**
    * TLS for the outbound connection. Default `true` (system trust, SNI =
-   * dialed host, and — deliberately — NO ALPN). Pass `false` only for
-   * plaintext dev/test setups, or an object for a private CA / mTLS.
+   * dialed host, ALPN `h2`). Pass `false` only for plaintext dev/test setups,
+   * or an object for a private CA / mTLS.
    */
   tls?: boolean | TunnelTlsOptions;
   /** Abort to stop reconnecting and close the tunnel (same as `close()`). */

--- a/packages/libs/restate-sdk-tunnel/src/types.ts
+++ b/packages/libs/restate-sdk-tunnel/src/types.ts
@@ -208,12 +208,14 @@ export interface ConnectTunnelOptions extends Omit<
   /**
    * Automatic graceful shutdown on process signals. **On by default**: the
    * engine installs a one-shot handler for each signal (default `SIGTERM`)
-   * that calls {@link TunnelConnection.shutdown} and then `process.exit(0)`
-   * once draining completes (or the grace elapses) — so an operator-managed
-   * deployment gets zero-dropped-invocation rollouts with no wiring. In
-   * Kubernetes, set `terminationGracePeriodSeconds` to at least the drain
-   * grace plus the handler slack you want to preserve. The handlers are
-   * removed when the connection closes.
+   * that calls {@link TunnelConnection.shutdown}. If multiple tunnels in the
+   * same process register for a signal, the shared process-level handler waits
+   * for all of them before calling `process.exit(0)` once draining completes
+   * (or the grace elapses) — so an operator-managed deployment gets
+   * zero-dropped-invocation rollouts with no wiring. In Kubernetes, set
+   * `terminationGracePeriodSeconds` to at least the drain grace plus the
+   * handler slack you want to preserve. The handlers are removed when the
+   * connection closes.
    *
    * Pass `false` to opt out entirely — e.g. to manage signals and process
    * exit yourself and call {@link TunnelConnection.shutdown} by hand. Pass an

--- a/packages/libs/restate-sdk-tunnel/test/connect.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/connect.test.ts
@@ -13,7 +13,7 @@
 // (see fake-cloud.ts), over loopback. Covers the handshake, the
 // fatal-vs-retryable reconnect policy, control paths, forwarded dispatch
 // into the real SDK handler, the end-to-end identity delegation, and the
-// TLS no-ALPN bridge path.
+// TLS negotiated-h2 bridge path.
 
 import { describe, expect, test } from "vitest";
 import * as fs from "node:fs";

--- a/packages/libs/restate-sdk-tunnel/test/connect.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/connect.test.ts
@@ -53,6 +53,7 @@ const baseOptions = (port: number): ConnectTunnelOptions => ({
   authToken: "key_test.secret",
   signingPublicKey: identity.publicKey,
   tunnelName: TUNNEL_NAME,
+  tunnelWorkerId: "worker-test-1",
   services: [greeter],
   handshakeTimeoutMs: 300,
   reconnectInitialMs: 5,
@@ -95,8 +96,13 @@ describe("connectTunnel — handshake", () => {
           expect(creds["authorization"]).toBe("Bearer key_test.secret");
           expect(creds["environment-id"]).toBe("env_abc123");
           expect(creds["tunnel-name"]).toBe(TUNNEL_NAME);
+          expect(creds["tunnel-worker-id"]).toBe("worker-test-1");
+          expect(creds["tunnel-connection-id"]).toMatch(
+            /^[0-9A-HJKMNP-TV-Z]{26}$/
+          );
           // Drain is implemented and advertised by default.
           expect(creds["supports-drain"]).toBe("true");
+          expect(creds["supports-client-drain"]).toBe("true");
           // The ready-made registration URL: advertised proxy base + the
           // constant in-process destination (routing is by tunnelName).
           expect(conn.deploymentUrl).toBe(
@@ -127,12 +133,17 @@ describe("connectTunnel — handshake", () => {
           );
           expect(joined).toMatch(/tunnel: connected socket to .*plaintext/);
           expect(joined).toMatch(
+            /worker_id=worker-test-1 connection_id=[0-9A-HJKMNP-TV-Z]{26}/
+          );
+          expect(joined).toMatch(
             /tunnel: h2 session established to .*localSettings=.*remoteSettings=/
           );
           expect(joined).toMatch(
             /tunnel: established \(name=test-tunnel, proxy=https:\/\/tunnel\.example:9080\/abc123\/test-tunnel\)/
           );
-          expect(joined).toMatch(/tunnel: service ready \(name=test-tunnel,/);
+          expect(joined).toMatch(
+            /tunnel: service ready \(name=test-tunnel, .*worker_id=worker-test-1, connection_id=[0-9A-HJKMNP-TV-Z]{26}, target=/
+          );
         } finally {
           await conn.close();
         }

--- a/packages/libs/restate-sdk-tunnel/test/connect.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/connect.test.ts
@@ -109,6 +109,37 @@ describe("connectTunnel — handshake", () => {
     );
   });
 
+  test("diagnostic logger reports connection lifecycle and service readiness", async () => {
+    await withFake(
+      { decideTrailers: () => okTrailers() },
+      async (_fake, options) => {
+        const logs: string[] = [];
+        const conn = connectTunnel({
+          ...options,
+          tunnelDiagnosticLogger: (m) => logs.push(m),
+        });
+        try {
+          await conn.ready;
+          const joined = logs.join("\n");
+          expect(joined).toMatch(/tunnel: using configured tunnel target\(s\):/);
+          expect(joined).toMatch(
+            /tunnel: target set from configured tunnel targets:/
+          );
+          expect(joined).toMatch(/tunnel: connected socket to .*plaintext/);
+          expect(joined).toMatch(
+            /tunnel: h2 session established to .*localSettings=.*remoteSettings=/
+          );
+          expect(joined).toMatch(
+            /tunnel: established \(name=test-tunnel, proxy=https:\/\/tunnel\.example:9080\/abc123\/test-tunnel\)/
+          );
+          expect(joined).toMatch(/tunnel: service ready \(name=test-tunnel,/);
+        } finally {
+          await conn.close();
+        }
+      }
+    );
+  });
+
   test("deploymentUrl normalizes a missing proxy port", async () => {
     await withFake(
       {

--- a/packages/libs/restate-sdk-tunnel/test/fake-cloud.ts
+++ b/packages/libs/restate-sdk-tunnel/test/fake-cloud.ts
@@ -67,8 +67,18 @@ export interface FakeTunnelConnection {
   creds: Promise<http2.IncomingHttpHeaders>;
   /** The role-flipped h2 client session — open streams to model forwarded requests. */
   session: http2.ClientHttp2Session;
+  /** GOAWAY frames received from the deployment side. */
+  goaways: FakeGoaway[];
+  /** Resolves when the next GOAWAY frame arrives on this session. */
+  waitForGoaway(): Promise<FakeGoaway>;
   /** The raw accepted socket (pause it to simulate a half-open peer). */
   rawSocket: Duplex;
+}
+
+export interface FakeGoaway {
+  errorCode: number;
+  lastStreamID: number;
+  opaqueData?: Buffer;
 }
 
 export interface FakeCloud {
@@ -118,6 +128,14 @@ export function startFakeCloud(options: FakeCloudOptions): Promise<FakeCloud> {
     });
     session.on("error", () => {}); // teardown resets are expected in tests
     sessions.push(session);
+    const goaways: FakeGoaway[] = [];
+    const goawayWaiters: Array<(goaway: FakeGoaway) => void> = [];
+    session.on("goaway", (errorCode, lastStreamID, opaqueData) => {
+      const goaway: FakeGoaway = { errorCode, lastStreamID, opaqueData };
+      goaways.push(goaway);
+      const waiters = goawayWaiters.splice(0);
+      for (const waiter of waiters) waiter(goaway);
+    });
 
     let credsResolve!: (h: http2.IncomingHttpHeaders) => void;
     const creds = new Promise<http2.IncomingHttpHeaders>((resolve) => {
@@ -162,6 +180,12 @@ export function startFakeCloud(options: FakeCloudOptions): Promise<FakeCloud> {
       index,
       creds,
       session,
+      goaways,
+      waitForGoaway() {
+        const last = goaways.at(-1);
+        if (last !== undefined) return Promise.resolve(last);
+        return new Promise((resolve) => goawayWaiters.push(resolve));
+      },
       rawSocket,
     };
     connections.push(conn);

--- a/packages/libs/restate-sdk-tunnel/test/fake-cloud.ts
+++ b/packages/libs/restate-sdk-tunnel/test/fake-cloud.ts
@@ -90,7 +90,7 @@ export interface FakeCloud {
 }
 
 export interface FakeCloudOptions {
-  /** Serve TLS (no ALPN — like the real tunnel listener). Plaintext if omitted. */
+  /** Serve TLS with h2 ALPN. Plaintext if omitted. */
   tls?: { cert: Buffer; key: Buffer };
   /**
    * Decide the handshake trailers for a connection, given the deployment's

--- a/packages/libs/restate-sdk-tunnel/test/multihome.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/multihome.test.ts
@@ -188,12 +188,14 @@ describe("multi-homing — DNS reconciliation (region mode)", () => {
       Promise.resolve([{ address: "127.0.0.1", family: 4 }] as never)
     );
 
+    const logs: string[] = [];
     const { tunnelServers: _drop, ...opts } = baseOptions([]);
     const conn = connectTunnel({
       ...opts,
       region: "us",
       tls: false, // plaintext fakes; region targets follow the global tls option
       resolveIntervalMs: 60,
+      tunnelDiagnosticLogger: (m) => logs.push(m),
     });
     try {
       await conn.ready;
@@ -206,6 +208,9 @@ describe("multi-homing — DNS reconciliation (region mode)", () => {
       ];
       await fake2.waitForConnection(0);
       await until(() => conn.connectionCount === 2, 2_000, "second handshake");
+      expect(logs.join("\n")).toContain(
+        `tunnel: discovered new tunnel target(s): 127.0.0.1:${fake2.port}`
+      );
 
       // The first server vanishes from DNS → its slot is torn down.
       current = [{ name: "node-2.tunnel.internal", port: fake2.port }];
@@ -215,6 +220,9 @@ describe("multi-homing — DNS reconciliation (region mode)", () => {
         "vanished server torn down"
       );
       expect(fake2.connections[0]!.session.destroyed).toBe(false);
+      expect(logs.join("\n")).toContain(
+        `tunnel: tunnel target(s) disappeared: 127.0.0.1:${fake1.port}`
+      );
     } finally {
       await conn.close();
       await fake1.close();

--- a/packages/libs/restate-sdk-tunnel/test/options.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/options.test.ts
@@ -416,6 +416,7 @@ describe("parseServerAddress", () => {
 describe("client-drain / graceful-shutdown options", () => {
   test("startupReady is optional and can be promise- or callback-backed", async () => {
     expect(resolveOptions(valid).startupReady).toBeUndefined();
+    expect(resolveOptions(valid).startupReadyTimeoutMs).toBe(120_000);
     await expect(
       resolveOptions({
         ...valid,
@@ -428,6 +429,13 @@ describe("client-drain / graceful-shutdown options", () => {
         startupReady: () => Promise.resolve(),
       }).startupReady?.()
     ).resolves.toBeUndefined();
+    expect(
+      resolveOptions({ ...valid, startupReadyTimeoutMs: 5_000 })
+        .startupReadyTimeoutMs
+    ).toBe(5_000);
+    expect(() =>
+      resolveOptions({ ...valid, startupReadyTimeoutMs: 0 })
+    ).toThrow(/startupReadyTimeoutMs must be a positive number/);
   });
 
   test("supportsClientDrain defaults to true", () => {

--- a/packages/libs/restate-sdk-tunnel/test/options.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/options.test.ts
@@ -414,6 +414,22 @@ describe("parseServerAddress", () => {
 });
 
 describe("client-drain / graceful-shutdown options", () => {
+  test("startupReady is optional and can be promise- or callback-backed", async () => {
+    expect(resolveOptions(valid).startupReady).toBeUndefined();
+    await expect(
+      resolveOptions({
+        ...valid,
+        startupReady: Promise.resolve(),
+      }).startupReady?.()
+    ).resolves.toBeUndefined();
+    await expect(
+      resolveOptions({
+        ...valid,
+        startupReady: () => Promise.resolve(),
+      }).startupReady?.()
+    ).resolves.toBeUndefined();
+  });
+
   test("supportsClientDrain defaults to true", () => {
     expect(resolveOptions(valid).supportsClientDrain).toBe(true);
   });

--- a/packages/libs/restate-sdk-tunnel/test/options.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/options.test.ts
@@ -22,6 +22,7 @@ import {
   CLOUD_REGION_ENV,
   SIGNING_PUBLIC_KEY_ENV,
   AUTH_TOKEN_FILE_ENV,
+  TUNNEL_WORKER_ID_ENV,
 } from "../src/options.js";
 import { parseServerAddress } from "../src/targets.js";
 import type { ConnectTunnelOptions } from "../src/types.js";
@@ -35,26 +36,27 @@ const valid: ConnectTunnelOptions = {
   services: [],
 };
 
-const INPROC_ENVS = [
+const OPTION_ENVS = [
   TUNNEL_NAME_ENV,
   ENVIRONMENT_ID_ENV,
   CLOUD_REGION_ENV,
   SIGNING_PUBLIC_KEY_ENV,
   AUTH_TOKEN_FILE_ENV,
+  TUNNEL_WORKER_ID_ENV,
 ];
 
-// Options resolution reads RESTATE_INPROC_* fallbacks from process.env;
-// isolate every test from the host environment and from each other.
+// Options resolution reads environment fallbacks from process.env; isolate
+// every test from the host environment and from each other.
 const savedEnv: Record<string, string | undefined> = {};
 const tmpDirs: string[] = [];
 beforeEach(() => {
-  for (const name of INPROC_ENVS) {
+  for (const name of OPTION_ENVS) {
     savedEnv[name] = process.env[name];
     delete process.env[name];
   }
 });
 afterEach(() => {
-  for (const name of INPROC_ENVS) {
+  for (const name of OPTION_ENVS) {
     if (savedEnv[name] === undefined) delete process.env[name];
     else process.env[name] = savedEnv[name];
   }
@@ -77,6 +79,7 @@ describe("resolveOptions — validation", () => {
     expect(r.connectionWindowSize).toBe(16 * 1024 * 1024);
     expect(r.maxSessionMemory).toBe(256);
     expect(r.tls).toBe(true);
+    expect(r.tunnelWorkerId).toMatch(/^[\x21-\x7e]+$/);
   });
 
   test("accepts a multi-label (BYOC) region", () => {
@@ -176,6 +179,15 @@ describe("resolveOptions — validation", () => {
     ).toThrow(/env_/);
   });
 
+  test("rejects a header-hostile tunnel worker id", () => {
+    expect(() =>
+      resolveOptions({ ...valid, tunnelWorkerId: "worker id" })
+    ).toThrow(/HTTP header/);
+    expect(() =>
+      resolveOptions({ ...valid, tunnelWorkerId: "worker\nid" })
+    ).toThrow(/HTTP header/);
+  });
+
   test("rejects non-positive numeric options", () => {
     expect(() => resolveOptions({ ...valid, reconnectInitialMs: 0 })).toThrow(
       /positive/
@@ -224,6 +236,16 @@ describe("resolveOptions — RESTATE_INPROC_* environment fallbacks", () => {
     expect(r.srvName).toBe("tunnel.us.restate.cloud");
     expect(r.signingPublicKey).toBe(valid.signingPublicKey);
     expect(r.authToken()).toBe("key_xyz.secret");
+  });
+
+  test("tunnelWorkerId falls back to RESTATE_TUNNEL_WORKER_ID and can be explicit", () => {
+    process.env[TUNNEL_WORKER_ID_ENV] = "worker-from-env";
+
+    expect(resolveOptions(valid).tunnelWorkerId).toBe("worker-from-env");
+    expect(
+      resolveOptions({ ...valid, tunnelWorkerId: "worker-explicit" })
+        .tunnelWorkerId
+    ).toBe("worker-explicit");
   });
 
   test("an explicit discovery option beats an injected region", () => {

--- a/packages/libs/restate-sdk-tunnel/test/resilience.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/resilience.test.ts
@@ -147,6 +147,32 @@ describe("startup readiness gate", () => {
     }
   });
 
+  test("a stuck startupReady gate fails fatally without dialing", async () => {
+    const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const logs: string[] = [];
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      startupReady: new Promise<void>(() => {}),
+      startupReadyTimeoutMs: 20,
+      tunnelDiagnosticLogger: (m) => logs.push(m),
+    });
+    try {
+      await expect(conn.ready).rejects.toThrow(
+        /startup readiness gate failed: startup readiness gate timed out after 20ms/
+      );
+      expect(fake.connections.length).toBe(0);
+      expect(logs.join("\n")).toMatch(
+        /tunnel: waiting for startup readiness gate \(timeoutMs=20\)/
+      );
+      expect(logs.join("\n")).toMatch(
+        /tunnel: FATAL .* startup readiness gate timed out after 20ms/
+      );
+    } finally {
+      await conn.close();
+      await fake.close();
+    }
+  });
+
   test("a forwarded request before the tunnel handshake gets the not-ready sentinel, never 502", async () => {
     let sessionResolve!: (session: http2.ClientHttp2Session) => void;
     const sessionPromise = new Promise<http2.ClientHttp2Session>((resolve) => {

--- a/packages/libs/restate-sdk-tunnel/test/resilience.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/resilience.test.ts
@@ -173,6 +173,26 @@ describe("startup readiness gate", () => {
     }
   });
 
+  test("close() while startupReady is pending stops cleanly without dialing", async () => {
+    const gate = deferred<void>();
+    const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      startupReady: gate.promise,
+      startupReadyTimeoutMs: 5_000,
+    });
+    try {
+      const start = Date.now();
+      await conn.close();
+      expect(Date.now() - start).toBeLessThan(500);
+      await expect(conn.ready).rejects.toThrow(/closed before the first handshake/);
+      expect(conn.error).toBeUndefined();
+      expect(fake.connections.length).toBe(0);
+    } finally {
+      await fake.close();
+    }
+  });
+
   test("a forwarded request before the tunnel handshake gets the not-ready sentinel, never 502", async () => {
     let sessionResolve!: (session: http2.ClientHttp2Session) => void;
     const sessionPromise = new Promise<http2.ClientHttp2Session>((resolve) => {

--- a/packages/libs/restate-sdk-tunnel/test/resilience.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/resilience.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, test } from "vitest";
 import * as net from "node:net";
+import * as http2 from "node:http2";
 import { once } from "node:events";
 import * as restate from "@restatedev/restate-sdk";
 
@@ -56,6 +57,28 @@ const baseOptions = (port: number): ConnectTunnelOptions => ({
 
 const DISCOVER_ACCEPT = "application/vnd.restate.endpointmanifest.v2+json";
 
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (err: Error) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const discoverReq = () => ({
+  ":method": "GET",
+  ":path": "/http/h/9080/discover",
+  accept: DISCOVER_ACCEPT,
+  "x-restate-signature-scheme": "v1",
+  "x-restate-jwt-v1": identity.sign("/discover"),
+});
+
 describe("handshake gate", () => {
   test("a request coalesced with the ok-trailers is served, not 503'd", async () => {
     // The real proxy parks pending invocations and fires them the instant
@@ -85,6 +108,80 @@ describe("handshake gate", () => {
     } finally {
       await conn.close();
       await fake.close();
+    }
+  });
+});
+
+describe("startup readiness gate", () => {
+  test("does not connect to the tunnel server until startupReady resolves, then serves", async () => {
+    const gate = deferred<void>();
+    const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const logs: string[] = [];
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      startupReady: gate.promise,
+      tunnelDiagnosticLogger: (m) => logs.push(m),
+    });
+    try {
+      await new Promise((r) => setTimeout(r, 120));
+      expect(fake.connections.length).toBe(0);
+      expect(conn.connectionCount).toBe(0);
+      expect(logs.join("\n")).toMatch(
+        /tunnel: waiting for startup readiness gate/
+      );
+
+      gate.resolve();
+      await conn.ready;
+      expect(fake.connections.length).toBe(1);
+      expect(logs.join("\n")).toMatch(
+        /tunnel: startup readiness gate passed/
+      );
+
+      const c0 = await fake.waitForConnection(0);
+      const result = await roundtrip(c0.session, discoverReq());
+      expect(result.status).toBe(200);
+      expect(result.body).toContain("greeter");
+    } finally {
+      await conn.close();
+      await fake.close();
+    }
+  });
+
+  test("a forwarded request before the tunnel handshake gets the not-ready sentinel, never 502", async () => {
+    let sessionResolve!: (session: http2.ClientHttp2Session) => void;
+    const sessionPromise = new Promise<http2.ClientHttp2Session>((resolve) => {
+      sessionResolve = resolve;
+    });
+    const server = net.createServer((rawSocket) => {
+      const session = http2.connect("http://fake-tunnel-peer", {
+        createConnection: () => rawSocket,
+      });
+      session.on("error", () => {});
+      sessionResolve(session);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+
+    const logs: string[] = [];
+    const conn = connectTunnel({
+      ...baseOptions(port),
+      handshakeTimeoutMs: 500,
+      tunnelDiagnosticLogger: (m) => logs.push(m),
+    });
+    try {
+      const session = await sessionPromise;
+      const result = await roundtrip(session, discoverReq());
+      expect(result.status).toBe(503);
+      expect(result.status).not.toBe(502);
+      expect(result.headers["x-restate-tunnel-draining"]).toBe("true");
+      expect(result.body).toContain("tunnel: not ready");
+      expect(logs.join("\n")).toMatch(
+        /tunnel: refused forwarded stream \d+ before tunnel handshake completed/
+      );
+    } finally {
+      await conn.close();
+      server.close();
     }
   });
 });

--- a/packages/libs/restate-sdk-tunnel/test/shutdown.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/shutdown.test.ts
@@ -15,6 +15,8 @@
 // sentinel, drains its in-flight invocations, and then tears down.
 
 import * as http2 from "node:http2";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import * as restate from "@restatedev/restate-sdk";
 
@@ -70,6 +72,18 @@ function withTimeout<T>(
       }
     );
   });
+}
+
+async function until(
+  cond: () => boolean,
+  timeoutMs = 2_000,
+  what = "condition"
+): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error(`timed out: ${what}`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
 }
 
 const greeter = restate.service({
@@ -288,6 +302,55 @@ describe("client-initiated graceful shutdown", () => {
     }
   });
 
+  test("shutdown() drains every active tunnel connection", async () => {
+    const fake1 = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const fake2 = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const conn = connectTunnel({
+      ...baseOptions(fake1.port),
+      tunnelServers: [
+        `http://127.0.0.1:${fake1.port}`,
+        `http://127.0.0.1:${fake2.port}`,
+      ],
+      drainGraceMs: 5_000,
+    });
+    try {
+      await conn.ready;
+      await until(() => conn.connectionCount === 2, 2_000, "both handshakes");
+      const c1 = await fake1.waitForConnection(0);
+      const c2 = await fake2.waitForConnection(0);
+      const held1 = await openHeldInvocation(c1.session);
+      const held2 = await openHeldInvocation(c2.session);
+
+      let shutdownDone = false;
+      const done = conn.shutdown().then(() => {
+        shutdownDone = true;
+      });
+
+      const [goaway1, goaway2] = await Promise.all([
+        c1.waitForGoaway(),
+        c2.waitForGoaway(),
+      ]);
+      expect(goaway1.errorCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+      expect(goaway2.errorCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+      expect(shutdownDone).toBe(false);
+
+      held1.close();
+      await new Promise((r) => setTimeout(r, 120));
+      expect(shutdownDone).toBe(false);
+
+      held2.close();
+      await done;
+      expect(shutdownDone).toBe(true);
+      await Promise.all([waitForClose(c1.session), waitForClose(c2.session)]);
+      expect(c1.session.destroyed).toBe(true);
+      expect(c2.session.destroyed).toBe(true);
+    } finally {
+      await conn.close();
+      await fake1.close();
+      await fake2.close();
+    }
+  });
+
   test("SIGTERM handler starts drain and exits after in-flight work completes", async () => {
     const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
     const conn = connectTunnel({
@@ -383,6 +446,38 @@ describe("client-initiated graceful shutdown", () => {
       expect(elapsed).toBeLessThan(2_000);
       await waitForClose(c0.session);
       expect(c0.session.destroyed).toBe(true);
+    } finally {
+      await conn.close();
+      await fake.close();
+    }
+  });
+
+  test("graceful h2 close is force-settled when the peer stops reading", async () => {
+    const cert = fs.readFileSync(path.join(__dirname, "fixtures", "cert.pem"));
+    const key = fs.readFileSync(path.join(__dirname, "fixtures", "key.pem"));
+    const fake = await startFakeCloud({
+      tls: { cert, key },
+      decideTrailers: () => okTrailers(),
+    });
+    const logs: string[] = [];
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      tunnelServers: [`127.0.0.1:${fake.port}`],
+      tls: { ca: cert },
+      tunnelDiagnosticLogger: (m) => logs.push(m),
+    });
+    try {
+      await conn.ready;
+      const c0 = await fake.waitForConnection(0);
+      c0.rawSocket.pause();
+
+      const start = Date.now();
+      await conn.shutdown();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeGreaterThanOrEqual(900);
+      expect(elapsed).toBeLessThan(2_500);
+      expect(logs.join("\n")).toContain("detail=session.close() timed out");
     } finally {
       await conn.close();
       await fake.close();

--- a/packages/libs/restate-sdk-tunnel/test/shutdown.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/shutdown.test.ts
@@ -391,6 +391,63 @@ describe("client-initiated graceful shutdown", () => {
     }
   });
 
+  test("SIGTERM handler waits for every tunnel in the process before exiting", async () => {
+    const fake1 = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const fake2 = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const conn1 = connectTunnel({
+      ...baseOptions(fake1.port),
+      drainGraceMs: 5_000,
+    });
+    const conn2 = connectTunnel({
+      ...baseOptions(fake2.port),
+      drainGraceMs: 5_000,
+    });
+    let exitCode: string | number | null | undefined;
+    let resolveExit!: () => void;
+    const exitCalled = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: string | number | null | undefined) => {
+        exitCode = code;
+        resolveExit();
+        return undefined as never;
+      }) as typeof process.exit);
+    try {
+      await Promise.all([conn1.ready, conn2.ready]);
+      const c1 = await fake1.waitForConnection(0);
+      const c2 = await fake2.waitForConnection(0);
+      const held1 = await openHeldInvocation(c1.session);
+      const held2 = await openHeldInvocation(c2.session);
+
+      process.emit("SIGTERM", "SIGTERM");
+
+      const [goaway1, goaway2] = await Promise.all([
+        c1.waitForGoaway(),
+        c2.waitForGoaway(),
+      ]);
+      expect(goaway1.errorCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+      expect(goaway2.errorCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      held1.close();
+      await new Promise((r) => setTimeout(r, 120));
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      held2.close();
+      await withTimeout(exitCalled, "SIGTERM handler did not call process.exit");
+      expect(exitCode).toBe(0);
+      await Promise.all([waitForClose(c1.session), waitForClose(c2.session)]);
+    } finally {
+      exitSpy.mockRestore();
+      await conn1.close();
+      await conn2.close();
+      await fake1.close();
+      await fake2.close();
+    }
+  });
+
   test("drains in-flight invocations while refusing new ones", async () => {
     const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
     const conn = connectTunnel({

--- a/packages/libs/restate-sdk-tunnel/test/shutdown.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/shutdown.test.ts
@@ -10,13 +10,12 @@
  */
 
 // Client-initiated graceful shutdown: on shutdown() the client advertises the
-// capability at handshake, refuses NEW invocations with the
-// `x-restate-tunnel-draining` sentinel (so the cloud deselects this
-// connection) without running them, drains its in-flight invocations, and then
-// tears down.
+// capability at handshake, sends GOAWAY proactively so the cloud stops opening
+// new streams, refuses any raced streams with the `x-restate-tunnel-draining`
+// sentinel, drains its in-flight invocations, and then tears down.
 
-import type * as http2 from "node:http2";
-import { describe, expect, test } from "vitest";
+import * as http2 from "node:http2";
+import { describe, expect, test, vi } from "vitest";
 import * as restate from "@restatedev/restate-sdk";
 
 import { connectTunnel } from "../src/index.js";
@@ -49,6 +48,27 @@ function waitForClose(
       clearTimeout(timer);
       resolve();
     });
+  });
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  message: string,
+  timeoutMs = 2_000
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    timer.unref();
+    void promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
   });
 }
 
@@ -90,6 +110,48 @@ const discoverReq = () => ({
   "x-restate-signature-scheme": "v1",
   "x-restate-jwt-v1": identity.sign("/discover"),
 });
+
+async function openHeldInvocation(session: http2.ClientHttp2Session) {
+  const disc = await roundtrip(session, discoverReq());
+  expect(disc.status).toBe(200);
+  const maxVersion = (
+    JSON.parse(disc.body) as { maxProtocolVersion: number }
+  ).maxProtocolVersion;
+  const invokePath = "/invoke/greeter/greet";
+  const held = session.request(
+    {
+      ":method": "POST",
+      ":path": `/http/h/9080${invokePath}`,
+      "content-type": `application/vnd.restate.invocation.v${maxVersion}`,
+      "x-restate-signature-scheme": "v1",
+      "x-restate-jwt-v1": identity.sign(invokePath),
+    },
+    { endStream: false } // keep the request open → invocation stays in flight
+  );
+  held.on("error", () => {});
+  held.resume();
+  // Let the forwarded invocation register as in-flight before draining.
+  await new Promise((r) => setTimeout(r, 80));
+  return held;
+}
+
+async function expectDrainedOrGoawayRefusal(
+  session: http2.ClientHttp2Session
+): Promise<void> {
+  const result = await roundtrip(session, discoverReq()).then(
+    (res) => ({ kind: "response" as const, res }),
+    (err) => ({ kind: "error" as const, err })
+  );
+  if (result.kind === "response") {
+    expect(result.res.status).toBe(503);
+    expect(result.res.headers["x-restate-tunnel-draining"]).toBe("true");
+    expect(result.res.body).not.toContain("greeter");
+    return;
+  }
+  expect((result.err as { code?: string }).code).toBe(
+    "ERR_HTTP2_GOAWAY_SESSION"
+  );
+}
 
 describe("client-initiated graceful shutdown", () => {
   test("advertises supports-client-drain by default", async () => {
@@ -185,7 +247,7 @@ describe("client-initiated graceful shutdown", () => {
     }
   });
 
-  test("drains in-flight invocations while refusing new ones with the sentinel", async () => {
+  test("shutdown() proactively sends GOAWAY before in-flight work completes", async () => {
     const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
     const conn = connectTunnel({
       ...baseOptions(fake.port),
@@ -194,29 +256,88 @@ describe("client-initiated graceful shutdown", () => {
     try {
       await conn.ready;
       const c0 = await fake.waitForConnection(0);
+      const held = await openHeldInvocation(c0.session);
+      const heldStreamID = held.id;
+      if (heldStreamID === undefined) {
+        throw new Error("held invocation stream has no HTTP/2 stream ID");
+      }
 
-      // Learn the service-protocol version so we can open a real invocation
-      // and hold it in flight (the SDK waits for input on the request stream).
-      const disc = await roundtrip(c0.session, discoverReq());
-      expect(disc.status).toBe(200);
-      const maxVersion = (
-        JSON.parse(disc.body) as { maxProtocolVersion: number }
-      ).maxProtocolVersion;
-      const invokePath = "/invoke/greeter/greet";
-      const held = c0.session.request(
-        {
-          ":method": "POST",
-          ":path": `/http/h/9080${invokePath}`,
-          "content-type": `application/vnd.restate.invocation.v${maxVersion}`,
-          "x-restate-signature-scheme": "v1",
-          "x-restate-jwt-v1": identity.sign(invokePath),
-        },
-        { endStream: false } // keep the request open → invocation stays in flight
+      let shutdownDone = false;
+      const done = conn.shutdown().then(() => {
+        shutdownDone = true;
+      });
+
+      const goaway = await c0.waitForGoaway();
+      expect(goaway.errorCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+      // GOAWAY is connection-scoped, but its lastStreamID must still cover
+      // streams already accepted by the SDK so in-flight invocations can
+      // drain rather than being treated as unprocessed by the peer.
+      expect(goaway.lastStreamID).toBeGreaterThanOrEqual(heldStreamID);
+      expect(shutdownDone).toBe(false);
+      await expect(roundtrip(c0.session, discoverReq())).rejects.toMatchObject(
+        { code: "ERR_HTTP2_GOAWAY_SESSION" }
       );
-      held.on("error", () => {});
-      held.resume();
-      // Let the forwarded invocation register as in-flight before draining.
-      await new Promise((r) => setTimeout(r, 80));
+
+      held.close();
+      await done;
+      expect(shutdownDone).toBe(true);
+      await waitForClose(c0.session);
+    } finally {
+      await conn.close();
+      await fake.close();
+    }
+  });
+
+  test("SIGTERM handler starts drain and exits after in-flight work completes", async () => {
+    const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      drainGraceMs: 5_000,
+    });
+    let exitCode: string | number | null | undefined;
+    let resolveExit!: () => void;
+    const exitCalled = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: string | number | null | undefined) => {
+        exitCode = code;
+        resolveExit();
+        return undefined as never;
+      }) as typeof process.exit);
+    try {
+      await conn.ready;
+      const c0 = await fake.waitForConnection(0);
+      const held = await openHeldInvocation(c0.session);
+
+      process.emit("SIGTERM", "SIGTERM");
+
+      const goaway = await c0.waitForGoaway();
+      expect(goaway.errorCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      held.close();
+      await withTimeout(exitCalled, "SIGTERM handler did not call process.exit");
+      expect(exitCode).toBe(0);
+      await waitForClose(c0.session);
+    } finally {
+      exitSpy.mockRestore();
+      await conn.close();
+      await fake.close();
+    }
+  });
+
+  test("drains in-flight invocations while refusing new ones", async () => {
+    const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      drainGraceMs: 5_000,
+    });
+    try {
+      await conn.ready;
+      const c0 = await fake.waitForConnection(0);
+      const held = await openHeldInvocation(c0.session);
 
       // Begin graceful shutdown; it must NOT resolve while the invocation runs.
       let shutdownDone = false;
@@ -226,17 +347,40 @@ describe("client-initiated graceful shutdown", () => {
       await new Promise((r) => setTimeout(r, 120));
       expect(shutdownDone).toBe(false); // still draining the in-flight invocation
 
-      // A NEW invocation is refused with the sentinel, WITHOUT running the
-      // handler (no manifest body) — the cloud will retry it elsewhere.
-      const refused = await roundtrip(c0.session, discoverReq());
-      expect(refused.status).toBe(503);
-      expect(refused.headers["x-restate-tunnel-draining"]).toBe("true");
-      expect(refused.body).not.toContain("greeter");
+      // A NEW invocation is refused immediately. If it races ahead of the
+      // proactive GOAWAY it gets the existing drain sentinel; once GOAWAY has
+      // arrived, Node refuses to open the stream at all.
+      await expectDrainedOrGoawayRefusal(c0.session);
 
       // The in-flight invocation finishes → shutdown completes and tears down.
       held.close();
       await done;
       expect(shutdownDone).toBe(true);
+      await waitForClose(c0.session);
+      expect(c0.session.destroyed).toBe(true);
+    } finally {
+      await conn.close();
+      await fake.close();
+    }
+  });
+
+  test("grace expiry force-closes an in-flight invocation", async () => {
+    const fake = await startFakeCloud({ decideTrailers: () => okTrailers() });
+    const conn = connectTunnel({
+      ...baseOptions(fake.port),
+      drainGraceMs: 80,
+    });
+    try {
+      await conn.ready;
+      const c0 = await fake.waitForConnection(0);
+      await openHeldInvocation(c0.session);
+
+      const start = Date.now();
+      await conn.shutdown();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeGreaterThanOrEqual(60);
+      expect(elapsed).toBeLessThan(2_000);
       await waitForClose(c0.session);
       expect(c0.session.destroyed).toBe(true);
     } finally {

--- a/packages/libs/restate-sdk-tunnel/test/targets.test.ts
+++ b/packages/libs/restate-sdk-tunnel/test/targets.test.ts
@@ -78,6 +78,7 @@ describe("resolveTargets — region / SRV", () => {
   });
 
   test("a TRANSPORT error (EAI_AGAIN) fails the whole resolution — healthy slots must not be torn down over a resolver blip", async () => {
+    const logs: string[] = [];
     resolveSrv.mockResolvedValueOnce([
       { name: "alive.internal", port: 1000, priority: 0, weight: 1 },
       { name: "flaky.internal", port: 1001, priority: 0, weight: 1 },
@@ -91,8 +92,14 @@ describe("resolveTargets — region / SRV", () => {
           )
         : Promise.resolve([{ address: "10.0.0.9", family: 4 }])) as never);
     await expect(
-      resolveTargets({ srvName: "tunnel.eu.example" })
+      resolveTargets({
+        srvName: "tunnel.eu.example",
+        logger: (m) => logs.push(m),
+      })
     ).rejects.toThrow(/temporary failure/);
+    expect(logs.join("\n")).toContain(
+      "tunnel: address lookup for SRV target flaky.internal:1001 failed: temporary failure"
+    );
   });
 
   test("all-negative answers yield an EMPTY set (everything reconciled away, like Rust)", async () => {


### PR DESCRIPTION
## Summary
- send h2 GOAWAY when client drain starts so tunnel-server stops opening new streams proactively
- drain in-flight streams until grace, then close h2 sessions gracefully or force teardown after expiry, with a bounded fallback if graceful h2 close wedges
- cover the real default SIGTERM path by stubbing process.exit, emitting SIGTERM, and asserting proactive drain before exit
- coordinate default process-signal shutdown across multiple `connectTunnel()` instances in the same process, so `process.exit(0)` waits for every registered tunnel to drain
- document that GOAWAY does not abort already accepted streams by asserting its `lastStreamID` covers the held in-flight invocation
- add multi-connection shutdown coverage so every active tunnel connection receives GOAWAY and the shared drain waits for all in-flight work
- add an opt-in startup readiness gate: `startupReady` can be a promise or callback, and the supervisor waits for it before resolving targets or dialing any tunnel server
- add `startupReadyTimeoutMs` (default 120s when `startupReady` is supplied) so a stuck startup gate fails visibly as a fatal tunnel error instead of leaving the worker silently absent from the fleet
- defensively return the existing not-ready sentinel (`503` + `x-restate-tunnel-draining:true`) for forwarded streams that arrive before the tunnel is ready, and log those refusals with connection identity
- send advisory `tunnel-worker-id` and `tunnel-connection-id` headers during `/_/start-tunnel`; `tunnelWorkerId` is stable for the SDK process and configurable via `RESTATE_TUNNEL_WORKER_ID`, while connection ids are compact ULID-like per h2 connection
- add tunnel diagnostic logs for target resolution, SRV target changes, lookup errors, socket/h2 establishment and settings, service readiness, server drain notifications, GOAWAY send failures, stream failures, and terminal connection outcomes, with worker/connection ids attached where applicable
- fix tunnel TLS docs/JSDoc to match current ALPN h2 behavior
- document generic Kubernetes graceful termination requirements, with GKE Autopilot linked only as an example of provider-specific eviction limits

## Forwarded-path finding
- The current in-process tunnel client does **not** dial a local `:9080` socket. `forwardedTail()` strips `/<scheme>/<host>/<port>` because the destination is vestigial for in-process SDK deployments.
- `connectTunnel()` builds a shared in-process SDK endpoint handler with `createEndpointHandler(...)`; forwarded requests are passed to that handler after the prefix is stripped.
- The response status for handler traffic is written from the SDK response head, not from a local proxy error mapper.
- I did not find a local `ECONNREFUSED` / socket-closed / handler-not-listening path in this package that maps to `502`. If a `502 Bad Gateway` is relayed through this in-process tunnel path, it is coming from another component/path or from handler/VM-generated response state, not from a tunnel-client TCP forwarder in this package.

## Deployment notes
- The startup readiness gate is opt-in. Existing callers that do not pass `startupReady` keep the previous behavior and dial immediately.
- Deployments with async startup work should either call `connectTunnel()` only after the local handler/dependencies are ready or pass `startupReady` wired to that real readiness signal. Agent-controller needs this wiring for the scale-up race to be eliminated.
- The sentinel is intentionally reused for now: `x-restate-tunnel-draining:true` is the server-understood deselect/retry signal. A distinct not-ready signal would need a protocol/server update.

## Kubernetes / managed-platform notes
- This fixes node drain/eviction only when SIGTERM reaches the SDK process and the effective pod/node grace window covers the SDK drain.
- Kubernetes pod termination sends TERM to process 1, then SIGKILL after the grace expires: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
- Container images should use an exec-form entrypoint, `exec` from wrapper scripts, or a signal-forwarding init wrapper so Node receives SIGTERM; Docker documents that shell-form ENTRYPOINT runs via `/bin/sh -c` and does not pass Unix signals: https://docs.docker.com/reference/dockerfile/#entrypoint
- Configure `terminationGracePeriodSeconds >= ceil(drainGraceMs / 1000)` plus the handler slack you expect to preserve.
- The default signal handler calls `process.exit(0)` after all registered tunnels in the process finish draining. Embedded applications that need to coordinate other shutdown work should pass `gracefulShutdown: false`, handle signals themselves, call `shutdown()` on each tunnel, and exit after their own cleanup.
- Managed platforms can impose event-specific eviction windows. For example, GKE Autopilot documents bounded GKE-initiated eviction grace: automatic node upgrades can be up to one hour and scale-down events up to 10 minutes: https://cloud.google.com/kubernetes-engine/docs/how-to/extended-duration-pods#about_gke-initiated_pod_eviction
- If a platform cuts the pod earlier than the drain window, tunnel-server stale-connection keepalive/socket-failure handling remains the backstop.

## Review follow-up
- `6da415eb` addresses external-review blockers: stale ALPN JSDoc and multi-connection client-drain coverage.
- The same commit adds coverage for the `session.close()` timeout fallback and `close()` while startup readiness is still pending.
- It also treats close/abort racing with startup readiness timeout as clean stop, marks the startup dispatch guard as defensive, and strips query strings from forwarded-path error logs.
- `c72298f4` addresses the follow-up review around default signal shutdown: signal handling is process-coordinated across multiple tunnels, the overloaded startup readiness boolean was renamed, forwarded-path log-only URL work was deferred to error paths, synchronous SDK handler throws now produce a contained 500 instead of rethrowing into the h2 request emitter, and README/JSDoc now explicitly call out the default `process.exit(0)` behavior.

## Verification
- CI: pending on `c72298f4` after the latest push
- Prior CI: Build and test / build (22.x) passed `pnpm verify` on `a76a3ebd`
- Prior CI: compatibility checks passed on `a76a3ebd` (`node`, `deno`, `bun`, `cloudflare`, `vercel`, `lambda`)
- Previous CI tunnel package: `@restatedev/restate-sdk-tunnel:_test` passed; `test/shutdown.test.ts` passed 9 tests; tunnel package total 100 tests passed on `b937ea7d`
- Local: `git diff --check`
- Local requested command: `pnpm --filter @restatedev/restate-sdk-tunnel exec vitest run` still fails before running tests due the Volta/Corepack pnpm signature mismatch (`Cannot find matching keyid`)
- Local workaround: `/Users/pavel/Library/pnpm/.tools/pnpm/11.1.1/bin/pnpm --filter @restatedev/restate-sdk-tunnel exec vitest run` passed: 7 files, 110 tests
- Local workaround: `/Users/pavel/Library/pnpm/.tools/pnpm/11.1.1/bin/pnpm --filter @restatedev/restate-sdk-tunnel build` passed: 3 packages built (`@restatedev/restate-sdk-core`, `@restatedev/restate-sdk`, `@restatedev/restate-sdk-tunnel`)
