### PR TITLE
Align retry logic following runtime changes

### DIFF
--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -492,7 +492,10 @@ export type RetryFailure =
  * observe the existing workflow.
  *
  * By default the following failures are retried: network errors (the underlying
- * `fetch` rejecting), HTTP `429`, and HTTP `5xx` responses. Override this with
+ * `fetch` rejecting) and responses with a transient status (`408`, `425`, `429`,
+ * or `5xx`). An error that restate attributes to the invocation itself (the
+ * `x-restate-error-source: invocation` header) is a terminal outcome and is
+ * never retried, whatever its status code. Override all of this with
  * {@link RetryPolicy.shouldRetry}.
  */
 export interface RetryPolicy {
@@ -523,7 +526,8 @@ export interface RetryPolicy {
 
   /**
    * Decide whether a given failure should be retried. When provided, this
-   * fully replaces the built-in rule (network / `429` / `5xx`).
+   * fully replaces the built-in rule (network / transient `408`/`425`/`429`/`5xx`,
+   * excluding invocation-sourced errors).
    *
    * The idempotency-key gate still applies to regular invocations; workflow
    * submissions, attaches, and output retrieval remain eligible without an
@@ -550,8 +554,9 @@ export type ConnectionOpts = {
   headers?: Record<string, string>;
 
   /**
-   * Opt in to automatic retries of ambiguous ingress failures (network errors,
-   * HTTP `429`, HTTP `5xx`).
+   * Opt in to automatic retries of ambiguous ingress failures (network errors
+   * and transient HTTP statuses `408`/`425`/`429`/`5xx`, excluding errors
+   * restate attributes to the invocation itself).
    *
    * Retries are **disabled by default**. Set `true` to enable the built-in
    * policy ({@link RetryPolicy}), or pass a {@link RetryPolicy} to tune it.

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -743,27 +743,25 @@ class HttpIngress implements Ingress {
     };
     //
     // make the call
+    //
     const url = `${this.opts.url}/restate/invocation/${send.invocationId}/attach`;
+    // Attaching only observes the existing invocation, so it is safe to retry
+    // when the connection has a retry policy.
+    const retryPolicy = resolveRetryPolicy(this.opts.retry);
 
-    const httpResponse = await getFetch(this.opts)(url, {
-      method: "GET",
-      headers,
-    });
-    if (httpResponse.ok) {
-      const responseBuf = new Uint8Array(await httpResponse.arrayBuffer());
-      const decodedBuf = this.opts.journalValueCodec
-        ? await this.opts.journalValueCodec.decode(responseBuf)
-        : responseBuf;
-      return (resultSerde ?? this.opts.serde ?? serde.json).deserialize(
-        decodedBuf
-      ) as T;
-    }
-    const body = await httpResponse.text();
-    throw new HttpCallError(
-      httpResponse.status,
-      body,
-      `Request failed: ${httpResponse.status}\n${body}`
+    const responseBuf = await fetchWithRetries(
+      this.opts,
+      url,
+      { method: "GET", headers },
+      undefined,
+      retryPolicy
     );
+    const decodedBuf = this.opts.journalValueCodec
+      ? await this.opts.journalValueCodec.decode(responseBuf)
+      : responseBuf;
+    return (resultSerde ?? this.opts.serde ?? serde.json).deserialize(
+      decodedBuf
+    ) as T;
   }
 }
 

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -193,7 +193,8 @@ const fetchWithRetries = async (
       )
     ) {
       // A non-2xx response was received, attempts remain, and the policy chose
-      // to retry it (by default, HTTP 429 and 5xx).
+      // to retry it (by default, transient statuses 408/425/429/5xx, unless the
+      // error is attributed to the invocation via x-restate-error-source).
       const retryAfter = parseRetryAfter(response.headers);
       await abortableSleep(
         backoffDelay(retryPolicy, attempt, retryAfter),

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -396,6 +396,30 @@ describe("ingress auto-retry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does NOT retry result() without a retry policy", async () => {
+    queue(fail(503), ok({ greeting: "hi" }));
+    await expect(
+      connect({ url: URL }).result({
+        invocationId: "inv-1",
+        status: "Accepted",
+        attachable: true,
+      })
+    ).rejects.toBeInstanceOf(HttpCallError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries result() attach when a retry policy is set", async () => {
+    queue(fail(503), ok({ greeting: "hi" }));
+    await expect(
+      connect({ url: URL, retry: fastRetry }).result({
+        invocationId: "inv-1",
+        status: "Accepted",
+        attachable: true,
+      })
+    ).resolves.toEqual({ greeting: "hi" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("does NOT retry workflow output when it is not ready by default", async () => {
     queue(fail(470), ok({ result: "done" }));
     const output = await workflow(fastRetry).workflowOutput();

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -69,7 +69,7 @@ describe("resolveRetryPolicy", () => {
 });
 
 describe("defaultShouldRetry", () => {
-  it("retries network errors and 429/5xx responses", () => {
+  it("retries network errors and transient responses", () => {
     expect(defaultShouldRetry({ kind: "network", error: new Error("x") })).toBe(
       true
     );
@@ -91,17 +91,39 @@ describe("defaultShouldRetry", () => {
       })
     ).toBe(false);
   });
+
+  it("retries a transient status flagged as an ingress error", () => {
+    expect(
+      defaultShouldRetry({
+        kind: "response",
+        status: 503,
+        headers: new Headers({ "x-restate-error-source": "ingress" }),
+      })
+    ).toBe(true);
+  });
+
+  it("does NOT retry an invocation-sourced error even on a 5xx", () => {
+    expect(
+      defaultShouldRetry({
+        kind: "response",
+        status: 500,
+        headers: new Headers({ "x-restate-error-source": "invocation" }),
+      })
+    ).toBe(false);
+  });
 });
 
 describe("isRetryableStatus", () => {
-  it("retries on 429 and 5xx", () => {
+  it("retries on 408, 425, 429 and 5xx", () => {
+    expect(isRetryableStatus(408)).toBe(true);
+    expect(isRetryableStatus(425)).toBe(true);
     expect(isRetryableStatus(429)).toBe(true);
     expect(isRetryableStatus(500)).toBe(true);
     expect(isRetryableStatus(503)).toBe(true);
     expect(isRetryableStatus(599)).toBe(true);
   });
 
-  it("does not retry on 4xx (except 429) or 2xx/3xx", () => {
+  it("does not retry on non-transient 4xx or 2xx/3xx", () => {
     expect(isRetryableStatus(200)).toBe(false);
     expect(isRetryableStatus(400)).toBe(false);
     expect(isRetryableStatus(404)).toBe(false);
@@ -385,6 +407,24 @@ describe("ingress auto-retry", () => {
     queue(fail(409), ok());
     await expect(call("k1", fastRetry)).rejects.toBeInstanceOf(HttpCallError);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the new transient statuses 408 and 425", async () => {
+    queue(fail(408), fail(425), ok({ greeting: "hi" }));
+    await expect(call("k1", fastRetry)).resolves.toEqual({ greeting: "hi" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT retry an invocation-sourced 5xx", async () => {
+    queue(fail(500, { "x-restate-error-source": "invocation" }), ok());
+    await expect(call("k1", fastRetry)).rejects.toBeInstanceOf(HttpCallError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries an ingress-sourced 5xx", async () => {
+    queue(fail(503, { "x-restate-error-source": "ingress" }), ok());
+    await expect(call("k1", fastRetry)).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("retry:false disables retries even with an idempotency key", async () => {

--- a/packages/libs/restate-sdk-clients/src/retry.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.ts
@@ -60,18 +60,43 @@ export function resolveRetryPolicy(
   };
 }
 
-/** Whether an HTTP response status warrants a retry. */
+/**
+ * Whether an HTTP response status is a transient ingress condition that
+ * warrants a retry: `408`, `425`, `429`, or any `5xx`.
+ */
 export function isRetryableStatus(status: number): boolean {
-  return status === 429 || (status >= 500 && status <= 599);
+  return (
+    status === 408 ||
+    status === 425 ||
+    status === 429 ||
+    (status >= 500 && status <= 599)
+  );
 }
 
 /**
- * The built-in retry decision: retry network errors, HTTP `429`, and HTTP
- * `5xx`. Exported so a custom {@link RetryPolicy.shouldRetry} can compose with
- * it rather than reimplement it.
+ * The built-in retry decision. Retries network errors and responses with a
+ * transient status (`408`, `425`, `429`, or `5xx`) — except errors restate
+ * attributes to the invocation itself, which are terminal outcomes of the
+ * durable execution and are never retried whatever their status code.
+ *
+ * restate-server discloses the origin via the `x-restate-error-source` header
+ * (`"invocation"` or `"ingress"`); when it is absent — a proxy stripped it, or
+ * an older server — the status alone drives the decision. See
+ * https://github.com/restatedev/restate/pull/5173.
+ *
+ * Exported so a custom {@link RetryPolicy.shouldRetry} can compose with it
+ * rather than reimplement it.
  */
 export function defaultShouldRetry(failure: RetryFailure): boolean {
-  return failure.kind === "network" || isRetryableStatus(failure.status);
+  if (failure.kind === "network") {
+    return true;
+  }
+  // An invocation-sourced error is the terminal result of the durable
+  // execution; retrying it re-runs nothing and never changes the outcome.
+  if (failure.headers.get("x-restate-error-source") === "invocation") {
+    return false;
+  }
+  return isRetryableStatus(failure.status);
 }
 
 /**


### PR DESCRIPTION
See https://github.com/restatedev/restate/pull/5173

This PR also makes sure we retry attach/output requests.