### PR TITLE
Retry safe ingress reads after drain and transport failures

### DIFF
--- a/.changeset/lucky-moons-attach.md
+++ b/.changeset/lucky-moons-attach.md
@@ -1,0 +1,26 @@
+---
+"@restatedev/restate-sdk-clients": patch
+---
+
+Retry the remaining safe ingress reads when `retry` is enabled
+
+`result()` and `workflowOutput` were still one-shot GETs, so a request that raced
+a draining ingress pod failed even though the durable invocation had completed
+exactly once. They now use the same retry policy as `workflowAttach`, with no
+idempotency-key gate: these reads only retrieve a result that already exists.
+
+On a read, a caller-provided `signal` or `timeout` bounds the whole operation
+including its retries. Handing each attempt a fresh timeout would silently
+multiply the wait the caller asked for by `maxAttempts`, since the work being
+waited on is already running elsewhere. Invocations keep their per-attempt
+deadline, where each attempt does start the wait over.
+
+`defaultShouldRetry` no longer retries a response that reports an invocation's
+own outcome, identified by the `x-restate-id` header. A handler's `TerminalError`
+surfaces with the failure's own status, which may be a `5xx`; retrying it only
+delayed the same error.
+
+`retry` policy overrides outside their documented domain — a non-integer or
+unbounded `maxAttempts`, a negative or non-finite interval, an exponentiation
+factor below 1 — now throw a `TypeError` instead of silently producing an
+unbounded loop or a backoff that collapses to an immediate retry.

