### PR TITLE
Auto-retry ingress calls on 5xx/429/network errors when an idempotency key is set

### DIFF
--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -441,16 +441,41 @@ export type IngressSendClient<M> = {
 };
 
 /**
+ * An ambiguous ingress failure that may be retried.
+ *
+ * Passed to {@link RetryPolicy.shouldRetry} so a caller can inspect the failure
+ * and decide whether to retry.
+ */
+export type RetryFailure =
+  | {
+      /** The underlying `fetch` call rejected (connection refused/reset, DNS). */
+      readonly kind: "network";
+      readonly error: unknown;
+    }
+  | {
+      /** The server returned a non-2xx response. */
+      readonly kind: "response";
+      readonly status: number;
+      readonly headers: Headers;
+      /**
+       * The response body, decoded as text. Present (possibly empty) for
+       * response failures; absent only when the body could not be read.
+       */
+      readonly body?: string;
+    };
+
+/**
  * Policy controlling automatic retries of ambiguous ingress failures.
  *
- * Retries are only ever attempted when an `idempotencyKey` is set on the call
- * (see {@link IngressCallOptions.idempotencyKey}). Retrying without one could
+ * Retries are **opt-in**: they happen only when a policy is configured (see
+ * {@link ConnectionOpts.retry}) **and** the call carries an `idempotencyKey`
+ * (see {@link IngressCallOptions.idempotencyKey}). Retrying without a key could
  * double-execute a non-idempotent invocation, so the idempotency key is the
- * safety boundary — this policy can tune or disable retries, but never bypass
- * that gate.
+ * safety boundary that a policy can never bypass.
  *
- * The following failures are considered retryable: network errors (the
- * underlying `fetch` rejecting), HTTP `429`, and HTTP `5xx` responses.
+ * By default the following failures are retried: network errors (the underlying
+ * `fetch` rejecting), HTTP `429`, and HTTP `5xx` responses. Override this with
+ * {@link RetryPolicy.shouldRetry}.
  */
 export interface RetryPolicy {
   /**
@@ -475,6 +500,20 @@ export interface RetryPolicy {
    * Defaults to `2`.
    */
   multiplier?: number;
+
+  /**
+   * Decide whether a given failure should be retried. When provided, this
+   * fully replaces the built-in rule (network / `429` / `5xx`).
+   *
+   * The idempotency-key gate and the `maxRetries` cap still apply — this
+   * predicate only narrows or broadens *which failures* are retryable within
+   * those bounds. Compose with the built-in rule via the exported
+   * `defaultShouldRetry`.
+   *
+   * @param failure the failure being considered
+   * @param attempt the zero-based index of the attempt that just failed
+   */
+  shouldRetry?: (failure: RetryFailure, attempt: number) => boolean;
 }
 
 export type ConnectionOpts = {
@@ -490,18 +529,19 @@ export type ConnectionOpts = {
   headers?: Record<string, string>;
 
   /**
-   * Automatic retry policy for ambiguous ingress failures (network errors,
+   * Opt in to automatic retries of ambiguous ingress failures (network errors,
    * HTTP `429`, HTTP `5xx`).
    *
-   * Retries fire **only** when an `idempotencyKey` is set on the call — without
-   * one a retry could double-execute a non-idempotent invocation. With a key,
-   * Restate dedupes the request, so a retry safely attaches to the in-flight or
-   * completed invocation instead of starting a new one.
+   * Retries are **disabled by default**. Set `true` to enable the built-in
+   * policy ({@link RetryPolicy}), or pass a {@link RetryPolicy} to tune it.
    *
-   * Defaults to a built-in policy ({@link RetryPolicy}). Set to `false` to
-   * disable automatic retries entirely.
+   * Even when enabled, retries fire **only** when an `idempotencyKey` is set on
+   * the call — without one a retry could double-execute a non-idempotent
+   * invocation. With a key, Restate dedupes the request, so a retry safely
+   * attaches to the in-flight or completed invocation instead of starting a new
+   * one.
    */
-  retry?: RetryPolicy | false;
+  retry?: RetryPolicy | boolean;
 
   /**
    * Default serde to use for ingress payloads when no operation-specific serde

--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -458,8 +458,8 @@ export type RetryFailure =
       readonly status: number;
       readonly headers: Headers;
       /**
-       * The response body, decoded as text. Present (possibly empty) for
-       * response failures; absent only when the body could not be read.
+       * The response body, decoded as text, when the response carried a
+       * non-empty body; `undefined` otherwise.
        */
       readonly body?: string;
     };

--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -440,6 +440,43 @@ export type IngressSendClient<M> = {
     : never;
 };
 
+/**
+ * Policy controlling automatic retries of ambiguous ingress failures.
+ *
+ * Retries are only ever attempted when an `idempotencyKey` is set on the call
+ * (see {@link IngressCallOptions.idempotencyKey}). Retrying without one could
+ * double-execute a non-idempotent invocation, so the idempotency key is the
+ * safety boundary — this policy can tune or disable retries, but never bypass
+ * that gate.
+ *
+ * The following failures are considered retryable: network errors (the
+ * underlying `fetch` rejecting), HTTP `429`, and HTTP `5xx` responses.
+ */
+export interface RetryPolicy {
+  /**
+   * Maximum number of retries after the initial attempt.
+   *
+   * Defaults to `5` (up to 6 attempts in total).
+   */
+  maxRetries?: number;
+
+  /**
+   * Initial backoff interval, in milliseconds. Defaults to `100`.
+   */
+  initialInterval?: number;
+
+  /**
+   * Maximum backoff interval, in milliseconds. Defaults to `2000`.
+   */
+  maxInterval?: number;
+
+  /**
+   * Multiplier applied to the backoff interval after each attempt.
+   * Defaults to `2`.
+   */
+  multiplier?: number;
+}
+
 export type ConnectionOpts = {
   /**
    * Restate ingress URL.
@@ -451,6 +488,20 @@ export type ConnectionOpts = {
    * Use this to attach authentication headers.
    */
   headers?: Record<string, string>;
+
+  /**
+   * Automatic retry policy for ambiguous ingress failures (network errors,
+   * HTTP `429`, HTTP `5xx`).
+   *
+   * Retries fire **only** when an `idempotencyKey` is set on the call — without
+   * one a retry could double-execute a non-idempotent invocation. With a key,
+   * Restate dedupes the request, so a retry safely attaches to the in-flight or
+   * completed invocation instead of starting a new one.
+   *
+   * Defaults to a built-in policy ({@link RetryPolicy}). Set to `false` to
+   * disable automatic retries entirely.
+   */
+  retry?: RetryPolicy | false;
 
   /**
    * Default serde to use for ingress payloads when no operation-specific serde

--- a/packages/libs/restate-sdk-clients/src/index.ts
+++ b/packages/libs/restate-sdk-clients/src/index.ts
@@ -34,6 +34,7 @@ export type {
   IngressSendClient,
   IngressWorkflowClient,
   IngressCallOptions,
+  RetryPolicy,
   Send,
   IngressSendOptions,
   WorkflowSubmission,

--- a/packages/libs/restate-sdk-clients/src/index.ts
+++ b/packages/libs/restate-sdk-clients/src/index.ts
@@ -35,6 +35,7 @@ export type {
   IngressWorkflowClient,
   IngressCallOptions,
   RetryPolicy,
+  RetryFailure,
   Send,
   IngressSendOptions,
   WorkflowSubmission,
@@ -46,3 +47,4 @@ export { Opts, SendOpts } from "./api.js";
 export { rpc } from "./api.js";
 
 export { connect, HttpCallError } from "./ingress.js";
+export { defaultShouldRetry } from "./retry.js";

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -36,7 +36,7 @@ import { Opts, SendOpts } from "./api.js";
 import {
   abortableSleep,
   backoffDelay,
-  isRetryableStatus,
+  defaultShouldRetry,
   parseRetryAfter,
   resolveRetryPolicy,
 } from "./retry.js";
@@ -214,14 +214,16 @@ const doComponentInvocation = async <I, O>(
   //
   // retries
   //
-  // We only retry when the call carries an idempotency key: Restate then
-  // dedupes the request, so re-issuing it after an ambiguous failure (network
-  // error, 429, 5xx) safely attaches to the in-flight/completed invocation
-  // instead of starting a duplicate. Without a key, retrying is unsafe.
+  // Retries are opt-in (opts.retry) AND only ever attempted when the call
+  // carries an idempotency key: Restate then dedupes the request, so re-issuing
+  // it after an ambiguous failure (network error, 429, 5xx) safely attaches to
+  // the in-flight/completed invocation instead of starting a duplicate. Without
+  // a key, retrying is unsafe.
   //
   const retryPolicy = idempotencyKey
     ? resolveRetryPolicy(opts.retry)
     : undefined;
+  const shouldRetry = retryPolicy?.shouldRetry ?? defaultShouldRetry;
 
   //
   // make the call
@@ -236,11 +238,12 @@ const doComponentInvocation = async <I, O>(
         signal: attemptSignal(),
       });
     } catch (e) {
-      // network error (fetch rejected) — ambiguous, retry if allowed
+      // network error (fetch rejected) — ambiguous
       if (
         retryPolicy &&
         attempt < retryPolicy.maxRetries &&
-        !userSignal?.aborted
+        !userSignal?.aborted &&
+        shouldRetry({ kind: "network", error: e }, attempt)
       ) {
         await abortableSleep(backoffDelay(retryPolicy, attempt), userSignal);
         continue;
@@ -250,22 +253,30 @@ const doComponentInvocation = async <I, O>(
     if (httpResponse.ok) {
       break;
     }
+    // Read the error body once; it is reused for the retry decision and, if we
+    // give up, for the thrown HttpCallError.
+    const errorBody = await httpResponse.text();
     if (
       retryPolicy &&
-      isRetryableStatus(httpResponse.status) &&
       attempt < retryPolicy.maxRetries &&
-      !userSignal?.aborted
+      !userSignal?.aborted &&
+      shouldRetry(
+        {
+          kind: "response",
+          status: httpResponse.status,
+          headers: httpResponse.headers,
+          body: errorBody || undefined,
+        },
+        attempt
+      )
     ) {
       const retryAfter = parseRetryAfter(httpResponse.headers);
-      // free the connection before re-issuing
-      await httpResponse.body?.cancel();
       await abortableSleep(
         backoffDelay(retryPolicy, attempt, retryAfter),
         userSignal
       );
       continue;
     }
-    const errorBody = await httpResponse.text();
     throw new HttpCallError(
       httpResponse.status,
       errorBody,

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -33,6 +33,13 @@ import {
 } from "./api.js";
 
 import { Opts, SendOpts } from "./api.js";
+import {
+  abortableSleep,
+  backoffDelay,
+  isRetryableStatus,
+  parseRetryAfter,
+  resolveRetryPolicy,
+} from "./retry.js";
 
 /**
  * Connect to the restate Ingress
@@ -191,35 +198,78 @@ const doComponentInvocation = async <I, O>(
   }
 
   // Abort signal, if any
-  let signal: AbortSignal | undefined;
-  if (
-    params.opts?.opts.signal !== undefined &&
-    params.opts?.opts.timeout !== undefined
-  ) {
+  const userSignal = params.opts?.opts.signal;
+  const timeout = params.opts?.opts.timeout;
+  if (userSignal !== undefined && timeout !== undefined) {
     throw new Error(
       "You can't specify both signal and timeout options at the same time"
     );
-  } else if (params.opts?.opts.signal !== undefined) {
-    signal = params.opts?.opts.signal;
-  } else if (params.opts?.opts.timeout !== undefined) {
-    signal = AbortSignal.timeout(params.opts?.opts.timeout);
   }
+  // A fresh timeout signal is minted per attempt below — a single
+  // AbortSignal.timeout() would already be aborted on the second attempt.
+  const attemptSignal = (): AbortSignal | undefined =>
+    userSignal ??
+    (timeout !== undefined ? AbortSignal.timeout(timeout) : undefined);
+
+  //
+  // retries
+  //
+  // We only retry when the call carries an idempotency key: Restate then
+  // dedupes the request, so re-issuing it after an ambiguous failure (network
+  // error, 429, 5xx) safely attaches to the in-flight/completed invocation
+  // instead of starting a duplicate. Without a key, retrying is unsafe.
+  //
+  const retryPolicy = idempotencyKey
+    ? resolveRetryPolicy(opts.retry)
+    : undefined;
 
   //
   // make the call
   //
-  const httpResponse = await fetch(url, {
-    method: params.method ?? "POST",
-    headers,
-    body,
-    signal,
-  });
-  if (!httpResponse.ok) {
-    const body = await httpResponse.text();
+  let httpResponse: Response;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      httpResponse = await fetch(url, {
+        method: params.method ?? "POST",
+        headers,
+        body,
+        signal: attemptSignal(),
+      });
+    } catch (e) {
+      // network error (fetch rejected) — ambiguous, retry if allowed
+      if (
+        retryPolicy &&
+        attempt < retryPolicy.maxRetries &&
+        !userSignal?.aborted
+      ) {
+        await abortableSleep(backoffDelay(retryPolicy, attempt), userSignal);
+        continue;
+      }
+      throw e;
+    }
+    if (httpResponse.ok) {
+      break;
+    }
+    if (
+      retryPolicy &&
+      isRetryableStatus(httpResponse.status) &&
+      attempt < retryPolicy.maxRetries &&
+      !userSignal?.aborted
+    ) {
+      const retryAfter = parseRetryAfter(httpResponse.headers);
+      // free the connection before re-issuing
+      await httpResponse.body?.cancel();
+      await abortableSleep(
+        backoffDelay(retryPolicy, attempt, retryAfter),
+        userSignal
+      );
+      continue;
+    }
+    const errorBody = await httpResponse.text();
     throw new HttpCallError(
       httpResponse.status,
-      body,
-      `Request failed: ${httpResponse.status}\n${body}`
+      errorBody,
+      `Request failed: ${httpResponse.status}\n${errorBody}`
     );
   }
   const responseBuf = new Uint8Array(await httpResponse.arrayBuffer());

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   abortableSleep,
   backoffDelay,
+  defaultShouldRetry,
   isRetryableStatus,
   parseRetryAfter,
   resolveRetryPolicy,
@@ -21,17 +22,21 @@ import { connect, HttpCallError } from "./ingress.js";
 import { Opts, type RetryPolicy } from "./api.js";
 
 describe("resolveRetryPolicy", () => {
-  it("returns the default policy when unset", () => {
-    expect(resolveRetryPolicy(undefined)).toEqual({
+  it("is disabled (undefined) when unset — retries are opt-in", () => {
+    expect(resolveRetryPolicy(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when disabled with false", () => {
+    expect(resolveRetryPolicy(false)).toBeUndefined();
+  });
+
+  it("returns the default policy when enabled with true", () => {
+    expect(resolveRetryPolicy(true)).toEqual({
       maxRetries: 5,
       initialInterval: 100,
       maxInterval: 2000,
       multiplier: 2,
     });
-  });
-
-  it("returns undefined when disabled", () => {
-    expect(resolveRetryPolicy(false)).toBeUndefined();
   });
 
   it("fills in missing fields with defaults", () => {
@@ -40,7 +45,38 @@ describe("resolveRetryPolicy", () => {
       initialInterval: 100,
       maxInterval: 2000,
       multiplier: 2,
+      shouldRetry: undefined,
     });
+  });
+
+  it("carries a custom shouldRetry through", () => {
+    const shouldRetry = () => false;
+    expect(resolveRetryPolicy({ shouldRetry })).toMatchObject({ shouldRetry });
+  });
+});
+
+describe("defaultShouldRetry", () => {
+  it("retries network errors and 429/5xx responses", () => {
+    expect(defaultShouldRetry({ kind: "network", error: new Error("x") })).toBe(
+      true
+    );
+    expect(
+      defaultShouldRetry({
+        kind: "response",
+        status: 503,
+        headers: new Headers(),
+      })
+    ).toBe(true);
+  });
+
+  it("does not retry non-retryable responses", () => {
+    expect(
+      defaultShouldRetry({
+        kind: "response",
+        status: 409,
+        headers: new Headers(),
+      })
+    ).toBe(false);
   });
 });
 
@@ -161,7 +197,7 @@ describe("ingress auto-retry", () => {
 
   const fastRetry = { initialInterval: 1, maxInterval: 2, multiplier: 2 };
 
-  const call = (idempotencyKey?: string, retry?: RetryPolicy | false) =>
+  const call = (idempotencyKey?: string, retry?: RetryPolicy | boolean) =>
     connect({ url: URL, retry }).call({
       service: "svc",
       handler: "greet",
@@ -184,6 +220,18 @@ describe("ingress auto-retry", () => {
       HttpCallError
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry by default — retries are opt-in", async () => {
+    queue(fail(503), ok());
+    await expect(call("k1", undefined)).rejects.toBeInstanceOf(HttpCallError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retry:true enables the built-in policy", async () => {
+    queue(fail(503), ok());
+    await expect(call("k1", true)).resolves.toEqual({ ok: true });
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it("retries 5xx then succeeds when an idempotency key is set", async () => {
@@ -214,6 +262,31 @@ describe("ingress auto-retry", () => {
     queue(fail(503), ok());
     await expect(call("k1", false)).rejects.toBeInstanceOf(HttpCallError);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a custom shouldRetry can narrow the decision (no retry on 500)", async () => {
+    queue(fail(500), ok());
+    await expect(
+      call("k1", {
+        ...fastRetry,
+        shouldRetry: (f) =>
+          defaultShouldRetry(f) && !(f.kind === "response" && f.status === 500),
+      })
+    ).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a custom shouldRetry can inspect the response body", async () => {
+    queue(fail(503, undefined), ok());
+    const seen: Array<string | undefined> = [];
+    await call("k1", {
+      ...fastRetry,
+      shouldRetry: (f) => {
+        if (f.kind === "response") seen.push(f.body);
+        return defaultShouldRetry(f);
+      },
+    });
+    expect(seen).toEqual(["nope"]); // body text was available to the predicate
   });
 
   it("gives up after maxRetries and throws the last error", async () => {

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  abortableSleep,
+  backoffDelay,
+  isRetryableStatus,
+  parseRetryAfter,
+  resolveRetryPolicy,
+} from "./retry.js";
+import { connect, HttpCallError } from "./ingress.js";
+import { Opts, type RetryPolicy } from "./api.js";
+
+describe("resolveRetryPolicy", () => {
+  it("returns the default policy when unset", () => {
+    expect(resolveRetryPolicy(undefined)).toEqual({
+      maxRetries: 5,
+      initialInterval: 100,
+      maxInterval: 2000,
+      multiplier: 2,
+    });
+  });
+
+  it("returns undefined when disabled", () => {
+    expect(resolveRetryPolicy(false)).toBeUndefined();
+  });
+
+  it("fills in missing fields with defaults", () => {
+    expect(resolveRetryPolicy({ maxRetries: 1 })).toEqual({
+      maxRetries: 1,
+      initialInterval: 100,
+      maxInterval: 2000,
+      multiplier: 2,
+    });
+  });
+});
+
+describe("isRetryableStatus", () => {
+  it("retries on 429 and 5xx", () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(599)).toBe(true);
+  });
+
+  it("does not retry on 4xx (except 429) or 2xx/3xx", () => {
+    expect(isRetryableStatus(200)).toBe(false);
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+    expect(isRetryableStatus(409)).toBe(false);
+    expect(isRetryableStatus(470)).toBe(false);
+  });
+});
+
+describe("backoffDelay", () => {
+  const policy = {
+    maxRetries: 5,
+    initialInterval: 100,
+    maxInterval: 2000,
+    multiplier: 2,
+  };
+
+  it("never exceeds the per-attempt ceiling (full jitter)", () => {
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const ceiling = Math.min(100 * 2 ** attempt, 2000);
+      for (let i = 0; i < 50; i++) {
+        const d = backoffDelay(policy, attempt);
+        expect(d).toBeGreaterThanOrEqual(0);
+        expect(d).toBeLessThanOrEqual(ceiling);
+      }
+    }
+  });
+
+  it("honors Retry-After, capped at maxInterval", () => {
+    expect(backoffDelay(policy, 0, 500)).toBe(500);
+    expect(backoffDelay(policy, 0, 10_000)).toBe(2000);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  const h = (v?: string) => new Headers(v ? { "retry-after": v } : {});
+
+  it("returns undefined when absent", () => {
+    expect(parseRetryAfter(h())).toBeUndefined();
+  });
+
+  it("parses delay-seconds", () => {
+    expect(parseRetryAfter(h("2"))).toBe(2000);
+  });
+
+  it("parses an HTTP-date relative to now", () => {
+    const now = 1_000_000;
+    const date = new Date(now + 3000).toUTCString();
+    expect(parseRetryAfter(h(date), now)).toBe(3000);
+  });
+
+  it("returns undefined for garbage", () => {
+    expect(parseRetryAfter(h("not-a-date"))).toBeUndefined();
+  });
+});
+
+describe("abortableSleep", () => {
+  it("resolves after the delay", async () => {
+    await expect(abortableSleep(1)).resolves.toBeUndefined();
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort(new Error("boom"));
+    await expect(abortableSleep(1000, ac.signal)).rejects.toThrow("boom");
+  });
+
+  it("rejects when aborted mid-sleep", async () => {
+    const ac = new AbortController();
+    const p = abortableSleep(1000, ac.signal);
+    ac.abort(new Error("late"));
+    await expect(p).rejects.toThrow("late");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: retry behavior through connect()/call()
+// ---------------------------------------------------------------------------
+
+describe("ingress auto-retry", () => {
+  const URL = "http://localhost:8080";
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  // Response/error factories — a fresh, unread Response per attempt (real
+  // fetch hands back a new Response per call).
+  type Attempt = () => Promise<Response>;
+  const ok =
+    (body: unknown = { ok: true }): Attempt =>
+    () =>
+      Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  const fail =
+    (status: number, headers?: Record<string, string>): Attempt =>
+    () =>
+      Promise.resolve(new Response("nope", { status, headers }));
+  const neterr =
+    (msg: string): Attempt =>
+    () =>
+      Promise.reject(new TypeError(msg));
+
+  // A fetch mock that plays back a queued sequence, repeating the last item.
+  const queue = (...attempts: Attempt[]) => {
+    let i = 0;
+    fetchMock.mockImplementation(() =>
+      attempts[Math.min(i++, attempts.length - 1)]!()
+    );
+  };
+
+  const fastRetry = { initialInterval: 1, maxInterval: 2, multiplier: 2 };
+
+  const call = (idempotencyKey?: string, retry?: RetryPolicy | false) =>
+    connect({ url: URL, retry }).call({
+      service: "svc",
+      handler: "greet",
+      parameter: {},
+      opts: idempotencyKey ? Opts.from({ idempotencyKey }) : undefined,
+    });
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT retry without an idempotency key", async () => {
+    queue(fail(503), ok());
+    await expect(call(undefined, fastRetry)).rejects.toBeInstanceOf(
+      HttpCallError
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries 5xx then succeeds when an idempotency key is set", async () => {
+    queue(fail(500), fail(503), ok({ greeting: "hi" }));
+    await expect(call("k1", fastRetry)).resolves.toEqual({ greeting: "hi" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on 429", async () => {
+    queue(fail(429), ok());
+    await expect(call("k1", fastRetry)).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on a network error", async () => {
+    queue(neterr("connection refused"), ok());
+    await expect(call("k1", fastRetry)).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry on a non-retryable 4xx", async () => {
+    queue(fail(409), ok());
+    await expect(call("k1", fastRetry)).rejects.toBeInstanceOf(HttpCallError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retry:false disables retries even with an idempotency key", async () => {
+    queue(fail(503), ok());
+    await expect(call("k1", false)).rejects.toBeInstanceOf(HttpCallError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after maxRetries and throws the last error", async () => {
+    queue(fail(500));
+    await expect(
+      call("k1", { ...fastRetry, maxRetries: 2 })
+    ).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("mints a fresh timeout signal per attempt", async () => {
+    queue(fail(500), ok());
+    await connect({ url: URL, retry: fastRetry }).call({
+      service: "svc",
+      handler: "greet",
+      parameter: {},
+      opts: Opts.from({ idempotencyKey: "k1", timeout: 10_000 }),
+    });
+    const signals = fetchMock.mock.calls.map(
+      (c) => (c[1] as RequestInit).signal
+    );
+    expect(signals[0]).not.toBe(signals[1]);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+});

--- a/packages/libs/restate-sdk-clients/src/retry.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.ts
@@ -9,7 +9,7 @@
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
 
-import type { RetryPolicy } from "./api.js";
+import type { RetryFailure, RetryPolicy } from "./api.js";
 
 /** Fully resolved retry policy, with all defaults applied. */
 export interface ResolvedRetryPolicy {
@@ -17,6 +17,7 @@ export interface ResolvedRetryPolicy {
   initialInterval: number;
   maxInterval: number;
   multiplier: number;
+  shouldRetry?: (failure: RetryFailure, attempt: number) => boolean;
 }
 
 const DEFAULT_RETRY_POLICY: ResolvedRetryPolicy = {
@@ -29,15 +30,17 @@ const DEFAULT_RETRY_POLICY: ResolvedRetryPolicy = {
 /**
  * Resolve a user supplied retry policy into a fully populated one.
  *
- * Returns `undefined` when retries are disabled (`retry: false`).
+ * Retries are opt-in: returns `undefined` (disabled) when `retry` is omitted or
+ * `false`. `true` enables the built-in policy; an object enables it with the
+ * provided overrides.
  */
 export function resolveRetryPolicy(
-  retry: RetryPolicy | false | undefined
+  retry: RetryPolicy | boolean | undefined
 ): ResolvedRetryPolicy | undefined {
-  if (retry === false) {
+  if (retry === undefined || retry === false) {
     return undefined;
   }
-  if (retry === undefined) {
+  if (retry === true) {
     return DEFAULT_RETRY_POLICY;
   }
   return {
@@ -46,12 +49,22 @@ export function resolveRetryPolicy(
       retry.initialInterval ?? DEFAULT_RETRY_POLICY.initialInterval,
     maxInterval: retry.maxInterval ?? DEFAULT_RETRY_POLICY.maxInterval,
     multiplier: retry.multiplier ?? DEFAULT_RETRY_POLICY.multiplier,
+    shouldRetry: retry.shouldRetry,
   };
 }
 
 /** Whether an HTTP response status warrants a retry. */
 export function isRetryableStatus(status: number): boolean {
   return status === 429 || (status >= 500 && status <= 599);
+}
+
+/**
+ * The built-in retry decision: retry network errors, HTTP `429`, and HTTP
+ * `5xx`. Exported so a custom {@link RetryPolicy.shouldRetry} can compose with
+ * it rather than reimplement it.
+ */
+export function defaultShouldRetry(failure: RetryFailure): boolean {
+  return failure.kind === "network" || isRetryableStatus(failure.status);
 }
 
 /**

--- a/packages/libs/restate-sdk-clients/src/retry.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import type { RetryPolicy } from "./api.js";
+
+/** Fully resolved retry policy, with all defaults applied. */
+export interface ResolvedRetryPolicy {
+  maxRetries: number;
+  initialInterval: number;
+  maxInterval: number;
+  multiplier: number;
+}
+
+const DEFAULT_RETRY_POLICY: ResolvedRetryPolicy = {
+  maxRetries: 5,
+  initialInterval: 100,
+  maxInterval: 2000,
+  multiplier: 2,
+};
+
+/**
+ * Resolve a user supplied retry policy into a fully populated one.
+ *
+ * Returns `undefined` when retries are disabled (`retry: false`).
+ */
+export function resolveRetryPolicy(
+  retry: RetryPolicy | false | undefined
+): ResolvedRetryPolicy | undefined {
+  if (retry === false) {
+    return undefined;
+  }
+  if (retry === undefined) {
+    return DEFAULT_RETRY_POLICY;
+  }
+  return {
+    maxRetries: retry.maxRetries ?? DEFAULT_RETRY_POLICY.maxRetries,
+    initialInterval:
+      retry.initialInterval ?? DEFAULT_RETRY_POLICY.initialInterval,
+    maxInterval: retry.maxInterval ?? DEFAULT_RETRY_POLICY.maxInterval,
+    multiplier: retry.multiplier ?? DEFAULT_RETRY_POLICY.multiplier,
+  };
+}
+
+/** Whether an HTTP response status warrants a retry. */
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+/**
+ * Compute the backoff for the given (zero based) attempt index using
+ * exponential backoff with full jitter, capped at `maxInterval`.
+ *
+ * When the server provided an explicit `Retry-After` we honor it instead,
+ * capped at `maxInterval` to avoid pathologically long waits.
+ */
+export function backoffDelay(
+  policy: ResolvedRetryPolicy,
+  attempt: number,
+  retryAfterMs?: number
+): number {
+  if (retryAfterMs !== undefined) {
+    return Math.min(retryAfterMs, policy.maxInterval);
+  }
+  const exp = policy.initialInterval * Math.pow(policy.multiplier, attempt);
+  const ceiling = Math.min(exp, policy.maxInterval);
+  // full jitter: random in [0, ceiling]
+  return Math.random() * ceiling;
+}
+
+/**
+ * Parse a `Retry-After` header value into milliseconds.
+ *
+ * Supports both the delay-seconds form (`"120"`) and the HTTP-date form
+ * (`"Wed, 21 Oct 2015 07:28:00 GMT"`). Returns `undefined` when absent or
+ * unparseable.
+ */
+export function parseRetryAfter(
+  headers: Headers,
+  now: number = Date.now()
+): number | undefined {
+  const value = headers.get("retry-after");
+  if (!value) {
+    return undefined;
+  }
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+  const dateMs = Date.parse(value);
+  if (Number.isNaN(dateMs)) {
+    return undefined;
+  }
+  return Math.max(0, dateMs - now);
+}
+
+/**
+ * Sleep for `ms`, rejecting early if `signal` aborts in the meantime.
+ */
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal
+): Promise<void> {
+  const abortError = (): Error => {
+    const reason: unknown = signal?.reason;
+    return reason instanceof Error
+      ? reason
+      : new Error("The operation was aborted");
+  };
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortError());
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/libs/restate-sdk-gen/README.md
+++ b/packages/libs/restate-sdk-gen/README.md
@@ -121,19 +121,32 @@ const greeting = await greeterClient.greet("sam");
 
 ### Automatic retries
 
-When a call carries an `idempotencyKey`, the client retries automatically on ambiguous failures — network errors, HTTP `429`, and HTTP `5xx` — with exponential backoff and jitter:
+Retries are **opt-in** and configured connection-wide via `retry` (`clients.RetryPolicy`). Enable the built-in policy with `true`, or pass an object to tune it:
+
+```ts
+clients.connect({ url, retry: true });
+clients.connect({ url, retry: { maxRetries: 5, initialInterval: 100, maxInterval: 2000 } });
+```
+
+When enabled, the client retries ambiguous failures — network errors, HTTP `429`, and HTTP `5xx` — with exponential backoff and jitter, **but only when the call carries an `idempotencyKey`**:
 
 ```ts
 await greeterClient.greet("sam", clients.Opts.from({ idempotencyKey: "greet-sam-once" }));
 ```
 
-The idempotency key is the safety boundary: Restate dedupes on it, so a retry attaches to the in-flight or completed invocation instead of starting a duplicate. **Without a key, no retry is attempted** — retrying a non-idempotent invocation could double-execute it.
+The idempotency key is the safety boundary: Restate dedupes on it, so a retry attaches to the in-flight or completed invocation instead of starting a duplicate. Without a key, no retry is attempted — retrying a non-idempotent invocation could double-execute it.
 
-Retries are on by default. Configure or disable them connection-wide via `retry` (`clients.RetryPolicy`):
+To decide per-failure (e.g. to skip a terminal `5xx`), supply `shouldRetry`. It fully replaces the built-in rule; compose with `clients.defaultShouldRetry` to narrow it. The `RetryFailure` carries the status, headers, and — for response failures — the body text when present:
 
 ```ts
-clients.connect({ url, retry: { maxRetries: 5, initialInterval: 100, maxInterval: 2000 } });
-clients.connect({ url, retry: false }); // opt out
+clients.connect({
+  url,
+  retry: {
+    shouldRetry: (failure, attempt) =>
+      clients.defaultShouldRetry(failure) &&
+      !(failure.kind === "response" && failure.body?.includes("do-not-retry")),
+  },
+});
 ```
 
 See `examples/tutorial/src/13-ingress.ts` for a runnable walkthrough.

--- a/packages/libs/restate-sdk-gen/README.md
+++ b/packages/libs/restate-sdk-gen/README.md
@@ -101,6 +101,43 @@ For routine-level "stop": use a `Channel<void>` plus `select({ work, stop: stop.
 
 Under the default `onMainExit: "abandon"` a spawned routine or race loser parked on a never-settling source does **not** hang the handler: the handler returns as soon as the main operation settles and the parked routine is abandoned. That hang only applies under `onMainExit: "join"`, where the scheduler keeps driving until every fiber finishes.
 
+## Ingress client
+
+To call a deployed endpoint from the outside — a plain process, not a handler — use the ingress client under the `clients` namespace. The same typed definition that hosts the handlers also types the client:
+
+```ts
+import { clients } from "@restatedev/restate-sdk-gen";
+import { greeter } from "./greeter.js";
+
+const ingress = clients.connect({ url: "http://localhost:8080" });
+const greeterClient = clients.client(ingress, greeter);
+
+const greeting = await greeterClient.greet("sam");
+```
+
+- `clients.client(ing, def)` / `clients.client(ing, def, key)` — typed request/response.
+- `clients.sendClient(ing, def)` / `(ing, def, key)` — fire-and-forget; resolves once the invocation is accepted.
+- `clients.Opts.from({ ... })` — per-call options (`idempotencyKey`, `headers`, `timeout`, `signal`).
+
+### Automatic retries
+
+When a call carries an `idempotencyKey`, the client retries automatically on ambiguous failures — network errors, HTTP `429`, and HTTP `5xx` — with exponential backoff and jitter:
+
+```ts
+await greeterClient.greet("sam", clients.Opts.from({ idempotencyKey: "greet-sam-once" }));
+```
+
+The idempotency key is the safety boundary: Restate dedupes on it, so a retry attaches to the in-flight or completed invocation instead of starting a duplicate. **Without a key, no retry is attempted** — retrying a non-idempotent invocation could double-execute it.
+
+Retries are on by default. Configure or disable them connection-wide via `retry` (`clients.RetryPolicy`):
+
+```ts
+clients.connect({ url, retry: { maxRetries: 5, initialInterval: 100, maxInterval: 2000 } });
+clients.connect({ url, retry: false }); // opt out
+```
+
+See `examples/tutorial/src/13-ingress.ts` for a runnable walkthrough.
+
 ## Repository layout
 
 This package lives in the [`sdk-typescript`](https://github.com/restatedev/sdk-typescript) workspace. The library proper is in `src/`; auxiliary subdirectories live alongside but are not published:

--- a/packages/libs/restate-sdk-gen/examples/tutorial/src/13-ingress.ts
+++ b/packages/libs/restate-sdk-gen/examples/tutorial/src/13-ingress.ts
@@ -21,11 +21,12 @@
 //   clients.sendClient(ing, def)   — fire-and-forget client
 //   clients.Opts.from({ ... })     — per-call options (idempotencyKey, headers, …)
 //
-// Auto-retry: when a call carries an `idempotencyKey`, the client retries
-// automatically on ambiguous failures (network errors, HTTP 429, HTTP 5xx).
-// Restate dedupes on the key, so a retry safely attaches to the in-flight or
-// completed invocation instead of starting a duplicate. Without a key, a retry
-// could double-execute, so none is attempted.
+// Auto-retry (opt-in): enable it via the connection's `retry` option. The
+// client then retries ambiguous failures (network errors, HTTP 429, HTTP 5xx),
+// but only when a call carries an `idempotencyKey`. Restate dedupes on the key,
+// so a retry safely attaches to the in-flight or completed invocation instead
+// of starting a duplicate. Without a key, a retry could double-execute, so none
+// is attempted.
 //
 // Run the endpoint first (`pnpm start:tutorial`), register it with a
 // restate-server, then run this module against the ingress URL.
@@ -38,10 +39,10 @@ import { greeter } from "./08-clients.js";
 const INGRESS_URL = process.env.RESTATE_INGRESS_URL ?? "http://localhost:8080";
 
 export async function runIngressDemo(url: string = INGRESS_URL) {
-  // Connect once and reuse. `retry` is a connection-wide default:
-  //   - omit it       → built-in policy (maxRetries 5, exp. backoff + jitter)
-  //   - retry: {...}  → tune the policy
-  //   - retry: false  → disable auto-retry entirely
+  // Connect once and reuse. `retry` is a connection-wide, opt-in setting:
+  //   - omit it / false → no retries (the default)
+  //   - retry: true     → built-in policy (maxRetries 5, exp. backoff + jitter)
+  //   - retry: {...}     → tune the policy, or supply shouldRetry (see below)
   const ingress = clients.connect({
     url,
     retry: { maxRetries: 5, initialInterval: 100, maxInterval: 2000 },
@@ -70,10 +71,19 @@ export async function runIngressDemo(url: string = INGRESS_URL) {
   //    non-idempotent handler). Use a key whenever a retry must be safe.
   await greeterClient.greet("anon");
 
-  // 4) Opt out of retries for a connection even when keys are present.
-  const noRetry = clients.connect({ url, retry: false });
+  // 4) Custom retry decision. shouldRetry replaces the built-in rule; compose
+  //    with defaultShouldRetry to narrow it — here we keep the defaults but
+  //    never retry a 501, and inspect the body when one is present.
+  const tuned = clients.connect({
+    url,
+    retry: {
+      shouldRetry: (failure) =>
+        clients.defaultShouldRetry(failure) &&
+        !(failure.kind === "response" && failure.status === 501),
+    },
+  });
   await clients
-    .client(noRetry, greeter)
+    .client(tuned, greeter)
     .greet("bob", clients.Opts.from({ idempotencyKey: "greet-bob" }));
 
   // 5) Fire-and-forget. `record` returns void; the send resolves once the

--- a/packages/libs/restate-sdk-gen/examples/tutorial/src/13-ingress.ts
+++ b/packages/libs/restate-sdk-gen/examples/tutorial/src/13-ingress.ts
@@ -73,13 +73,16 @@ export async function runIngressDemo(url: string = INGRESS_URL) {
 
   // 4) Custom retry decision. shouldRetry replaces the built-in rule; compose
   //    with defaultShouldRetry to narrow it — here we keep the defaults but
-  //    never retry a 501, and inspect the body when one is present.
+  //    bail when the response body marks the failure as terminal. The body is
+  //    available on response failures when one was present.
   const tuned = clients.connect({
     url,
     retry: {
       shouldRetry: (failure) =>
         clients.defaultShouldRetry(failure) &&
-        !(failure.kind === "response" && failure.status === 501),
+        !(
+          failure.kind === "response" && failure.body?.includes("do-not-retry")
+        ),
     },
   });
   await clients

--- a/packages/libs/restate-sdk-gen/examples/tutorial/src/13-ingress.ts
+++ b/packages/libs/restate-sdk-gen/examples/tutorial/src/13-ingress.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+// Tier 13: calling Restate from the outside — the ingress client.
+//
+// Tiers 1–12 run *inside* Restate (handlers). This tier is the other side:
+// a plain Node process that submits invocations to a running endpoint over
+// HTTP, using the same typed service definitions.
+//
+//   clients.connect(opts)          — open an ingress connection
+//   clients.client(ing, def)       — typed request/response client
+//   clients.client(ing, def, key)  — typed client for an object/workflow key
+//   clients.sendClient(ing, def)   — fire-and-forget client
+//   clients.Opts.from({ ... })     — per-call options (idempotencyKey, headers, …)
+//
+// Auto-retry: when a call carries an `idempotencyKey`, the client retries
+// automatically on ambiguous failures (network errors, HTTP 429, HTTP 5xx).
+// Restate dedupes on the key, so a retry safely attaches to the in-flight or
+// completed invocation instead of starting a duplicate. Without a key, a retry
+// could double-execute, so none is attempted.
+//
+// Run the endpoint first (`pnpm start:tutorial`), register it with a
+// restate-server, then run this module against the ingress URL.
+
+import { clients } from "@restatedev/restate-sdk-gen";
+// Reuse the typed `greeter` definition from tier 8 — the same object that
+// hosts the handlers also types the ingress client.
+import { greeter } from "./08-clients.js";
+
+const INGRESS_URL = process.env.RESTATE_INGRESS_URL ?? "http://localhost:8080";
+
+export async function runIngressDemo(url: string = INGRESS_URL) {
+  // Connect once and reuse. `retry` is a connection-wide default:
+  //   - omit it       → built-in policy (maxRetries 5, exp. backoff + jitter)
+  //   - retry: {...}  → tune the policy
+  //   - retry: false  → disable auto-retry entirely
+  const ingress = clients.connect({
+    url,
+    retry: { maxRetries: 5, initialInterval: 100, maxInterval: 2000 },
+  });
+
+  const greeterClient = clients.client(ingress, greeter);
+
+  // 1) Idempotent request/response call.
+  //    The idempotencyKey both arms auto-retry and makes the invocation
+  //    safely repeatable end-to-end — re-running this line with the same key
+  //    returns the original result rather than greeting twice.
+  const greeting = await greeterClient.greet(
+    "sam",
+    clients.Opts.from({ idempotencyKey: "greet-sam-once" })
+  );
+  console.log(greeting); // "hello, sam"
+
+  // 2) Standard-schema handler — input/output typed from the Zod schemas.
+  const localized = await greeterClient.greetLocalized(
+    { name: "sam", locale: "it" },
+    clients.Opts.from({ idempotencyKey: "greet-sam-it" })
+  );
+  console.log(localized.greeting); // "ciao, sam"
+
+  // 3) No idempotency key → NOT retried on 5xx (retrying could double-run a
+  //    non-idempotent handler). Use a key whenever a retry must be safe.
+  await greeterClient.greet("anon");
+
+  // 4) Opt out of retries for a connection even when keys are present.
+  const noRetry = clients.connect({ url, retry: false });
+  await clients
+    .client(noRetry, greeter)
+    .greet("bob", clients.Opts.from({ idempotencyKey: "greet-bob" }));
+
+  // 5) Fire-and-forget. `record` returns void; the send resolves once the
+  //    invocation is accepted, not when it completes.
+  await clients.sendClient(ingress, greeter).record("audit-line");
+}
+
+// Run directly: `node dist/13-ingress.js` (or via tsx in dev).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runIngressDemo().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/libs/restate-sdk-gen/examples/tutorial/src/server.ts
+++ b/packages/libs/restate-sdk-gen/examples/tutorial/src/server.ts
@@ -28,6 +28,10 @@
 //   /ambient           — context-local storage: request-scoped ambient
 //                        values shared across helpers and spawned routines
 //
+// Tier 13 (13-ingress.ts) is the client side: a plain Node process that calls
+// this endpoint over HTTP via the ingress client (with auto-retry). It is not a
+// service, so it is not registered here — run it separately against the ingress.
+//
 // See ../README.md for curl invocations grouped by tier.
 
 import * as restate from "@restatedev/restate-sdk";

--- a/packages/libs/restate-sdk-gen/src/ingress.ts
+++ b/packages/libs/restate-sdk-gen/src/ingress.ts
@@ -19,17 +19,19 @@ import {
   type IngressWorkflowClient,
   type IngressSendClient,
   type ConnectionOpts,
+  type RetryPolicy,
   connect as clientsConnect,
 } from "@restatedev/restate-sdk-clients";
 import type { HandlerDescriptor, Descriptor } from "./define.js";
 
 // Re-export connect, Ingress, SendOpts so consumers can use clients.connect / clients.Ingress
 export {
+  Opts,
   SendOpts,
   type ConnectionOpts,
+  type RetryPolicy,
   type Ingress,
   type Send,
-  type Opts,
   type IngressClient,
   type IngressWorkflowClient,
   type IngressSendClient,

--- a/packages/libs/restate-sdk-gen/src/ingress.ts
+++ b/packages/libs/restate-sdk-gen/src/ingress.ts
@@ -23,6 +23,7 @@ import {
   type RetryFailure,
   connect as clientsConnect,
   defaultShouldRetry,
+  HttpCallError,
 } from "@restatedev/restate-sdk-clients";
 import type { HandlerDescriptor, Descriptor } from "./define.js";
 
@@ -31,6 +32,7 @@ export {
   Opts,
   SendOpts,
   defaultShouldRetry,
+  HttpCallError,
   type ConnectionOpts,
   type RetryPolicy,
   type RetryFailure,

--- a/packages/libs/restate-sdk-gen/src/ingress.ts
+++ b/packages/libs/restate-sdk-gen/src/ingress.ts
@@ -20,7 +20,9 @@ import {
   type IngressSendClient,
   type ConnectionOpts,
   type RetryPolicy,
+  type RetryFailure,
   connect as clientsConnect,
+  defaultShouldRetry,
 } from "@restatedev/restate-sdk-clients";
 import type { HandlerDescriptor, Descriptor } from "./define.js";
 
@@ -28,8 +30,10 @@ import type { HandlerDescriptor, Descriptor } from "./define.js";
 export {
   Opts,
   SendOpts,
+  defaultShouldRetry,
   type ConnectionOpts,
   type RetryPolicy,
+  type RetryFailure,
   type Ingress,
   type Send,
   type IngressClient,


### PR DESCRIPTION
## What

Ingress calls can retry automatically on ambiguous failures — **network errors, HTTP `429`, and HTTP `5xx`** — gated on two independent conditions:

1. **Opt-in.** Retries are off unless a policy is configured. `ConnectionOpts.retry` is `RetryPolicy | boolean`:
   - omitted / `false` → no retries (default)
   - `true` → built-in policy
   - `{ ... }` → tuned policy
2. **Idempotency key.** Even when enabled, a retry only fires when the call carries an `idempotencyKey`. Restate dedupes on it, so the retry attaches to the in-flight/completed invocation instead of starting a duplicate. Without a key, retrying could double-execute a non-idempotent handler, so none is attempted. This gate is absolute — no policy can bypass it.

```ts
const ingress = clients.connect({ url, retry: true });              // built-in policy
const ingress = clients.connect({ url, retry: { maxRetries: 5 } }); // tuned
await client(ingress, greeter).greet("sam", clients.Opts.from({ idempotencyKey: "req-1" }));
```

## Custom retry decisions

`RetryPolicy.shouldRetry(failure, attempt)` fully replaces the built-in rule. `RetryFailure` is a `network | response` union; response failures carry `status`, `headers`, and — when a non-empty body was present — the decoded `body` text (the error body is read once and reused for both the predicate and the thrown `HttpCallError`). Compose with the exported `defaultShouldRetry` to narrow rather than reimplement — e.g. to skip a terminal `5xx`:

```ts
clients.connect({
  url,
  retry: {
    shouldRetry: (f) =>
      clients.defaultShouldRetry(f) &&
      !(f.kind === "response" && f.body?.includes("do-not-retry")),
  },
});
```

## Changes

**`restate-sdk-clients`**
- `RetryPolicy` (+ `shouldRetry`), `RetryFailure`, and `ConnectionOpts.retry?: RetryPolicy | boolean` (opt-in; defaults: `maxRetries 5`, `initialInterval 100`, `maxInterval 2000`, `multiplier 2`).
- Retry loop in `doComponentInvocation` (the shared call/send path). Same failure surface once exhausted (`HttpCallError` / rethrown network error).
- `src/retry.ts`: `resolveRetryPolicy`, `isRetryableStatus`, `defaultShouldRetry`, `backoffDelay`, `parseRetryAfter` (honors `Retry-After`), `abortableSleep`.
- Fixes a latent **timeout bug**: a single `AbortSignal.timeout()` would be pre-aborted on the second attempt — now a fresh signal per attempt; a user `signal` still aborts the whole loop, including mid-backoff.

**`restate-sdk-gen`**
- Re-exports `RetryPolicy`, `RetryFailure`, `defaultShouldRetry`; promotes `Opts` to a value export (symmetry with `SendOpts`) so `idempotencyKey` can be set through the gen package.
- New tutorial tier `13-ingress.ts` (ingress-client walkthrough) + README "Ingress client" section.

## Scope
Applies to the call/send path. `workflowSubmit` rides it and retries when its key is set. Attach/output GETs are inherently idempotent but have no idempotency-key concept — left out of this change.

## Testing
`src/retry.test.ts`: unit tests for the helpers (incl. `defaultShouldRetry`) + integration tests through `connect()`/`call()` with a mocked `fetch` — opt-in default off, `retry:true` enables, no retry without a key, retry-then-succeed on 5xx/429/network error, no retry on non-retryable 4xx, custom `shouldRetry` narrowing, body visible to the predicate, give-up after `maxRetries`, fresh-timeout-signal-per-attempt. Build, lint, typecheck, API Extractor, ATTW pass; gen unit suite green.

## Note
Adds public API to both packages, so it needs a changeset (`pnpm changeset`) before release — not included here since it's interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)