### PR TITLE
Release 1.16.0

### DIFF
--- a/packages/libs/restate-sdk-clients/CHANGELOG.md
+++ b/packages/libs/restate-sdk-clients/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @restatedev/restate-sdk-clients
 
+## 1.16.0
+
+### Minor Changes
+
+- Ingress calls now automatically retry on 5xx, 429, and network errors when an idempotency key is set.
+
+### Patch Changes
+
+- @restatedev/restate-sdk-core@1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-clients/package.json
+++ b/packages/libs/restate-sdk-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-clients",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Typescript SDK for Restate",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-cloudflare-workers/CHANGELOG.md
+++ b/packages/libs/restate-sdk-cloudflare-workers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @restatedev/restate-sdk-cloudflare-workers
 
+## 1.16.0
+
+### Patch Changes
+
+- @restatedev/restate-sdk-core@1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-cloudflare-workers/package.json
+++ b/packages/libs/restate-sdk-cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-cloudflare-workers",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Typescript SDK for Restate",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-core/CHANGELOG.md
+++ b/packages/libs/restate-sdk-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @restatedev/restate-sdk-core
 
+## 1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-core/package.json
+++ b/packages/libs/restate-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-core",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Typescript SDK for Restate",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-gen/CHANGELOG.md
+++ b/packages/libs/restate-sdk-gen/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @restatedev/restate-sdk-gen
 
+## 1.16.0
+
+### Minor Changes
+
+- Ingress calls now automatically retry on 5xx, 429, and network errors when an idempotency key is set.
+
+### Patch Changes
+
+- Updated dependencies
+  - @restatedev/restate-sdk-clients@1.16.0
+  - @restatedev/restate-sdk-core@1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-gen/package.json
+++ b/packages/libs/restate-sdk-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-gen",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Generator-based DSL for composing Restate workflows",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-opentelemetry/CHANGELOG.md
+++ b/packages/libs/restate-sdk-opentelemetry/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @restatedev/restate-sdk-opentelemetry
 
+## 1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-opentelemetry/package.json
+++ b/packages/libs/restate-sdk-opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-opentelemetry",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "OpenTelemetry integration for the Restate TypeScript SDK",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-testcontainers/CHANGELOG.md
+++ b/packages/libs/restate-sdk-testcontainers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @restatedev/restate-sdk-testcontainers
 
+## 1.16.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @restatedev/restate-sdk-clients@1.16.0
+  - @restatedev/restate-sdk@1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-testcontainers/package.json
+++ b/packages/libs/restate-sdk-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-testcontainers",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Typescript SDK for Restate",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-tunnel/CHANGELOG.md
+++ b/packages/libs/restate-sdk-tunnel/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @restatedev/restate-sdk-tunnel
 
+## 1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-tunnel/package.json
+++ b/packages/libs/restate-sdk-tunnel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-tunnel",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Reverse-tunnel client for Restate Cloud — serve a Restate SDK deployment over an outbound tunnel connection, with no inbound HTTP listener",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk-zod/CHANGELOG.md
+++ b/packages/libs/restate-sdk-zod/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @restatedev/restate-sdk-zod
 
+## 1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk-zod/package.json
+++ b/packages/libs/restate-sdk-zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk-zod",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Typescript SDK for Restate",
   "author": "Restate Developers",
   "email": "code@restate.dev",

--- a/packages/libs/restate-sdk/CHANGELOG.md
+++ b/packages/libs/restate-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @restatedev/restate-sdk
 
+## 1.16.0
+
+### Patch Changes
+
+- @restatedev/restate-sdk-core@1.16.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/libs/restate-sdk/package.json
+++ b/packages/libs/restate-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-sdk",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Typescript SDK for Restate",
   "author": "Restate Developers",
   "email": "code@restate.dev",


### PR DESCRIPTION
Version bump for the next release, generated by `pnpm changeset version`. Bumps all `@restatedev/*` libs `1.15.1 → 1.16.0` (they version together via the `fixed` group).

## What ships in 1.16.0

The headline change is **#754 — ingress calls now automatically retry on 5xx/429/network errors when an idempotency key is set** (new public API in `restate-sdk-clients`, hence the **minor** bump). This has been on `main` unreleased since Jun 26; npm's 1.15.1 does not contain it.

The `restate-sdk-clients` / `restate-sdk-gen` CHANGELOGs carry the feature line; the other packages are patch-bumped as part of the fixed group.

Not in the changelog by design: the recent Dependabot/security work (#758) changed nothing in any published package (workspace `overrides`, a private example, CI, and dev-deps/tests only), so it has no per-package CHANGELOG entry. It will still appear in the auto-generated GitHub release notes.

## On merge

Pushing this to `main` triggers `release.yml`: it detects `1.16.0` has no `v1.16.0` tag, tags it, creates the GitHub release (`--generate-notes`, so #754/#757/#758 etc. are listed), and publishes all public libs to npm under `latest`.

The branch is intentionally **not** named `release-*` so pushing it doesn't trigger a premature publish — only the merge to `main` does.

## Heads-up (separate from this PR)

The `v1.15.1` tag sits on a commit that isn't an ancestor of `main` (its release commit was never merged back), which is why `main` read `1.15.1` while still carrying unreleased work. This PR bumps from `main`'s baseline and is correct, but someone may want to reconcile that drift so future releases stay on the `main` line.