--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -79,6 +79,9 @@ export interface Ingress {
   /**
    * Obtain the result of a service that was asynchronously submitted (via a sendClient).
    *
+   * This only retrieves a result that already exists, so it is retried whenever
+   * {@link ConnectionOpts.retry} is enabled — no idempotency key is needed.
+   *
    * @param send either the send response or the workflow submission as obtained by the respective clients.
    */
   result<T>(
@@ -234,12 +237,20 @@ export interface IngressCallOptions<I = unknown, O = unknown> {
    *
    * Same as {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal#aborting_a_fetch_with_timeout_or_explicit_abort | AbortSignal.timeout()}.
    *
+   * With {@link ConnectionOpts.retry} enabled, each attempt at invoking a handler
+   * gets the full timeout, since every attempt starts the wait over. On the reads
+   * (`result`, `workflowAttach`, `workflowOutput`) the timeout instead bounds the
+   * whole operation including its retries, because the work being waited on is
+   * already running elsewhere.
+   *
    * This field is exclusive with `signal`, and using both of them will result in a runtime failure.
    */
   timeout?: number;
 
   /**
    * Signal to abort the underlying `fetch` operation. See {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal}.
+   *
+   * Aborting also stops any pending retry.
    *
    * This field is exclusive with `timeout`, and using both of them will result in a runtime failure.
    */
@@ -413,7 +424,9 @@ export type IngressWorkflowClient<M> = Omit<
      * If the output is ready, the 'result' field will contain the output.
      * note: that this operation will not wait for the workflow to complete, to do so use 'workflowAttach'.
      * When automatic retries are enabled on the connection, the client retries
-     * ambiguous output retrieval failures according to the configured retry policy.
+     * ambiguous output retrieval failures according to the configured retry policy;
+     * a workflow whose output is simply not ready yet is reported as such rather
+     * than retried.
      *
      * @returns a promise that resolves if the workflow's output is ready/available.
      */
@@ -488,12 +501,21 @@ export type RetryFailure =
  * {@link ConnectionOpts.retry}) and the request is safe to repeat. Regular
  * calls require an `idempotencyKey` (see
  * {@link IngressCallOptions.idempotencyKey}); workflow submissions are
- * idempotent by workflow ID, while workflow attaches and output retrieval only
- * observe the existing workflow.
+ * idempotent by workflow ID, while workflow attaches, output retrieval, and
+ * {@link Ingress.result} only observe an invocation that already exists.
  *
  * By default the following failures are retried: network errors (the underlying
- * `fetch` rejecting), HTTP `429`, and HTTP `5xx` responses. Override this with
- * {@link RetryPolicy.shouldRetry}.
+ * `fetch` rejecting), HTTP `429`, and HTTP `5xx` responses. A response that
+ * reports an invocation's own outcome is never retried, even a `5xx` one, since
+ * a terminal failure does not become less terminal on a second look. Override
+ * all of this with {@link RetryPolicy.shouldRetry}.
+ *
+ * A failure stays ambiguous until the response body has been received in full,
+ * so a connection lost mid-body is retried like any other transport failure.
+ *
+ * An override outside the documented domain — a non-integer or unbounded
+ * `maxAttempts`, a negative or non-finite interval — throws a `TypeError` rather
+ * than being clamped.
  */
 export interface RetryPolicy {
   /**
@@ -526,10 +548,15 @@ export interface RetryPolicy {
    * fully replaces the built-in rule (network / `429` / `5xx`).
    *
    * The idempotency-key gate still applies to regular invocations; workflow
-   * submissions, attaches, and output retrieval remain eligible without an
-   * idempotency key. The `maxAttempts` cap applies to all of them. This predicate
-   * only narrows or broadens *which failures* are retryable within those bounds.
-   * Compose with the built-in rule via the exported `defaultShouldRetry`.
+   * submissions, attaches, output retrieval, and {@link Ingress.result} remain
+   * eligible without an idempotency key. The `maxAttempts` cap applies to all of
+   * them. This predicate only narrows or broadens *which failures* are retryable
+   * within those bounds. Compose with the built-in rule via the exported
+   * `defaultShouldRetry`.
+   *
+   * Because it replaces the built-in rule everywhere, it also sees read-path
+   * failures — including the `470` that `workflowOutput` uses to report an
+   * output that is not ready yet.
    *
    * @param failure the failure being considered
    * @param attempt the zero-based index of the attempt that just failed
@@ -558,11 +585,14 @@ export type ConnectionOpts = {
    *
    * Even when enabled, regular calls are retried **only** when an
    * `idempotencyKey` is set — without one a retry could double-execute a
-   * non-idempotent invocation. Workflow submissions, attaches, and output
-   * retrieval are also retried: submissions are idempotent by workflow ID,
-   * while attach and output operations only observe the existing workflow. If a
-   * submission retry observes a workflow accepted by an earlier attempt, its
+   * non-idempotent invocation. Workflow submissions, attaches, output retrieval,
+   * and {@link Ingress.result} are also retried: submissions are idempotent by
+   * workflow ID, while the reads only observe an invocation that already exists.
+   * If a submission retry observes a workflow accepted by an earlier attempt, its
    * status is `PreviouslyAccepted`.
+   *
+   * Retrying the reads is what lets them survive an ingress being drained
+   * mid-read during a rolling deploy.
    */
   retry?: RetryPolicy | boolean;
 

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -122,26 +122,71 @@ const LIMIT_KEY_HEADER = "x-restate-limit-key";
 const getFetch = (opts: ConnectionOpts): NonNullable<ConnectionOpts["fetch"]> =>
   opts.fetch ?? globalThis.fetch;
 
-const fetchWithRetries = async (
-  opts: ConnectionOpts,
-  url: string,
-  init: RequestInit,
-  callOpts: Opts<unknown, unknown> | SendOpts<unknown> | undefined,
-  retryPolicy: ResolvedRetryPolicy | undefined
-): Promise<Uint8Array> => {
-  const userSignal = callOpts?.opts.signal;
-  const timeout = callOpts?.opts.timeout;
-  if (userSignal !== undefined && timeout !== undefined) {
+type CancellationOptions = { signal?: AbortSignal; timeout?: number };
+
+type AttemptDeadline = {
+  /**
+   * Cancellation observed between attempts: once it aborts, no further attempt
+   * is made and any pending backoff is cut short.
+   */
+  cancellation?: AbortSignal;
+  /** The signal handed to `fetch` for the next attempt. */
+  attemptSignal: () => AbortSignal | undefined;
+};
+
+const assertSignalAndTimeoutExclusive = (opts?: CancellationOptions) => {
+  if (opts?.signal !== undefined && opts.timeout !== undefined) {
     // The caller configured two mutually exclusive ways to abort each attempt.
     throw new Error(
       "You can't specify both signal and timeout options at the same time"
     );
   }
-  // A fresh timeout signal is minted per attempt below — a single
-  // AbortSignal.timeout() would already be aborted on the second attempt.
-  const attemptSignal = (): AbortSignal | undefined =>
-    userSignal ??
-    (timeout !== undefined ? AbortSignal.timeout(timeout) : undefined);
+};
+
+/**
+ * A deadline per attempt. Each attempt at invoking a handler starts the wait
+ * over, so each is given the full timeout.
+ */
+const perAttemptDeadline = (opts?: CancellationOptions): AttemptDeadline => {
+  assertSignalAndTimeoutExclusive(opts);
+  const userSignal = opts?.signal;
+  const timeout = opts?.timeout;
+  return {
+    cancellation: userSignal,
+    // A fresh timeout signal is minted per attempt — a single
+    // AbortSignal.timeout() would already be aborted on the second attempt.
+    attemptSignal: () =>
+      userSignal ??
+      (timeout !== undefined ? AbortSignal.timeout(timeout) : undefined),
+  };
+};
+
+/**
+ * One deadline covering the whole operation, retries and backoff included.
+ *
+ * This is what a deadline means on a read: the caller is giving up on work that
+ * is already running elsewhere, so handing each attempt a fresh timeout would
+ * silently multiply the wait they asked for by `maxAttempts`.
+ */
+const wholeOperationDeadline = (
+  opts?: CancellationOptions
+): AttemptDeadline => {
+  assertSignalAndTimeoutExclusive(opts);
+  const signal =
+    opts?.signal ??
+    (opts?.timeout !== undefined
+      ? AbortSignal.timeout(opts.timeout)
+      : undefined);
+  return { cancellation: signal, attemptSignal: () => signal };
+};
+
+const fetchWithRetries = async (
+  opts: ConnectionOpts,
+  url: string,
+  init: RequestInit,
+  { cancellation, attemptSignal }: AttemptDeadline,
+  retryPolicy: ResolvedRetryPolicy | undefined
+): Promise<Uint8Array> => {
   const shouldRetry = retryPolicy?.shouldRetry ?? defaultShouldRetry;
 
   for (let attempt = 0; ; attempt++) {
@@ -166,12 +211,12 @@ const fetchWithRetries = async (
       if (
         retryPolicy &&
         attempt < retryPolicy.maxAttempts - 1 &&
-        !userSignal?.aborted &&
+        !cancellation?.aborted &&
         shouldRetry({ kind: "network", error: e }, attempt)
       ) {
         // Retries are enabled, attempts remain, the caller did not abort, and
         // the policy accepted this network failure.
-        await abortableSleep(backoffDelay(retryPolicy, attempt), userSignal);
+        await abortableSleep(backoffDelay(retryPolicy, attempt), cancellation);
         continue;
       }
       // Retries are disabled or exhausted, the caller aborted, or the policy
@@ -181,7 +226,7 @@ const fetchWithRetries = async (
     if (
       retryPolicy &&
       attempt < retryPolicy.maxAttempts - 1 &&
-      !userSignal?.aborted &&
+      !cancellation?.aborted &&
       shouldRetry(
         {
           kind: "response",
@@ -197,7 +242,7 @@ const fetchWithRetries = async (
       const retryAfter = parseRetryAfter(response.headers);
       await abortableSleep(
         backoffDelay(retryPolicy, attempt, retryAfter),
-        userSignal
+        cancellation
       );
       continue;
     }
@@ -309,7 +354,7 @@ const doComponentInvocation = async <I, O>(
       headers,
       body,
     },
-    params.opts,
+    perAttemptDeadline(params.opts?.opts),
     retryPolicy
   );
   if (!params.send) {
@@ -323,42 +368,53 @@ const doComponentInvocation = async <I, O>(
   return { ...json, attachable };
 };
 
-const doWorkflowHandleCall = async <O>(
+const deserializeResponse = async <T>(
+  bytes: Uint8Array,
+  outputSerde: Serde<T>,
+  journalValueCodec?: JournalValueCodec
+): Promise<T> =>
+  outputSerde.deserialize(
+    journalValueCodec ? await journalValueCodec.decode(bytes) : bytes
+  );
+
+/**
+ * Read the outcome of an invocation that already exists: attach, output, and an
+ * attached send result only observe work that has already been submitted.
+ *
+ * Retried whenever {@link ConnectionOpts.retry} is enabled, with no
+ * idempotency-key gate: a GET has no side effects, so reissuing it can at worst
+ * return the same answer twice. That is what lets these reads survive an ingress
+ * being drained mid-read during a rolling deploy.
+ */
+const safeRead = async <T>(
+  opts: ConnectionOpts,
+  url: string,
+  outputSerde: Serde<T>,
+  callOpts?: Opts<void, T>
+): Promise<T> => {
+  const bytes = await fetchWithRetries(
+    opts,
+    url,
+    { method: "GET", headers: { ...(opts.headers ?? {}) } },
+    wholeOperationDeadline(callOpts?.opts),
+    resolveRetryPolicy(opts.retry)
+  );
+  return deserializeResponse(bytes, outputSerde, opts.journalValueCodec);
+};
+
+const doWorkflowHandleCall = <O>(
   opts: ConnectionOpts,
   wfName: string,
   wfKey: string,
   op: "output" | "attach",
-  callOpts?: Opts<unknown, O> | SendOpts<unknown>
-): Promise<O> => {
-  const outputSerde = callOpts?.opts.output ?? opts.serde ?? serde.json;
-  //
-  // headers
-  //
-  const headers = {
-    ...(opts.headers ?? {}),
-  };
-  //
-  // make the call
-  //
-  const url = `${opts.url}/restate/workflow/${wfName}/${encodeURIComponent(
-    wfKey
-  )}/${op}`;
-  // Attach and output only observe the existing workflow, so both are eligible
-  // when the connection has a retry policy.
-  const retryPolicy = resolveRetryPolicy(opts.retry);
-
-  const responseBuf = await fetchWithRetries(
+  callOpts?: Opts<void, O>
+): Promise<O> =>
+  safeRead(
     opts,
-    url,
-    { method: "GET", headers },
-    callOpts,
-    retryPolicy
+    `${opts.url}/restate/workflow/${wfName}/${encodeURIComponent(wfKey)}/${op}`,
+    (callOpts?.opts.output ?? opts.serde ?? serde.json) as Serde<O>,
+    callOpts
   );
-  const decodedBuf = opts.journalValueCodec
-    ? await opts.journalValueCodec.decode(responseBuf)
-    : responseBuf;
-  return outputSerde.deserialize(decodedBuf) as O;
-};
 
 class HttpIngress implements Ingress {
   constructor(private readonly opts: ConnectionOpts) {}
@@ -734,34 +790,10 @@ class HttpIngress implements Ingress {
         A service's result is stored only with an idempotencyKey is supplied when invocating the service.`
       );
     }
-    //
-    // headers
-    //
-    const headers = {
-      ...(this.opts.headers ?? {}),
-    };
-    //
-    // make the call
-    const url = `${this.opts.url}/restate/invocation/${send.invocationId}/attach`;
-
-    const httpResponse = await getFetch(this.opts)(url, {
-      method: "GET",
-      headers,
-    });
-    if (httpResponse.ok) {
-      const responseBuf = new Uint8Array(await httpResponse.arrayBuffer());
-      const decodedBuf = this.opts.journalValueCodec
-        ? await this.opts.journalValueCodec.decode(responseBuf)
-        : responseBuf;
-      return (resultSerde ?? this.opts.serde ?? serde.json).deserialize(
-        decodedBuf
-      ) as T;
-    }
-    const body = await httpResponse.text();
-    throw new HttpCallError(
-      httpResponse.status,
-      body,
-      `Request failed: ${httpResponse.status}\n${body}`
+    return safeRead(
+      this.opts,
+      `${this.opts.url}/restate/invocation/${send.invocationId}/attach`,
+      (resultSerde ?? this.opts.serde ?? serde.json) as Serde<T>
     );
   }
 }

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -66,6 +66,51 @@ describe("resolveRetryPolicy", () => {
       maxInterval: 30_000,
     });
   });
+
+  it("rejects a maxAttempts that is not a positive integer", () => {
+    expect(() => resolveRetryPolicy({ maxAttempts: Infinity })).toThrow(
+      TypeError
+    );
+    expect(() => resolveRetryPolicy({ maxAttempts: 0 })).toThrow(TypeError);
+    expect(() => resolveRetryPolicy({ maxAttempts: -1 })).toThrow(TypeError);
+    expect(() => resolveRetryPolicy({ maxAttempts: 2.5 })).toThrow(TypeError);
+    expect(() => resolveRetryPolicy({ maxAttempts: NaN })).toThrow(TypeError);
+  });
+
+  it("accepts maxAttempts of 1, which simply makes no retry", () => {
+    expect(resolveRetryPolicy({ maxAttempts: 1 })).toMatchObject({
+      maxAttempts: 1,
+    });
+  });
+
+  it("rejects intervals that are negative or not finite", () => {
+    expect(() => resolveRetryPolicy({ initialInterval: -1 })).toThrow(
+      TypeError
+    );
+    expect(() => resolveRetryPolicy({ initialInterval: Infinity })).toThrow(
+      TypeError
+    );
+    expect(() => resolveRetryPolicy({ maxInterval: -1 })).toThrow(TypeError);
+    expect(() => resolveRetryPolicy({ maxInterval: NaN })).toThrow(TypeError);
+  });
+
+  it("rejects an exponentiation factor below 1 or not finite", () => {
+    expect(() => resolveRetryPolicy({ exponentiationFactor: 0 })).toThrow(
+      TypeError
+    );
+    expect(() => resolveRetryPolicy({ exponentiationFactor: 0.5 })).toThrow(
+      TypeError
+    );
+    expect(() =>
+      resolveRetryPolicy({ exponentiationFactor: Infinity })
+    ).toThrow(TypeError);
+  });
+
+  it("names the offending field in the error", () => {
+    expect(() => resolveRetryPolicy({ maxInterval: -1 })).toThrow(
+      /retry\.maxInterval/
+    );
+  });
 });
 
 describe("defaultShouldRetry", () => {
@@ -88,6 +133,18 @@ describe("defaultShouldRetry", () => {
         kind: "response",
         status: 409,
         headers: new Headers(),
+      })
+    ).toBe(false);
+  });
+
+  it("does not retry a 5xx that reports an invocation's own outcome", () => {
+    // A handler's TerminalError surfaces with the failure's own status; the
+    // ingress marks such responses with the invocation id.
+    expect(
+      defaultShouldRetry({
+        kind: "response",
+        status: 500,
+        headers: new Headers({ "x-restate-id": "inv_1abc" }),
       })
     ).toBe(false);
   });
@@ -177,58 +234,80 @@ describe("abortableSleep", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Integration: retry behavior through connect()/call()
+// Integration: retry behavior through connect()
 // ---------------------------------------------------------------------------
 
+const URL = "http://localhost:8080";
+
+// Response/error factories — a fresh, unread Response per attempt (real
+// fetch hands back a new Response per call).
+type Attempt = () => Promise<Response>;
+const ok =
+  (body: unknown = { ok: true }): Attempt =>
+  () =>
+    Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+const fail =
+  (status: number, headers?: Record<string, string>): Attempt =>
+  () =>
+    Promise.resolve(new Response("nope", { status, headers }));
+const neterr =
+  (msg: string): Attempt =>
+  () =>
+    Promise.reject(new TypeError(msg));
+// Headers arrived, then the connection died part-way through the body.
+const streamerr =
+  (msg: string, status = 200, headers?: Record<string, string>): Attempt =>
+  () => {
+    let sentChunk = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentChunk) {
+          controller.enqueue(new TextEncoder().encode('{"partial":'));
+          sentChunk = true;
+          return;
+        }
+        controller.error(new TypeError(msg));
+      },
+    });
+    return Promise.resolve(new Response(body, { status, headers }));
+  };
+
+const fastRetry = {
+  initialInterval: 1,
+  maxInterval: 2,
+  exponentiationFactor: 2,
+};
+
+/**
+ * Stub out global fetch for the enclosing describe, returning a `queue` that
+ * plays back a sequence of attempts, repeating the last one.
+ */
+const stubFetch = () => {
+  let fetchMock!: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  return {
+    calls: () => fetchMock.mock.calls,
+    attempts: () => fetchMock.mock.calls.length,
+    queue: (...attempts: Attempt[]) => {
+      let i = 0;
+      fetchMock.mockImplementation(() =>
+        attempts[Math.min(i++, attempts.length - 1)]!()
+      );
+    },
+  };
+};
+
 describe("ingress auto-retry", () => {
-  const URL = "http://localhost:8080";
-  let fetchMock: ReturnType<typeof vi.fn>;
-
-  // Response/error factories — a fresh, unread Response per attempt (real
-  // fetch hands back a new Response per call).
-  type Attempt = () => Promise<Response>;
-  const ok =
-    (body: unknown = { ok: true }): Attempt =>
-    () =>
-      Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
-  const fail =
-    (status: number, headers?: Record<string, string>): Attempt =>
-    () =>
-      Promise.resolve(new Response("nope", { status, headers }));
-  const neterr =
-    (msg: string): Attempt =>
-    () =>
-      Promise.reject(new TypeError(msg));
-  const streamerr =
-    (msg: string): Attempt =>
-    () => {
-      let sentChunk = false;
-      const body = new ReadableStream<Uint8Array>({
-        pull(controller) {
-          if (!sentChunk) {
-            controller.enqueue(new TextEncoder().encode('{"partial":'));
-            sentChunk = true;
-            return;
-          }
-          controller.error(new TypeError(msg));
-        },
-      });
-      return Promise.resolve(new Response(body, { status: 200 }));
-    };
-
-  // A fetch mock that plays back a queued sequence, repeating the last item.
-  const queue = (...attempts: Attempt[]) => {
-    let i = 0;
-    fetchMock.mockImplementation(() =>
-      attempts[Math.min(i++, attempts.length - 1)]!()
-    );
-  };
-
-  const fastRetry = {
-    initialInterval: 1,
-    maxInterval: 2,
-    exponentiationFactor: 2,
-  };
+  const { queue, calls, attempts } = stubFetch();
 
   const call = (idempotencyKey?: string, retry?: RetryPolicy | boolean) =>
     connect({ url: URL, retry }).call({
@@ -255,57 +334,48 @@ describe("ingress auto-retry", () => {
       .scope("scope")
       .workflowClient(testWorkflow, "workflow-id");
 
-  beforeEach(() => {
-    fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("does NOT retry without an idempotency key", async () => {
     queue(fail(503), ok());
     await expect(call(undefined, fastRetry)).rejects.toBeInstanceOf(
       HttpCallError
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("does NOT retry by default — retries are opt-in", async () => {
     queue(fail(503), ok());
     await expect(call("k1", undefined)).rejects.toBeInstanceOf(HttpCallError);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("retry:true enables the built-in policy", async () => {
     queue(fail(503), ok());
     await expect(call("k1", true)).resolves.toEqual({ ok: true });
-    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(attempts()).toBeGreaterThanOrEqual(2);
   });
 
   it("retries 5xx then succeeds when an idempotency key is set", async () => {
     queue(fail(500), fail(503), ok({ greeting: "hi" }));
     await expect(call("k1", fastRetry)).resolves.toEqual({ greeting: "hi" });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(attempts()).toBe(3);
   });
 
   it("retries on 429", async () => {
     queue(fail(429), ok());
     await expect(call("k1", fastRetry)).resolves.toEqual({ ok: true });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("retries on a network error", async () => {
     queue(neterr("connection refused"), ok());
     await expect(call("k1", fastRetry)).resolves.toEqual({ ok: true });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("retries when a successful response body stream fails", async () => {
     queue(streamerr("stream interrupted"), ok({ greeting: "hi" }));
     await expect(call("k1", fastRetry)).resolves.toEqual({ greeting: "hi" });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("does NOT retry workflow submission without a retry policy", async () => {
@@ -313,7 +383,7 @@ describe("ingress auto-retry", () => {
     await expect(workflow().workflowSubmit({})).rejects.toBeInstanceOf(
       HttpCallError
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("retries workflow submission without an idempotency key", async () => {
@@ -327,7 +397,7 @@ describe("ingress auto-retry", () => {
         status: "PreviouslyAccepted",
       }
     );
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("retries scoped workflow submission without an idempotency key", async () => {
@@ -338,7 +408,7 @@ describe("ingress auto-retry", () => {
       invocationId: "invocation-id",
       status: "Accepted",
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("does NOT retry workflow attach without a retry policy", async () => {
@@ -346,7 +416,7 @@ describe("ingress auto-retry", () => {
     await expect(workflow().workflowAttach()).rejects.toBeInstanceOf(
       HttpCallError
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("retries workflow attach without an idempotency key", async () => {
@@ -354,7 +424,7 @@ describe("ingress auto-retry", () => {
     await expect(workflow(fastRetry).workflowAttach()).resolves.toEqual({
       result: "done",
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("does NOT retry workflow output without a retry policy", async () => {
@@ -362,7 +432,7 @@ describe("ingress auto-retry", () => {
     await expect(workflow().workflowOutput()).rejects.toBeInstanceOf(
       HttpCallError
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("retries workflow output without an idempotency key", async () => {
@@ -371,26 +441,26 @@ describe("ingress auto-retry", () => {
       ready: true,
       result: { result: "done" },
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(attempts()).toBe(2);
   });
 
   it("does NOT retry workflow output when it is not ready by default", async () => {
     queue(fail(470), ok({ result: "done" }));
     const output = await workflow(fastRetry).workflowOutput();
     expect(output.ready).toBe(false);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("does NOT retry on a non-retryable 4xx", async () => {
     queue(fail(409), ok());
     await expect(call("k1", fastRetry)).rejects.toBeInstanceOf(HttpCallError);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("retry:false disables retries even with an idempotency key", async () => {
     queue(fail(503), ok());
     await expect(call("k1", false)).rejects.toBeInstanceOf(HttpCallError);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("a custom shouldRetry can narrow the decision (no retry on 500)", async () => {
@@ -402,7 +472,7 @@ describe("ingress auto-retry", () => {
           defaultShouldRetry(f) && !(f.kind === "response" && f.status === 500),
       })
     ).rejects.toMatchObject({ status: 500 });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(attempts()).toBe(1);
   });
 
   it("a custom shouldRetry can inspect the response body", async () => {
@@ -423,7 +493,7 @@ describe("ingress auto-retry", () => {
     await expect(
       call("k1", { ...fastRetry, maxAttempts: 3 })
     ).rejects.toMatchObject({ status: 500 });
-    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+    expect(attempts()).toBe(3); // initial + 2 retries
   });
 
   it("mints a fresh timeout signal per attempt", async () => {
@@ -434,10 +504,208 @@ describe("ingress auto-retry", () => {
       parameter: {},
       opts: Opts.from({ idempotencyKey: "k1", timeout: 10_000 }),
     });
-    const signals = fetchMock.mock.calls.map(
-      (c) => (c[1] as RequestInit).signal
-    );
+    const signals = calls().map((c) => (c[1] as RequestInit).signal);
     expect(signals[0]).not.toBe(signals[1]);
     expect(signals[0]?.aborted).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: reading the outcome of an existing invocation — result(),
+// workflowOutput, and workflowAttach beyond the cases above. These GETs must
+// survive an ingress draining mid-read during a rolling deploy, which is what
+// the drain 503, the reset connection and the truncated body stand in for.
+// ---------------------------------------------------------------------------
+
+describe("ingress read auto-retry", () => {
+  const { queue, calls, attempts } = stubFetch();
+
+  // What a draining ingress sends: 503 plus, on HTTP/1.1, a connection close.
+  const drain = fail(503, { "retry-after": "0", connection: "close" });
+  // A handler's TerminalError, which the ingress reports with the failure's own
+  // status and marks with the invocation id.
+  const terminalFailure = fail(500, { "x-restate-id": "inv_1abc" });
+
+  type TestWorkflow = WorkflowDefinition<
+    "workflow",
+    {
+      run: (
+        context: unknown,
+        input: Record<string, unknown>
+      ) => Promise<Record<string, unknown>>;
+    }
+  >;
+  const testWorkflow: TestWorkflow = { name: "workflow" };
+  const workflow = (retry?: RetryPolicy | boolean) =>
+    connect({ url: URL, retry }).workflowClient(testWorkflow, "workflow-id");
+  const scopedWorkflow = (retry?: RetryPolicy | boolean) =>
+    connect({ url: URL, retry })
+      .scope("scope")
+      .workflowClient(testWorkflow, "workflow-id");
+
+  const result = (retry?: RetryPolicy | boolean) =>
+    connect({ url: URL, retry }).result({
+      invocationId: "inv_1abc",
+      status: "Accepted",
+      attachable: true,
+    });
+
+  describe("result()", () => {
+    it("retries a drain 503, then succeeds", async () => {
+      queue(drain, ok({ greeting: "hi" }));
+      await expect(result(fastRetry)).resolves.toEqual({ greeting: "hi" });
+      expect(attempts()).toBe(2);
+    });
+
+    it("retries a transport failure, then succeeds", async () => {
+      queue(neterr("socket hang up"), ok({ greeting: "hi" }));
+      await expect(result(fastRetry)).resolves.toEqual({ greeting: "hi" });
+      expect(attempts()).toBe(2);
+    });
+
+    it("retries a body cut short after a 200, then succeeds", async () => {
+      queue(streamerr("stream interrupted"), ok({ greeting: "hi" }));
+      await expect(result(fastRetry)).resolves.toEqual({ greeting: "hi" });
+      expect(attempts()).toBe(2);
+    });
+
+    it("retries a body cut short after a drain 503, then succeeds", async () => {
+      queue(streamerr("stream interrupted", 503), ok({ greeting: "hi" }));
+      await expect(result(fastRetry)).resolves.toEqual({ greeting: "hi" });
+      expect(attempts()).toBe(2);
+    });
+
+    it("needs no idempotency key — the read itself is safe", async () => {
+      queue(drain, ok());
+      await expect(result(true)).resolves.toEqual({ ok: true });
+      expect(attempts()).toBeGreaterThanOrEqual(2);
+    });
+
+    it("does NOT retry by default — retries are opt-in", async () => {
+      queue(drain, ok());
+      await expect(result()).rejects.toBeInstanceOf(HttpCallError);
+      expect(attempts()).toBe(1);
+    });
+
+    it("does NOT retry an invocation's own terminal failure", async () => {
+      queue(terminalFailure, ok());
+      await expect(result(fastRetry)).rejects.toMatchObject({ status: 500 });
+      expect(attempts()).toBe(1);
+    });
+
+    it("gives up after maxAttempts and throws the last error", async () => {
+      queue(drain);
+      await expect(
+        result({ ...fastRetry, maxAttempts: 3 })
+      ).rejects.toMatchObject({ status: 503, responseText: "nope" });
+      expect(attempts()).toBe(3);
+    });
+
+    it("does not fetch at all when the send is not attachable", async () => {
+      queue(ok());
+      await expect(
+        connect({ url: URL, retry: fastRetry }).result({
+          invocationId: "inv_1abc",
+          status: "Accepted",
+          attachable: false,
+        })
+      ).rejects.toThrow(/Unable to fetch the result/);
+      expect(attempts()).toBe(0);
+    });
+  });
+
+  describe("workflowAttach", () => {
+    it("retries a body cut short, then succeeds", async () => {
+      queue(streamerr("stream interrupted"), ok({ done: true }));
+      await expect(workflow(fastRetry).workflowAttach()).resolves.toEqual({
+        done: true,
+      });
+      expect(attempts()).toBe(2);
+    });
+
+    it("does NOT retry once the caller has aborted", async () => {
+      queue(drain, ok());
+      const ac = new AbortController();
+      ac.abort(new Error("caller gave up"));
+      await expect(
+        workflow(fastRetry).workflowAttach(Opts.from({ signal: ac.signal }))
+      ).rejects.toThrow();
+      expect(attempts()).toBe(1);
+    });
+
+    it("stops retrying when the caller aborts between attempts", async () => {
+      const ac = new AbortController();
+      queue(() => {
+        ac.abort(new Error("caller gave up"));
+        return Promise.resolve(new Response("nope", { status: 503 }));
+      }, ok());
+      await expect(
+        workflow({ ...fastRetry, initialInterval: 10_000 }).workflowAttach(
+          Opts.from({ signal: ac.signal })
+        )
+      ).rejects.toBeInstanceOf(HttpCallError);
+      expect(attempts()).toBe(1);
+    });
+
+    it("bounds the whole read, retries included, with one timeout signal", async () => {
+      queue(drain, ok());
+      await workflow(fastRetry).workflowAttach(Opts.from({ timeout: 10_000 }));
+      const signals = calls().map((c) => (c[1] as RequestInit).signal);
+      expect(attempts()).toBe(2);
+      expect(signals[0]).toBe(signals[1]);
+    });
+
+    it("does NOT retry an invocation's own terminal failure", async () => {
+      queue(terminalFailure, ok());
+      await expect(workflow(fastRetry).workflowAttach()).rejects.toMatchObject({
+        status: 500,
+      });
+      expect(attempts()).toBe(1);
+    });
+  });
+
+  describe("workflowOutput", () => {
+    it("retries a drain 503, then reports the output as not ready", async () => {
+      queue(drain, fail(470));
+      await expect(workflow(fastRetry).workflowOutput()).resolves.toMatchObject(
+        { ready: false }
+      );
+      expect(attempts()).toBe(2);
+    });
+
+    it("does NOT retry the 470 that means 'not ready yet'", async () => {
+      queue(fail(470), ok());
+      await expect(workflow(fastRetry).workflowOutput()).resolves.toMatchObject(
+        { ready: false }
+      );
+      expect(attempts()).toBe(1);
+    });
+
+    it("retries a transport failure, then returns the output", async () => {
+      queue(neterr("ECONNRESET"), ok({ done: true }));
+      await expect(workflow(fastRetry).workflowOutput()).resolves.toEqual({
+        ready: true,
+        result: { done: true },
+      });
+      expect(attempts()).toBe(2);
+    });
+  });
+
+  describe("scoped workflow reads", () => {
+    it("retries a drain 503 on attach, then succeeds", async () => {
+      queue(drain, ok({ done: true }));
+      await expect(scopedWorkflow(fastRetry).workflowAttach()).resolves.toEqual(
+        { done: true }
+      );
+      expect(attempts()).toBe(2);
+    });
+
+    it("retries a drain 503 on output, then succeeds", async () => {
+      queue(drain, ok({ done: true }));
+      await expect(scopedWorkflow(fastRetry).workflowOutput()).resolves.toEqual(
+        { ready: true, result: { done: true } }
+      );
+      expect(attempts()).toBe(2);
+    });
   });
 });

--- a/packages/libs/restate-sdk-clients/src/retry.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.ts
@@ -29,11 +29,46 @@ const DEFAULT_RETRY_POLICY: ResolvedRetryPolicy = {
 };
 
 /**
+ * Bounds are checked rather than clamped: a policy that cannot be honored as
+ * written — an unbounded `maxAttempts`, a backoff that collapses to an immediate
+ * retry — is a mistake to surface, not to quietly reinterpret.
+ */
+const checkedAttempts = (value: number): number => {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new TypeError(
+      `retry.maxAttempts must be an integer of at least 1, got ${value}`
+    );
+  }
+  return value;
+};
+
+const checkedInterval = (name: string, value: number): number => {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new TypeError(
+      `retry.${name} must be a finite, non-negative duration, got ${value}`
+    );
+  }
+  return value;
+};
+
+const checkedFactor = (value: number): number => {
+  if (!Number.isFinite(value) || value < 1) {
+    throw new TypeError(
+      `retry.exponentiationFactor must be a finite number of at least 1, got ${value}`
+    );
+  }
+  return value;
+};
+
+/**
  * Resolve a user supplied retry policy into a fully populated one.
  *
  * Retries are opt-in: returns `undefined` (disabled) when `retry` is omitted or
  * `false`. `true` enables the built-in policy; an object enables it with the
  * provided overrides.
+ *
+ * @throws TypeError if an override is outside the domain documented on
+ *   {@link RetryPolicy}.
  */
 export function resolveRetryPolicy(
   retry: RetryPolicy | boolean | undefined
@@ -45,17 +80,28 @@ export function resolveRetryPolicy(
     return DEFAULT_RETRY_POLICY;
   }
   return {
-    maxAttempts: retry.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
+    maxAttempts:
+      retry.maxAttempts !== undefined
+        ? checkedAttempts(retry.maxAttempts)
+        : DEFAULT_RETRY_POLICY.maxAttempts,
     initialInterval:
       retry.initialInterval !== undefined
-        ? millisOrDurationToMillis(retry.initialInterval)
+        ? checkedInterval(
+            "initialInterval",
+            millisOrDurationToMillis(retry.initialInterval)
+          )
         : DEFAULT_RETRY_POLICY.initialInterval,
     maxInterval:
       retry.maxInterval !== undefined
-        ? millisOrDurationToMillis(retry.maxInterval)
+        ? checkedInterval(
+            "maxInterval",
+            millisOrDurationToMillis(retry.maxInterval)
+          )
         : DEFAULT_RETRY_POLICY.maxInterval,
     exponentiationFactor:
-      retry.exponentiationFactor ?? DEFAULT_RETRY_POLICY.exponentiationFactor,
+      retry.exponentiationFactor !== undefined
+        ? checkedFactor(retry.exponentiationFactor)
+        : DEFAULT_RETRY_POLICY.exponentiationFactor,
     shouldRetry: retry.shouldRetry,
   };
 }
@@ -66,12 +112,30 @@ export function isRetryableStatus(status: number): boolean {
 }
 
 /**
+ * Set by the ingress on every response that carries an invocation's own outcome.
+ * Its presence separates "the invocation ended this way" from "the ingress could
+ * not answer": a handler's terminal failure surfaces with the failure's own HTTP
+ * status, which may well be a `5xx`.
+ */
+const INVOCATION_ID_HEADER = "x-restate-id";
+
+/**
  * The built-in retry decision: retry network errors, HTTP `429`, and HTTP
  * `5xx`. Exported so a custom {@link RetryPolicy.shouldRetry} can compose with
  * it rather than reimplement it.
+ *
+ * A response identifying an invocation is never retried, whatever its status —
+ * the ingress reached the invocation and reported its outcome, and asking again
+ * cannot make a terminal failure any less terminal.
  */
 export function defaultShouldRetry(failure: RetryFailure): boolean {
-  return failure.kind === "network" || isRetryableStatus(failure.status);
+  if (failure.kind === "network") {
+    return true;
+  }
+  if (failure.headers.has(INVOCATION_ID_HEADER)) {
+    return false;
+  }
+  return isRetryableStatus(failure.status);
 }
 
 /**


### PR DESCRIPTION
Fixes #769.

Rebased onto #775 and #777, which landed the shared retry loop, moved the
response body read inside an attempt, and retried workflow submission, attach and
output. This is the remaining delta.

## Summary

`result()` is the last safe read still issuing a one-shot GET, so it can fail
against a draining ingress pod while the durable invocation has completed exactly
once. It now uses the same policy as the workflow reads — it only retrieves a
result that already exists, so like them it needs no idempotency key. Handler
invocations are unchanged: still retried only when they carry one.

The rest of this PR is the three cross-cutting changes below: read deadlines,
terminal outcomes, and policy bounds.

## Behaviour

| Operation | Retries require | Timeout semantics |
| --- | --- | --- |
| Handler call/send | `idempotencyKey` | Per attempt |
| `workflowSubmit()` | Retry policy enabled (idempotent by workflow ID) | Per attempt |
| `workflowAttach()` / `workflowOutput()` | Retry policy enabled (#775, #777) | One timeout/signal bounds the whole read, including backoff |
| `result()` | Retry policy enabled (this PR) | No per-call timeout API |

## Read deadlines cover the whole operation

This is the one place where the branch intentionally diverges from #775, so
please sanity-check it: the workflow reads previously took a fresh
`AbortSignal.timeout()` per attempt.

A read waits on work that is already running elsewhere. Handing each attempt its
own deadline turns `workflowAttach(Opts.from({ timeout: 30_000 }))` from "wait up
to 30s" into up to `maxAttempts × 30s` plus backoff, which is not what the caller
asked for. So the reads mint one signal up front and use it for every attempt and
for the backoff. Invocations keep per-attempt deadlines, where each attempt does
genuinely restart the wait — `fetchWithRetries` now takes whichever the caller
needs, via `perAttemptDeadline` / `wholeOperationDeadline`.

## Terminal invocation outcomes

A handler `TerminalError` is returned with the failure's own status, so it can
arrive as a `5xx` that no status-based rule can tell apart from a drain `5xx`.
The two are built differently in the server, though:

- an invocation's own outcome comes from `reply_with_invocation_response`, which
  sets `x-restate-id`;
- ingress-level failures (`Unavailable` → 503, `DispatcherError` → 500) and any
  proxy-generated `5xx` use `into_response()` on a fresh builder, with no such
  header.

So `defaultShouldRetry` now treats a response carrying `x-restate-id` as
terminal. Without it, every terminally-failed attach — a normal outcome for that
API — would burn `maxAttempts` round trips and ~10s of backoff before returning
the same error. When the header is absent, including on older servers or through
intermediaries that drop it, the previous status-based behaviour is unchanged.
This also affects the keyed invocation path.

## Retry policy bounds

`resolveRetryPolicy` accepted any number, so `maxAttempts: Infinity` built an
unbounded loop and non-finite or negative intervals collapsed the backoff into
immediate retries. Overrides outside the documented domain now throw a
`TypeError` naming the field rather than being clamped, which matters more now
that the policy governs the long-lived reads.

## Implementation

`safeRead` holds the safe-GET contract once — headers, retry policy,
whole-operation deadline, codec decode, serde deserialize — leaving `result()`
and `doWorkflowHandleCall` with only their URL, their serde, and `result()`'s
attachable check. `doWorkflowHandleCall` becomes a single expression, and #777's
now-unconditional retry policy for attach and output falls out of `safeRead` by
construction. `fetchWithRetries` keeps its loop from #775; only its signal
handling changed.

A custom `shouldRetry` still fully replaces the built-in decision, and now also
sees read-path failures — including the `470` that `workflowOutput` uses for "not
ready yet". Noted in the `RetryPolicy` docs.

## Coverage

65 tests, up from 40 on main. The shared harness was hoisted so both integration
describes use it; every test from #775 and #777 is retained (their direct
`fetchMock` assertions now go through the shared fixture). New cases, per read path:

- drain `503` / `Retry-After`, then success;
- transport failure before a response, then success;
- body cut short after `200`, and after a drain `503`;
- retry exhaustion, throwing the last error;
- caller abort before and between attempts;
- whole-read timeout: one signal shared across attempts;
- `workflowOutput` `470` not retried, and `503` → `470` retried once;
- terminal `5xx` with `x-restate-id` not retried;
- `result()` on a non-attachable send issues no request at all;
- scoped workflow attach and output;
- the retry-policy bounds.

13 of these fail against main without this change.

## Scope / follow-up

Still one-shot, and out of scope here: `resolveAwakeable()` / `rejectAwakeable()`
(POSTs, though idempotent server-side). `result()` also still takes no `Opts`, so
it has no caller deadline — its retries are bounded only by `maxAttempts` and
`maxInterval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


