### PR TITLE
Guard request half-close abort on readableEnded

### DIFF
--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -191,11 +191,6 @@ function nodeHandlerImpl(
     const outputWriter = outputWriterAdapter(httpResponse);
     const res = httpResponse as NodeWritableResponse;
 
-    // Abort controller used to cleanup resources at the end of this stream lifecycle
-    const abortSignal = abortSignalForRequest(httpRequest);
-
-    const writeHead = res.writeHead.bind(res);
-
     // handle should never throw
     const restateResponse = handler.handle({
       url,
@@ -207,8 +202,8 @@ function nodeHandlerImpl(
       .process({
         inputReader,
         outputWriter,
-        writeHead,
-        abortSignal,
+        writeHead: res.writeHead.bind(res),
+        abortSignal: abortSignalForRequest(httpRequest),
       })
       .catch((e) => {
         // Responses handle their own errors before rejecting; anything

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -165,6 +165,18 @@ function nodeHttp2Handler(
   return nodeHandlerImpl(endpoint, protocolMode);
 }
 
+export function abortSignalForRequest(request: {
+  on(event: "close", listener: () => void): unknown;
+  readonly readableEnded: boolean;
+}): AbortSignal {
+  const abortController = new AbortController();
+  request.on("close", () => {
+    // https://nodejs.org/api/stream.html#readablereadableended
+    if (!request.readableEnded) abortController.abort();
+  });
+  return abortController.signal;
+}
+
 function nodeHandlerImpl(
   endpoint: Endpoint,
   protocolMode: ProtocolMode
@@ -181,10 +193,7 @@ function nodeHandlerImpl(
     const res = httpResponse as NodeWritableResponse;
 
     // Abort controller used to cleanup resources at the end of this stream lifecycle
-    const abortController = new AbortController();
-    httpRequest.on("close", () => {
-      abortController.abort();
-    });
+    const abortSignal = abortSignalForRequest(httpRequest);
 
     const writeHead = res.writeHead.bind(res);
 
@@ -200,7 +209,7 @@ function nodeHandlerImpl(
         inputReader,
         outputWriter,
         writeHead,
-        abortSignal: abortController.signal,
+        abortSignal,
       })
       .catch((e) => {
         // Responses handle their own errors before rejecting; anything

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -187,8 +187,6 @@ function nodeHandlerImpl(
 
   return (httpRequest, httpResponse) => {
     const url = httpRequest.url!;
-    const inputReader = inputReaderAdapter(httpRequest);
-    const outputWriter = outputWriterAdapter(httpResponse);
     const res = httpResponse as NodeWritableResponse;
 
     // handle should never throw
@@ -200,8 +198,8 @@ function nodeHandlerImpl(
 
     restateResponse
       .process({
-        inputReader,
-        outputWriter,
+        inputReader: inputReaderAdapter(httpRequest),
+        outputWriter: outputWriterAdapter(httpResponse),
         writeHead: res.writeHead.bind(res),
         abortSignal: abortSignalForRequest(httpRequest),
       })

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -190,13 +190,12 @@ function nodeHandlerImpl(
     const res = httpResponse as NodeWritableResponse;
 
     // handle should never throw
-    const restateResponse = handler.handle({
-      url,
-      headers: httpRequest.headers,
-      extraArgs: [],
-    });
-
-    restateResponse
+    handler
+      .handle({
+        url,
+        headers: httpRequest.headers,
+        extraArgs: [],
+      })
       .process({
         inputReader: inputReaderAdapter(httpRequest),
         outputWriter: outputWriterAdapter(httpResponse),

--- a/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
+++ b/packages/libs/restate-sdk/src/endpoint/node_endpoint.ts
@@ -19,6 +19,7 @@ import type {
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Http2ServerRequest, Http2ServerResponse } from "node:http2";
 import * as http2 from "node:http2";
+import type { Readable } from "node:stream";
 import type { Endpoint } from "./endpoint.js";
 import { EndpointBuilder } from "./endpoint.js";
 import { createRestateHandler } from "./handlers/generic.js";
@@ -165,10 +166,8 @@ function nodeHttp2Handler(
   return nodeHandlerImpl(endpoint, protocolMode);
 }
 
-export function abortSignalForRequest(request: {
-  on(event: "close", listener: () => void): unknown;
-  readonly readableEnded: boolean;
-}): AbortSignal {
+/** @internal For testing only. */
+export function abortSignalForRequest(request: Readable): AbortSignal {
   const abortController = new AbortController();
   request.on("close", () => {
     // https://nodejs.org/api/stream.html#readablereadableended

--- a/packages/libs/restate-sdk/test/node_endpoint.test.ts
+++ b/packages/libs/restate-sdk/test/node_endpoint.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2024 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import { once } from "node:events";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { abortSignalForRequest } from "../src/endpoint/node_endpoint.js";
+
+describe("abortSignalForRequest", () => {
+  it("aborts when the request closes before it has fully ended", async () => {
+    const request = Readable.from(["data"]); // left unconsumed
+    const signal = abortSignalForRequest(request);
+
+    request.destroy();
+    await once(request, "close");
+
+    expect(request.readableEnded).toBe(false);
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("does not abort when the request closes after it has fully ended", async () => {
+    const request = Readable.from(["data"]);
+    const signal = abortSignalForRequest(request);
+
+    request.resume(); // consume to completion
+    await once(request, "close");
+
+    expect(request.readableEnded).toBe(true);
+    expect(signal.aborted).toBe(false);
+  });
+});

--- a/packages/libs/restate-sdk/test/node_endpoint.test.ts
+++ b/packages/libs/restate-sdk/test/node_endpoint.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 - Restate Software, Inc., Restate GmbH
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
  *
  * This file is part of the Restate SDK for Node.js/TypeScript,
  * which is released under the MIT license.


### PR DESCRIPTION
Closes #745.

Depends on #774 (unrelated e2e test issue this change exposes; CI won't be green here until that merges).

In REQUEST_RESPONSE mode, the runtime half-closes the request after the journal is delivered and keeps the response open for the reply. The request's "close" event was aborting the invocation unconditionally, killing any handler suspended on a call or promise. Surfaced as `[500] Connection closed` plus a retry loop.

`complete` can't distinguish a clean half-close from a mid-stream RST on Node 24 (both read true). `readableEnded` can: it's only true after the stream actually saw "end".

Fix: gate the abort on `!request.readableEnded`, extracted into `abortSignalForRequest`.

Added `test/node_endpoint.test.ts` against a real `node:stream` Readable. Confirmed the test fails without the guard before adding it. Suite and typecheck pass.

No public API change, so no changeset. Flag if you want a release note anyway.