### PR TITLE
Fix premature Node HTTP/1.1 aborts after request body completion

### DIFF
--- a/.github/workflows/integration-http1.yaml
+++ b/.github/workflows/integration-http1.yaml
@@ -1,0 +1,145 @@
+name: Integration HTTP/1.1
+
+# Controls when the workflow will run
+on:
+  pull_request:
+  push:
+    branches: [main, release-**]
+  schedule:
+    - cron: "0 */6 * * *" # Every 6 hours
+  workflow_dispatch:
+    inputs:
+      restateCommit:
+        description: "restate commit"
+        required: false
+        default: ""
+        type: string
+      restateImage:
+        description: "restate image, superseded by restate commit"
+        required: false
+        default: "ghcr.io/restatedev/restate:main"
+        type: string
+      serviceImage:
+        description: "service image, if provided it will skip building the image from sdk main branch"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  sdk-test-suite:
+    if: github.repository_owner == 'restatedev'
+    runs-on: warp-ubuntu-latest-x64-4x
+    name: Node HTTP/1.1 integration test
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+      actions: read
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: restatedev/sdk-typescript
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      # support importing oci-format restate.tar
+      - name: Set up Docker containerd snapshotter
+        uses: docker/setup-docker-action@v4
+        with:
+          version: "v28.5.2"
+          set-host: true
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      ### Download the Restate container image, if needed
+      # Due to https://github.com/actions/upload-artifact/issues/53
+      # We must use download-artifact to get artifacts created during *this* workflow run, ie by workflow call
+      - name: Download restate snapshot from in-progress workflow
+        if: ${{ inputs.restateCommit != '' && github.event_name != 'workflow_dispatch' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: restate.tar
+      # In the workflow dispatch case where the artifact was created in a previous run, we can download as normal
+      - name: Download restate snapshot from completed workflow
+        if: ${{ inputs.restateCommit != '' && github.event_name == 'workflow_dispatch' }}
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          repo: restatedev/restate
+          workflow: ci.yml
+          commit: ${{ inputs.restateCommit }}
+          name: restate.tar
+      - name: Install restate snapshot
+        if: ${{ inputs.restateCommit != '' }}
+        run: |
+          output=$(docker load --input restate.tar | head -n 1)
+          docker tag "${output#*: }" "localhost/restatedev/restate-commit-download:latest"
+          docker image ls -a
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+
+      # Pre-emptively pull the test-services image, to avoid affecting execution time
+      - name: Pull test services image
+        if: ${{ inputs.serviceImage != '' }}
+        shell: bash
+        run: docker pull ${{ inputs.serviceImage }}
+
+      - name: Build Typescript test-services image
+        if: ${{ inputs.serviceImage == '' }}
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: "packages/tests/restate-e2e-services/Dockerfile"
+          push: false
+          load: true
+          tags: restatedev/typescript-test-services
+          cache-from: type=gha,url=http://127.0.0.1:49160/,version=1,scope=${{ github.workflow }}
+          cache-to: type=gha,url=http://127.0.0.1:49160/,mode=max,version=1,scope=${{ github.workflow }}
+
+      - name: Prepare HTTP/1.1 service container environment
+        id: service-env
+        shell: bash
+        run: |
+          env_file=".service-container-http1.env"
+          cp packages/tests/restate-e2e-services/.env "$env_file"
+          printf "\n" >> "$env_file"
+          printf "RESTATE_E2E_ENDPOINT_ADAPTER=node-http1\n" >> "$env_file"
+          printf "SERVICES=NodeEndpoint\n" >> "$env_file"
+          printf "PORT=9080\n" >> "$env_file"
+          echo "path=$env_file" >> "$GITHUB_OUTPUT"
+
+      - name: Run test tool
+        uses: restatedev/e2e/sdk-tests@v2.2
+        with:
+          restateContainerImage: ${{ inputs.restateCommit != '' && 'localhost/restatedev/restate-commit-download:latest' || (inputs.restateImage != '' && inputs.restateImage || 'ghcr.io/restatedev/restate:main') }}
+          serviceContainerImage: ${{ inputs.serviceImage != '' && inputs.serviceImage || 'restatedev/typescript-test-services' }}
+          exclusionsFile: "packages/tests/restate-e2e-services/exclusions.yaml"
+          customTestsFile: "packages/tests/restate-e2e-services/custom_tests_http1.yaml"
+          serviceContainerEnvFile: ${{ steps.service-env.outputs.path }}
+          testSuite: default
+          testName: Custom
+          testArtifactOutput: sdk-typescript-fetch-integration-test-report

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -183,7 +183,9 @@ function nodeHandlerImpl(
     // Abort controller used to cleanup resources at the end of this stream lifecycle
     const abortController = new AbortController();
     httpRequest.on("close", () => {
-      abortController.abort();
+      if (!httpRequest.readableEnded) {
+        abortController.abort();
+      }
     });
 
     const writeHead = res.writeHead.bind(res);

--- a/packages/tests/restate-e2e-services/README.md
+++ b/packages/tests/restate-e2e-services/README.md
@@ -19,16 +19,19 @@ pnpm --filter @restatedev/restate-e2e-services app
 By default all services are registered on port `9080`. The following environment
 variables are supported:
 
-| Variable                        | Default      | Purpose                                                       |
-| ------------------------------- | ------------ | ------------------------------------------------------------- |
-| `SERVICES`                      | all          | Comma-separated list of services to register, or `*` for all  |
-| `PORT`                          | `9080`       | HTTP/2 server port                                            |
-| `RESTATE_E2E_ENDPOINT_ADAPTER`  | `node-http2` | Endpoint implementation (`node-http2` or `fetch`)             |
+| Variable                       | Default      | Purpose                                                       |
+|--------------------------------|--------------|---------------------------------------------------------------|
+| `SERVICES`                     | all          | Comma-separated list of services to register, or `*` for all  |
+| `PORT`                         | `9080`       | HTTP/2 server port                                            |
+| `RESTATE_E2E_ENDPOINT_ADAPTER` | `node-http2` | Endpoint implementation (`node-http2`, `node-http1`, `fetch`) |
 
 Examples:
 
 ```shell
 SERVICES=Counter,EventHandler PORT=9080 pnpm app
+
+# run with the HTTP/1.1 endpoint adapter
+pnpm app:http1
 
 # run with the fetch-based endpoint adapter
 pnpm app:fetch

--- a/packages/tests/restate-e2e-services/custom_tests_http1.yaml
+++ b/packages/tests/restate-e2e-services/custom_tests_http1.yaml
@@ -1,0 +1,3 @@
+tests:
+  - name: "node http1 vitest"
+    command: "pnpm --filter @restatedev/restate-e2e-services run testrunner:http1"

--- a/packages/tests/restate-e2e-services/package.json
+++ b/packages/tests/restate-e2e-services/package.json
@@ -17,10 +17,12 @@
   "type": "module",
   "scripts": {
     "app": "tsx src/app.ts",
+    "app:http1": "RESTATE_E2E_ENDPOINT_ADAPTER=node-http1 tsx src/app.ts",
     "app:fetch": "RESTATE_E2E_ENDPOINT_ADAPTER=fetch tsx src/app.ts",
     "build": "turbo run _build --filter={.}...",
     "_build": "tsc -b tsconfig.test.json",
     "testrunner": "vitest run --exclude \"**/memory_leak.test.ts\" && vitest run test/memory_leak.test.ts",
+    "testrunner:http1": "vitest run test/node_endpoint.test.ts",
     "testrunner:fetch": "vitest run test/memory_leak.test.ts",
     "clean": "rm -rf dist *.tsbuildinfo .turbo",
     "check:types": "turbo run _check:types --filter={.}...",

--- a/packages/tests/restate-e2e-services/src/app.ts
+++ b/packages/tests/restate-e2e-services/src/app.ts
@@ -31,6 +31,8 @@ import "./preview_serdes.js";
 import "./ingress_default_serde.js";
 import "./hooks.js";
 import "./memory_leak.js";
+import "./node_endpoint.js";
+import * as http from "http";
 import * as http2 from "http2";
 import * as heapdump from "heapdump";
 import path from "path";
@@ -125,11 +127,40 @@ function startNodeHttp2Endpoint() {
   });
 }
 
+function startNodeHttp1Endpoint() {
+  let inflightRequests = 0;
+
+  const handler = restate.createEndpointHandler({
+    services: selectedServices,
+    identityKeys,
+    bidirectional: false,
+  });
+  const server = http.createServer((req, res) => {
+    inflightRequests++;
+    res.once("close", () => {
+      inflightRequests--;
+    });
+    handler(req, res);
+  });
+
+  setInterval(() => {
+    console.log(
+      `${new Date().toISOString()}: Inflight requests: ${inflightRequests}`
+    );
+  }, 30 * 1000);
+
+  server.listen(port, "0.0.0.0", () => {
+    console.log(`HTTP/1.1 server listening on 0.0.0.0:${port}`);
+  });
+}
+
 const endpointAdapter =
   process.env.RESTATE_E2E_ENDPOINT_ADAPTER ?? "node-http2";
 if (endpointAdapter === "fetch") {
   const { startFetchEndpoint } = await import("./fetch_endpoint.js");
   startFetchEndpoint({ port, services: selectedServices, identityKeys });
+} else if (endpointAdapter === "node-http1" || endpointAdapter === "http1") {
+  startNodeHttp1Endpoint();
 } else if (endpointAdapter === "node-http2" || endpointAdapter === "http2") {
   startNodeHttp2Endpoint();
 } else {

--- a/packages/tests/restate-e2e-services/src/node_endpoint.ts
+++ b/packages/tests/restate-e2e-services/src/node_endpoint.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import { setTimeout } from "node:timers/promises";
+import * as restate from "@restatedev/restate-sdk";
+import { REGISTRY } from "./services.js";
+
+type DelayOutsideRunRequest = {
+  delayMillis?: number;
+};
+
+type DelayOutsideRunResponse = {
+  attempt: number;
+};
+
+const attempts = new Map<string, number>();
+
+async function delayOutsideRun(
+  ctx: restate.Context,
+  input: DelayOutsideRunRequest
+): Promise<DelayOutsideRunResponse> {
+  const delayMillis = input.delayMillis ?? 500;
+  const invocationId = ctx.request().id;
+  const attempt = (attempts.get(invocationId) ?? 0) + 1;
+  attempts.set(invocationId, attempt);
+
+  await setTimeout(delayMillis);
+
+  return {
+    attempt,
+  };
+}
+
+const nodeEndpointService = restate.service({
+  name: "NodeEndpoint",
+  handlers: {
+    delayOutsideRun: restate.handlers.handler(
+      {
+        retryPolicy: {
+          initialInterval: 250,
+          maxAttempts: 1,
+          onMaxAttempts: "kill",
+        },
+      },
+      delayOutsideRun
+    ),
+  },
+});
+
+REGISTRY.addService(nodeEndpointService);
+
+export type NodeEndpoint = typeof nodeEndpointService;

--- a/packages/tests/restate-e2e-services/test/node_endpoint.test.ts
+++ b/packages/tests/restate-e2e-services/test/node_endpoint.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import { describe, expect, it } from "vitest";
+import { ingressClient } from "./utils.js";
+import type { NodeEndpoint } from "../src/node_endpoint.js";
+
+const nodeEndpoint: NodeEndpoint = {
+  name: "NodeEndpoint",
+};
+
+describe("Node endpoint request lifecycle", () => {
+  const ingress = ingressClient();
+
+  it("does not restart when async work outside ctx.run", async () => {
+    const result = await ingress
+      .serviceClient(nodeEndpoint)
+      .delayOutsideRun({ delayMillis: 500 });
+
+    expect(result).toEqual({ attempt: 1 });
+  }, 5_000);
+});


### PR DESCRIPTION
was testing some use-cases with flow-control in nodejs, created simple handler that only had `await setTimeout(5000)` and invoked few tasks, that kept failing with `RestateError: (500) Connection closed` error. was poking around, and found that the abort controller was triggered right after the connection closed, which simply aborted the connection when the request finished. it wasn't visible in http2 or when used with durable wrappers (eg `ctx.run()`).

because this only affects http1.1 i've prepared separate e2e/integration tests, similarly how tests for `fetch` are done. i'm not sure about the github actions, so that would need more attention.

EDIT:

some more information:  `close` event is always triggered by `IncomingMessage` no matter if it was aborted or finished, since node 16: https://nodejs.org/api/http.html#event-close-3 to resolve that issue we can use `readableEnded` of the `IncomingMessage` stream, to distinguish between aborted and finished request.


## running the tests

start the service:

```shell
SERVICES=NodeEndpoint PORT=8000 pnpm --filter @restatedev/restate-e2e-services app:http1
```

then register the http1.1 deployment

```shell
curl -X POST http://localhost:9070/deployments \
  -H 'content-type: application/json' \
  -d '{"uri": "http://localhost:8000", "use_http_11": true}'
```

and then run the test

```shell
RESTATE_INGRESS_URL=http://localhost:8080 \
RESTATE_ADMIN_URL=http://localhost:9070 \
pnpm --filter @restatedev/restate-e2e-services exec vitest run test/node_endpoint.test.ts
```