### PR TITLE
Improvements to ingress retries 

### DIFF
--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -508,13 +508,13 @@ export interface RetryPolicy {
 
   /**
    * Initial backoff interval. If a number is provided, it is interpreted as
-   * milliseconds. Defaults to `100` milliseconds.
+   * milliseconds. Defaults to `250` milliseconds.
    */
   initialInterval?: Duration | number;
 
   /**
    * Maximum backoff interval. If a number is provided, it is interpreted as
-   * milliseconds. Defaults to `2000` milliseconds.
+   * milliseconds. Defaults to `3000` milliseconds.
    */
   maxInterval?: Duration | number;
 
@@ -523,6 +523,20 @@ export interface RetryPolicy {
    * Defaults to `2`.
    */
   exponentiationFactor?: number;
+
+  /**
+   * Whether to honor a `Retry-After` response header when the server provides
+   * one. When `true` (the default), a `Retry-After` value overrides the computed
+   * exponential backoff for that attempt.
+   *
+   * Set to `false` to always use the exponential backoff and ignore the header.
+   *
+   * Note that `Retry-After` never extends the number of retries: {@link maxAttempts}
+   * is always respected regardless of this setting.
+   *
+   * Defaults to `true`.
+   */
+  respectRetryAfter?: boolean;
 
   /**
    * Decide whether a given failure should be retried. When provided, this

--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -493,18 +493,32 @@ export type RetryFailure =
  *
  * By default the following failures are retried: network errors (the underlying
  * `fetch` rejecting) and responses with a transient status (`408`, `425`, `429`,
- * or `5xx`). An error that restate attributes to the invocation itself (the
- * `x-restate-error-source: invocation` header) is a terminal outcome and is
- * never retried, whatever its status code. Override all of this with
- * {@link RetryPolicy.shouldRetry}.
+ * or `5xx`). A terminal error of the invocation is never retried, whatever its status code.
+ * Override all of this with {@link RetryPolicy.shouldRetry}.
  */
 export interface RetryPolicy {
   /**
    * Max number of attempts (including the initial), before giving up.
    *
-   * Defaults to `6` (the initial attempt plus up to 5 retries).
+   * Retrying stops as soon as **either** `maxDuration` or {@link maxAttempts} is reached.
+   *
+   * Defaults to `6` (the initial attempt plus up to 5 retries). Pass `false` to
+   * remove the attempt bound.
    */
-  maxAttempts?: number;
+  maxAttempts?: number | false;
+
+  /**
+   * Max total duration of retries, measured from the first attempt, before
+   * giving up. If a number is provided, it is interpreted as milliseconds.
+   *
+   * This bound is checked only when deciding whether to start another
+   * attempt after a failure: it never aborts an in-flight request.
+   *
+   * Retrying stops as soon as **either** {@link maxDuration} or {@link maxAttempts} is reached.
+   *
+   * Defaults to 60 seconds. Pass `false` to remove the duration bound.
+   */
+  maxDuration?: Duration | number | false;
 
   /**
    * Initial backoff interval. If a number is provided, it is interpreted as
@@ -531,8 +545,8 @@ export interface RetryPolicy {
    *
    * Set to `false` to always use the exponential backoff and ignore the header.
    *
-   * Note that `Retry-After` never extends the number of retries: {@link maxAttempts}
-   * is always respected regardless of this setting.
+   * Note that `Retry-After` never extends the number of retries: {@link maxAttempts} and
+   * {@link maxDuration} is always respected regardless of this setting.
    *
    * Defaults to `true`.
    */

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -118,6 +118,9 @@ function optsFromArgs(args: unknown[]): {
 
 const IDEMPOTENCY_KEY_HEADER = "idempotency-key";
 const LIMIT_KEY_HEADER = "x-restate-limit-key";
+// Carries the 1-based attempt number on every request so the server can observe
+// how many times the client has (re)issued it.
+const ATTEMPT_HEADER = "x-restateclient-attempt";
 
 const getFetch = (opts: ConnectionOpts): NonNullable<ConnectionOpts["fetch"]> =>
   opts.fetch ?? globalThis.fetch;
@@ -144,12 +147,17 @@ const fetchWithRetries = async (
     (timeout !== undefined ? AbortSignal.timeout(timeout) : undefined);
   const shouldRetry = retryPolicy?.shouldRetry ?? defaultShouldRetry;
 
+  // Headers are always a plain record in this codebase; carry them forward and
+  // stamp the attempt number afresh on each try.
+  const baseHeaders = (init.headers ?? {}) as Record<string, string>;
+
   for (let attempt = 0; ; attempt++) {
     let response: Response;
     let errorBody: string;
     try {
       response = await getFetch(opts)(url, {
         ...init,
+        headers: { ...baseHeaders, [ATTEMPT_HEADER]: String(attempt + 1) },
         signal: attemptSignal(),
       });
       if (response.ok) {
@@ -195,9 +203,14 @@ const fetchWithRetries = async (
       // A non-2xx response was received, attempts remain, and the policy chose
       // to retry it (by default, transient statuses 408/425/429/5xx, unless the
       // error is attributed to the invocation via x-restate-error-source).
-      const retryAfter = parseRetryAfter(response.headers);
+      // Honoring Retry-After only affects the delay of this attempt — the
+      // maxAttempts cap above always applies, so it can never extend the retries.
+      const retryAfter = retryPolicy.respectRetryAfter
+        ? parseRetryAfter(response.headers)
+        : undefined;
+
       await abortableSleep(
-        backoffDelay(retryPolicy, attempt, retryAfter),
+        retryAfter ?? backoffDelay(retryPolicy, attempt),
         userSignal
       );
       continue;

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -120,7 +120,7 @@ const IDEMPOTENCY_KEY_HEADER = "idempotency-key";
 const LIMIT_KEY_HEADER = "x-restate-limit-key";
 // Carries the 1-based attempt number on every request so the server can observe
 // how many times the client has (re)issued it.
-const ATTEMPT_HEADER = "x-restateclient-attempt";
+const ATTEMPT_HEADER = "x-restateclient-retry-attempt";
 
 const getFetch = (opts: ConnectionOpts): NonNullable<ConnectionOpts["fetch"]> =>
   opts.fetch ?? globalThis.fetch;
@@ -146,6 +146,19 @@ const fetchWithRetries = async (
     userSignal ??
     (timeout !== undefined ? AbortSignal.timeout(timeout) : undefined);
   const shouldRetry = retryPolicy?.shouldRetry ?? defaultShouldRetry;
+
+  // Whether waiting `delay` and then starting the next attempt would still fall
+  // within the maxDuration budget (measured from the first attempt; a non-finite
+  // maxDuration disables the bound). Checked *after* the delay is known so we
+  // never sleep out a backoff — or a long Retry-After — only to give up on the
+  // attempt it precedes. This is a decision-time gate only: it never aborts an
+  // in-flight request. The maxAttempts count is gated separately, before the
+  // delay is computed.
+  const startTime = Date.now();
+  const nextAttemptFitsBudget = (
+    policy: ResolvedRetryPolicy,
+    delay: number
+  ): boolean => Date.now() - startTime + delay < policy.maxDuration;
 
   // Headers are always a plain record in this codebase; carry them forward and
   // stamp the attempt number afresh on each try.
@@ -178,12 +191,16 @@ const fetchWithRetries = async (
         shouldRetry({ kind: "network", error: e }, attempt)
       ) {
         // Retries are enabled, attempts remain, the caller did not abort, and
-        // the policy accepted this network failure.
-        await abortableSleep(backoffDelay(retryPolicy, attempt), userSignal);
-        continue;
+        // the policy accepted this failure. Retry only if the backoff still
+        // leaves us within the duration budget.
+        const delay = backoffDelay(retryPolicy, attempt);
+        if (nextAttemptFitsBudget(retryPolicy, delay)) {
+          await abortableSleep(delay, userSignal);
+          continue;
+        }
       }
-      // Retries are disabled or exhausted, the caller aborted, or the policy
-      // rejected this failure.
+      // Retries are disabled or exhausted, the caller aborted, the policy
+      // rejected this failure, or the duration budget is spent.
       throw e;
     }
     if (
@@ -202,18 +219,17 @@ const fetchWithRetries = async (
     ) {
       // A non-2xx response was received, attempts remain, and the policy chose
       // to retry it (by default, transient statuses 408/425/429/5xx, unless the
-      // error is attributed to the invocation via x-restate-error-source).
-      // Honoring Retry-After only affects the delay of this attempt — the
-      // maxAttempts cap above always applies, so it can never extend the retries.
+      // error is attributed to the invocation via x-restate-error-source). The
+      // delay is the server's Retry-After when present, else the computed
+      // backoff; either way we only retry if it still fits the duration budget.
       const retryAfter = retryPolicy.respectRetryAfter
         ? parseRetryAfter(response.headers)
         : undefined;
-
-      await abortableSleep(
-        retryAfter ?? backoffDelay(retryPolicy, attempt),
-        userSignal
-      );
-      continue;
+      const delay = retryAfter ?? backoffDelay(retryPolicy, attempt);
+      if (nextAttemptFitsBudget(retryPolicy, delay)) {
+        await abortableSleep(delay, userSignal);
+        continue;
+      }
     }
     // The response is not retryable, retries are disabled or exhausted, the
     // caller aborted, or the policy rejected this response.

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -38,6 +38,7 @@ describe("resolveRetryPolicy", () => {
       maxInterval: 3000,
       exponentiationFactor: 2,
       respectRetryAfter: true,
+      maxDuration: 60_000,
     });
   });
 
@@ -48,7 +49,26 @@ describe("resolveRetryPolicy", () => {
       maxInterval: 3000,
       exponentiationFactor: 2,
       respectRetryAfter: true,
+      maxDuration: 60_000,
       shouldRetry: undefined,
+    });
+  });
+
+  it("resolves maxDuration to milliseconds", () => {
+    expect(resolveRetryPolicy({ maxDuration: 1234 })).toMatchObject({
+      maxDuration: 1234,
+    });
+    expect(resolveRetryPolicy({ maxDuration: { seconds: 5 } })).toMatchObject({
+      maxDuration: 5000,
+    });
+  });
+
+  it("treats maxDuration: false and maxAttempts: false as unbounded (Infinity)", () => {
+    expect(
+      resolveRetryPolicy({ maxDuration: false, maxAttempts: false })
+    ).toMatchObject({
+      maxDuration: Infinity,
+      maxAttempts: Infinity,
     });
   });
 
@@ -147,6 +167,7 @@ describe("backoffDelay", () => {
     maxInterval: 2000,
     exponentiationFactor: 2,
     respectRetryAfter: true,
+    maxDuration: 60_000,
   };
 
   it("stays within ±20% of the (capped) exponential base", () => {
@@ -499,20 +520,18 @@ describe("ingress auto-retry", () => {
       (c) => (c[1] as RequestInit).headers as Record<string, string>
     );
 
-  it("stamps x-restateclient-attempt: 1 on a non-retried request", async () => {
+  it("stamps x-restateclient-retry-attempt: 1 on a non-retried request", async () => {
     queue(ok({ greeting: "hi" }));
     await call("k1");
-    expect(attemptHeaders()[0]?.["x-restateclient-attempt"]).toBe("1");
+    expect(attemptHeaders()[0]?.["x-restateclient-retry-attempt"]).toBe("1");
   });
 
-  it("stamps an incrementing x-restateclient-attempt header on each attempt", async () => {
+  it("stamps an incrementing x-restateclient-retry-attempt header on each attempt", async () => {
     queue(fail(503), fail(503), ok({ greeting: "hi" }));
     await expect(call("k1", fastRetry)).resolves.toEqual({ greeting: "hi" });
-    expect(attemptHeaders().map((h) => h["x-restateclient-attempt"])).toEqual([
-      "1",
-      "2",
-      "3",
-    ]);
+    expect(
+      attemptHeaders().map((h) => h["x-restateclient-retry-attempt"])
+    ).toEqual(["1", "2", "3"]);
   });
 
   it("stops at maxAttempts even when the server keeps sending Retry-After", async () => {
@@ -522,6 +541,63 @@ describe("ingress auto-retry", () => {
       call("k1", { ...fastRetry, maxAttempts: 3 })
     ).rejects.toMatchObject({ status: 503 });
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops retrying once maxDuration elapses (maxAttempts disabled)", async () => {
+    vi.useFakeTimers();
+    // Fix the jitter (factor 0.8 + 0.5*0.4 = 1.0) so each backoff is exactly the
+    // 100ms base, making the elapsed-time math deterministic.
+    const rand = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      queue(fail(503)); // always fails
+      const p = call("k1", {
+        initialInterval: 100,
+        maxInterval: 100,
+        exponentiationFactor: 1, // constant 100ms base per attempt
+        maxAttempts: false, // duration is the only bound
+        maxDuration: 250,
+      });
+      // Attach the rejection expectation up front so the eventual rejection is
+      // never momentarily unhandled while we drive the fake clock.
+      const rejects = expect(p).rejects.toBeInstanceOf(HttpCallError);
+      // The budget check happens *after* the backoff is computed: we only sleep
+      // if the next attempt would still start within maxDuration.
+      await vi.advanceTimersByTimeAsync(0); // attempt 0 @0ms (0+100 < 250) → sleep
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(100); // attempt 1 @100ms (100+100 < 250) → sleep
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(100); // attempt 2 @200ms (200+100 >= 250) → give up
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      await rejects;
+      await vi.advanceTimersByTimeAsync(1000); // no further attempts, no wasted wait
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      rand.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up immediately when the delay would overrun maxDuration (no wasteful wait)", async () => {
+    vi.useFakeTimers();
+    try {
+      queue(fail(503, { "retry-after": "5" })); // asks for a 5s wait
+      const p = call("k1", {
+        initialInterval: 1,
+        maxInterval: 2,
+        exponentiationFactor: 2,
+        maxAttempts: false, // duration is the only bound
+        maxDuration: 250, // 5s Retry-After can't fit → don't even wait
+      });
+      const rejects = expect(p).rejects.toBeInstanceOf(HttpCallError);
+      await vi.advanceTimersByTimeAsync(0); // attempt 0 fails; 0+5000 >= 250 → give up now
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await rejects;
+      // We never slept the 5s: advancing well past it yields no further attempt.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("honors Retry-After verbatim by default, beyond maxInterval", async () => {

--- a/packages/libs/restate-sdk-clients/src/retry.test.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.test.ts
@@ -34,19 +34,27 @@ describe("resolveRetryPolicy", () => {
   it("returns the default policy when enabled with true", () => {
     expect(resolveRetryPolicy(true)).toEqual({
       maxAttempts: 6,
-      initialInterval: 100,
-      maxInterval: 2000,
+      initialInterval: 250,
+      maxInterval: 3000,
       exponentiationFactor: 2,
+      respectRetryAfter: true,
     });
   });
 
   it("fills in missing fields with defaults", () => {
     expect(resolveRetryPolicy({ maxAttempts: 3 })).toEqual({
       maxAttempts: 3,
-      initialInterval: 100,
-      maxInterval: 2000,
+      initialInterval: 250,
+      maxInterval: 3000,
       exponentiationFactor: 2,
+      respectRetryAfter: true,
       shouldRetry: undefined,
+    });
+  });
+
+  it("carries respectRetryAfter: false through", () => {
+    expect(resolveRetryPolicy({ respectRetryAfter: false })).toMatchObject({
+      respectRetryAfter: false,
     });
   });
 
@@ -138,22 +146,18 @@ describe("backoffDelay", () => {
     initialInterval: 100,
     maxInterval: 2000,
     exponentiationFactor: 2,
+    respectRetryAfter: true,
   };
 
-  it("never exceeds the per-attempt ceiling (full jitter)", () => {
+  it("stays within ±20% of the (capped) exponential base", () => {
     for (let attempt = 0; attempt < 6; attempt++) {
-      const ceiling = Math.min(100 * 2 ** attempt, 2000);
+      const base = Math.min(100 * 2 ** attempt, 2000);
       for (let i = 0; i < 50; i++) {
         const d = backoffDelay(policy, attempt);
-        expect(d).toBeGreaterThanOrEqual(0);
-        expect(d).toBeLessThanOrEqual(ceiling);
+        expect(d).toBeGreaterThanOrEqual(base * 0.8);
+        expect(d).toBeLessThanOrEqual(base * 1.2);
       }
     }
-  });
-
-  it("honors Retry-After, capped at maxInterval", () => {
-    expect(backoffDelay(policy, 0, 500)).toBe(500);
-    expect(backoffDelay(policy, 0, 10_000)).toBe(2000);
   });
 });
 
@@ -488,6 +492,83 @@ describe("ingress auto-retry", () => {
       call("k1", { ...fastRetry, maxAttempts: 3 })
     ).rejects.toMatchObject({ status: 500 });
     expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  const attemptHeaders = () =>
+    fetchMock.mock.calls.map(
+      (c) => (c[1] as RequestInit).headers as Record<string, string>
+    );
+
+  it("stamps x-restateclient-attempt: 1 on a non-retried request", async () => {
+    queue(ok({ greeting: "hi" }));
+    await call("k1");
+    expect(attemptHeaders()[0]?.["x-restateclient-attempt"]).toBe("1");
+  });
+
+  it("stamps an incrementing x-restateclient-attempt header on each attempt", async () => {
+    queue(fail(503), fail(503), ok({ greeting: "hi" }));
+    await expect(call("k1", fastRetry)).resolves.toEqual({ greeting: "hi" });
+    expect(attemptHeaders().map((h) => h["x-restateclient-attempt"])).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("stops at maxAttempts even when the server keeps sending Retry-After", async () => {
+    // Retry-After: 0 keeps the delays instantaneous; the cap must still hold.
+    queue(fail(503, { "retry-after": "0" }));
+    await expect(
+      call("k1", { ...fastRetry, maxAttempts: 3 })
+    ).rejects.toMatchObject({ status: 503 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("honors Retry-After verbatim by default, beyond maxInterval", async () => {
+    vi.useFakeTimers();
+    try {
+      queue(fail(503, { "retry-after": "5" }), ok({ greeting: "hi" }));
+      // maxInterval is a mere 2ms, far below the 5s Retry-After: if it were
+      // capped, the retry would fire almost immediately.
+      const p = call("k1", {
+        initialInterval: 1,
+        maxInterval: 2,
+        exponentiationFactor: 2,
+        maxAttempts: 2,
+      });
+      await vi.advanceTimersByTimeAsync(0); // let the first attempt fail
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(3); // past maxInterval, but not the 5s wait
+      expect(fetchMock).toHaveBeenCalledTimes(1); // still waiting out the Retry-After
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      await expect(p).resolves.toEqual({ greeting: "hi" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores Retry-After when respectRetryAfter is false", async () => {
+    vi.useFakeTimers();
+    try {
+      queue(fail(503, { "retry-after": "5" }), ok({ greeting: "hi" }));
+      const p = call("k1", {
+        initialInterval: 100,
+        maxInterval: 100,
+        exponentiationFactor: 2,
+        maxAttempts: 2,
+        respectRetryAfter: false,
+      });
+      await vi.advanceTimersByTimeAsync(0); // let the first attempt fail
+      // The exponential backoff base is 100ms — far below the 5s Retry-After
+      // the server asked for. Advancing 200ms (past the jittered base) retries,
+      // proving the header was ignored.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      await expect(p).resolves.toEqual({ greeting: "hi" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("mints a fresh timeout signal per attempt", async () => {

--- a/packages/libs/restate-sdk-clients/src/retry.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.ts
@@ -14,11 +14,20 @@ import type { RetryFailure, RetryPolicy } from "./api.js";
 
 /** Fully resolved retry policy, with all defaults applied. */
 export interface ResolvedRetryPolicy {
+  /**
+   * `Infinity` means retries are not bounded by attempt count (the user passed
+   * `maxAttempts: false`).
+   */
   maxAttempts: number;
   initialInterval: number;
   maxInterval: number;
   exponentiationFactor: number;
   respectRetryAfter: boolean;
+  /**
+   * In milliseconds. `Infinity` means retries are not bounded by duration (the
+   * user passed `maxDuration: false`).
+   */
+  maxDuration: number;
   shouldRetry?: (failure: RetryFailure, attempt: number) => boolean;
 }
 
@@ -28,6 +37,7 @@ const DEFAULT_RETRY_POLICY: ResolvedRetryPolicy = {
   maxInterval: 3000,
   exponentiationFactor: 2,
   respectRetryAfter: true,
+  maxDuration: 60_000,
 };
 
 /**
@@ -47,7 +57,11 @@ export function resolveRetryPolicy(
     return DEFAULT_RETRY_POLICY;
   }
   return {
-    maxAttempts: retry.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts,
+    // `false` disables the bound (Infinity); otherwise the override or default.
+    maxAttempts:
+      retry.maxAttempts === false
+        ? Infinity
+        : (retry.maxAttempts ?? DEFAULT_RETRY_POLICY.maxAttempts),
     initialInterval:
       retry.initialInterval !== undefined
         ? millisOrDurationToMillis(retry.initialInterval)
@@ -60,6 +74,14 @@ export function resolveRetryPolicy(
       retry.exponentiationFactor ?? DEFAULT_RETRY_POLICY.exponentiationFactor,
     respectRetryAfter:
       retry.respectRetryAfter ?? DEFAULT_RETRY_POLICY.respectRetryAfter,
+    // Defaults to 60s; `false` disables the duration bound (Infinity), relying
+    // on maxAttempts alone.
+    maxDuration:
+      retry.maxDuration === false
+        ? Infinity
+        : retry.maxDuration !== undefined
+          ? millisOrDurationToMillis(retry.maxDuration)
+          : DEFAULT_RETRY_POLICY.maxDuration,
     shouldRetry: retry.shouldRetry,
   };
 }

--- a/packages/libs/restate-sdk-clients/src/retry.ts
+++ b/packages/libs/restate-sdk-clients/src/retry.ts
@@ -18,14 +18,16 @@ export interface ResolvedRetryPolicy {
   initialInterval: number;
   maxInterval: number;
   exponentiationFactor: number;
+  respectRetryAfter: boolean;
   shouldRetry?: (failure: RetryFailure, attempt: number) => boolean;
 }
 
 const DEFAULT_RETRY_POLICY: ResolvedRetryPolicy = {
   maxAttempts: 6,
-  initialInterval: 100,
-  maxInterval: 2000,
+  initialInterval: 250,
+  maxInterval: 3000,
   exponentiationFactor: 2,
+  respectRetryAfter: true,
 };
 
 /**
@@ -56,6 +58,8 @@ export function resolveRetryPolicy(
         : DEFAULT_RETRY_POLICY.maxInterval,
     exponentiationFactor:
       retry.exponentiationFactor ?? DEFAULT_RETRY_POLICY.exponentiationFactor,
+    respectRetryAfter:
+      retry.respectRetryAfter ?? DEFAULT_RETRY_POLICY.respectRetryAfter,
     shouldRetry: retry.shouldRetry,
   };
 }
@@ -101,24 +105,19 @@ export function defaultShouldRetry(failure: RetryFailure): boolean {
 
 /**
  * Compute the backoff for the given (zero based) attempt index using
- * exponential backoff with full jitter, capped at `maxInterval`.
- *
- * When the server provided an explicit `Retry-After` we honor it instead,
- * capped at `maxInterval` to avoid pathologically long waits.
+ * exponential backoff with ±20% jitter. The exponential base is capped at
+ * `maxInterval`; jitter is then applied on top, so the returned delay can sit
+ * up to 20% above `maxInterval`.
  */
 export function backoffDelay(
   policy: ResolvedRetryPolicy,
-  attempt: number,
-  retryAfterMs?: number
+  attempt: number
 ): number {
-  if (retryAfterMs !== undefined) {
-    return Math.min(retryAfterMs, policy.maxInterval);
-  }
   const exp =
     policy.initialInterval * Math.pow(policy.exponentiationFactor, attempt);
-  const ceiling = Math.min(exp, policy.maxInterval);
-  // full jitter: random in [0, ceiling]
-  return Math.random() * ceiling;
+  const base = Math.min(exp, policy.maxInterval);
+  // ±20% jitter keeps clients from retrying in lockstep after a shared blip.
+  return base * (0.8 + Math.random() * 0.4);
 }
 
 /**


### PR DESCRIPTION
* Add `x-restateclient-retry-attempt` header
* Change defaults of the retry policy
* Add support for Retry-After header, with option to disable it.
* Add `maxDuration` to bound the total duration of retries combined. This wont stop in flight attempts.