### PR TITLE
Gate interrupt e2e's run-signal assertion under alwaysReplay

### DIFF
--- a/packages/libs/restate-sdk-gen/e2e/interrupt.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/interrupt.e2e.test.ts
@@ -46,12 +46,15 @@ const waitForAbort = (signal: AbortSignal, key: string): Promise<string> =>
       resolve("aborted");
       return;
     }
-    signal.addEventListener("abort", () => {
+    const onAbort = () => {
+      clearTimeout(fallback);
       obs[key] = "aborted";
       resolve("aborted");
-    });
+    };
+    signal.addEventListener("abort", onAbort);
     // Fallback so a missing abort fails fast rather than hanging the test.
-    setTimeout(() => {
+    const fallback = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
       obs[key] = "timeout";
       resolve("timeout");
     }, 5000);
@@ -424,7 +427,12 @@ describe.each(modes)("interrupt — $name mode", ({ alwaysReplay }) => {
     const client = clients.client(ingress, interruptSvc);
     const result = await client.scopedInterrupt();
     expect(result).toBe("worker-interrupted:stop|mainAbortedAtStart=false");
-    // The worker's in-flight run signal fired (scoped per fiber).
-    expect(obs.worker).toBe("aborted");
+    // Under alwaysReplay this signal can't be observed: delivering sleep's
+    // completion requires a suspend, but the SDK won't suspend while this
+    // run() is still pending — so it only ever settles via its own
+    // fallback, never via the abort. See #773.
+    if (!alwaysReplay) {
+      expect(obs.worker).toBe("aborted");
+    }
   });
 });


### PR DESCRIPTION
Fixes #773.

Under alwaysReplay, delivering a sibling fiber's already-ready durable completion requires the attempt to suspend, but the SDK won't suspend while a run() is still pending — and that run() can only stop being pending via interrupt() (gated behind that same suspend) or its own fallback. Closed loop: the run signal never gets a chance to observe the abort in that mode, only its own fallback ever fires, regardless of the fallback's duration (measured at 0/200/5000/20000ms — same outcome, different speed).

The journaled interrupt-delivery path (`this.wake` throwing into the fiber, the actual SDK contract this test verifies) is unaffected — `result` passes 100% reliably in every mode and every variant tested. Only the auxiliary, non-journaled `obs.worker` side-channel is unobservable under alwaysReplay by construction.

## Changes

`packages/libs/restate-sdk-gen/e2e/interrupt.e2e.test.ts`
- Gate `expect(obs.worker).toBe("aborted")` to `!alwaysReplay`; keep the `result` assertion unconditional in both modes.
- Clean up `waitForAbort`'s abort listener and fallback timer so the promise settles exactly once instead of leaving both live after resolution — this masked the real issue before: a stale listener firing after the promise had already resolved via timeout was overwriting `obs.worker` back to `"aborted"`.

## Testing

Verified against current `main` (3/3 green) and against #771's `node_endpoint.ts` fix cherry-picked on top (3/3 green), so this doesn't depend on merge order between the two PRs.