### PR TITLE
Fix flaky tests

### DIFF
--- a/.github/workflows/_test-lambda-template.yml
+++ b/.github/workflows/_test-lambda-template.yml
@@ -58,7 +58,11 @@ jobs:
 
       - name: Install AWS CLI Local
         run: |
-          pip install awscli-local[ver1]
+          python3 -m venv "$RUNNER_TEMP/awscli-local"
+          "$RUNNER_TEMP/awscli-local/bin/pip" install \
+            "awscli-local[ver1]==0.22.2" \
+            "awscli==1.45.64"
+          echo "$RUNNER_TEMP/awscli-local/bin" >> "$GITHUB_PATH"
 
       - name: Wait for LocalStack
         run: |

--- a/packages/examples/node/test/http1.test.ts
+++ b/packages/examples/node/test/http1.test.ts
@@ -25,6 +25,8 @@ import {
 } from "testcontainers";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 
+const TESTCONTAINERS_START_TIMEOUT = 120_000;
+
 const greeter = service({
   name: "greeter",
   handlers: {
@@ -79,7 +81,7 @@ function defineHttp1Tests(
 
       const ingressUrl = `http://${restateContainer.getHost()}:${restateContainer.getMappedPort(8080)}`;
       rs = clients.connect({ url: ingressUrl });
-    }, 30_000);
+    }, TESTCONTAINERS_START_TIMEOUT);
 
     afterAll(async () => {
       if (restateContainer) {

--- a/packages/examples/node/test/testcontainers.test.ts
+++ b/packages/examples/node/test/testcontainers.test.ts
@@ -24,6 +24,8 @@ import {
 } from "@restatedev/restate-sdk";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 
+const TESTCONTAINERS_START_TIMEOUT = 120_000;
+
 // Non-deterministic handler: sets state to a random value then sleeps.
 // On replay, Math.random() produces a different value, causing a journal mismatch.
 // With alwaysReplay, this is caught. Without it, the handler completes in one shot.
@@ -66,7 +68,7 @@ describe("ExampleObject", () => {
       services: [counter],
     });
     rs = clients.connect({ url: restateTestEnvironment.baseUrl() });
-  }, 20_000);
+  }, TESTCONTAINERS_START_TIMEOUT);
 
   // Stop Restate and the Service endpoint
   afterAll(async () => {
@@ -168,7 +170,7 @@ describe("Always replay", () => {
       disableRetries: true,
     });
     rs = clients.connect({ url: restateTestEnvironment.baseUrl() });
-  }, 20_000);
+  }, TESTCONTAINERS_START_TIMEOUT);
 
   afterAll(async () => {
     if (restateTestEnvironment !== undefined) {
@@ -195,7 +197,7 @@ describe("Disable retries", () => {
       disableRetries: true,
     });
     rs = clients.connect({ url: restateTestEnvironment.baseUrl() });
-  }, 20_000);
+  }, TESTCONTAINERS_START_TIMEOUT);
 
   afterAll(async () => {
     if (restateTestEnvironment !== undefined) {
@@ -229,7 +231,7 @@ describe("Custom testcontainer config", () => {
             stream.on("err", (line) => console.error(line));
           })
     );
-  }, 20_000);
+  }, TESTCONTAINERS_START_TIMEOUT);
 
   // Stop Restate and the Service endpoint
   afterAll(async () => {
@@ -252,7 +254,7 @@ describe("Testcontainers host networking with disk storage", () => {
       storage: "disk",
     });
     rs = clients.connect({ url: restateTestEnvironment.baseUrl() });
-  }, 20_000);
+  }, TESTCONTAINERS_START_TIMEOUT);
 
   afterAll(async () => {
     if (restateTestEnvironment !== undefined) {

--- a/packages/tests/restate-e2e-services/src/hooks.ts
+++ b/packages/tests/restate-e2e-services/src/hooks.ts
@@ -861,7 +861,9 @@ function createHookLevelSuite(level: HookLevel) {
       return { invocationId: ctx.request().id };
     },
     options: {
-      inactivityTimeout: 100,
+      // Leave enough time for the successful retry's run completion to reach
+      // Restate before the next inactivity timeout on loaded CI runners.
+      inactivityTimeout: 500,
       abortTimeout: 100,
       retryPolicy: {
         initialInterval: 10,


### PR DESCRIPTION
### https://github.com/restatedev/e2e/issues/443
The test used a very short 100 ms inactivity timeout. On busy CI runners, the successful retry sometimes completed just after that deadline, causing an extra suspend and replay that broke the expected hook sequence. Increasing the timeout to 500 ms gives the completion enough time to reach Restate while still testing the 100 ms abort behavior. Not the best fix, as it can still be flaky. but for now should make the test pass.

### Lambda integration test
The Lambda test was failing before it even started. An unpinned AWS CLI dependency became incompatible with the GitHub runner, so this change pins a working version and installs it in isolation. Better fix to write CI job to be compatible with latest aws cli