### PR TITLE
Port restate.interface to promise SDK

### DIFF
--- a/packages/examples/node/package.json
+++ b/packages/examples/node/package.json
@@ -15,6 +15,7 @@
     "greeter_http1": "RESTATE_LOGGING=debug tsx --tsconfig ./tsconfig.json ./src/greeter_http1.ts",
     "preview_serde": "RESTATE_LOGGING=debug tsx --tsconfig ./tsconfig.json ./src/preview_serde.ts",
     "zgreeter": "RESTATE_LOGGING=debug tsx --tsconfig ./tsconfig.json ./src/zod_greeter.ts",
+    "iface": "RESTATE_LOGGING=debug tsx --tsconfig ./tsconfig.json ./src/iface_greeter.ts",
     "workflow": "RESTATE_LOGGING=debug tsx --tsconfig ./tsconfig.json ./src/workflow.ts",
     "workflow_client": "RESTATE_LOGGING=debug tsx --tsconfig ./tsconfig.json ./src/workflow_client.ts",
     "ingress": "RESTATE_LOGGING=debug tsx ./src/ingress_client.ts",

--- a/packages/examples/node/src/iface_greeter.ts
+++ b/packages/examples/node/src/iface_greeter.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import * as restate from "@restatedev/restate-sdk/node";
+import { connect } from "@restatedev/restate-sdk-clients";
+import { z } from "zod";
+
+// 1. The service interface (contract)
+
+const Greeting = z.object({ name: z.string() });
+const GreetingResponse = z.object({ result: z.string() });
+
+export const greeterInterface = restate.iface.service("greeter", {
+  greet: restate.iface.schemas({ input: Greeting, output: GreetingResponse }),
+  ping: restate.iface.json<void, string>(),
+});
+
+// 2. The implementation
+
+const greeter = restate.implement(greeterInterface, {
+  handlers: {
+    greet: async (_ctx, { name }) => ({ result: `Hello, ${name}!` }),
+    ping: async (_ctx) => "pong",
+  },
+});
+
+// 3. A service that CALLS greeter through the interface.
+
+const frontend = restate.service({
+  name: "frontend",
+  handlers: {
+    hello: async (ctx, name: string) => {
+      const client = ctx.client(greeterInterface);
+      const { result } = await client.greet({ name });
+      return result;
+    },
+  },
+});
+
+void restate.serve({
+  services: [greeter, frontend],
+  port: 9080,
+});
+
+// 4. Calling greeter from OUTSIDE Restate (ingress).
+
+export async function callFromIngress(name: string) {
+  const ingress = connect({ url: "http://localhost:8080" });
+
+  const { result } = await ingress.client(greeterInterface).greet({
+    name,
+  });
+
+  console.log(result);
+}

--- a/packages/libs/restate-sdk-clients/src/api.ts
+++ b/packages/libs/restate-sdk-clients/src/api.ts
@@ -8,6 +8,12 @@ import type {
   Serde,
   Duration,
   JournalValueCodec,
+  HandlerDescriptor,
+  ServiceDescriptor,
+  ObjectDescriptor,
+  WorkflowDescriptor,
+  InferInput,
+  InferOutput,
 } from "@restatedev/restate-sdk-core";
 import { millisOrDurationToMillis } from "@restatedev/restate-sdk-core";
 
@@ -48,19 +54,57 @@ export interface Ingress {
   ): IngressClient<VirtualObject<D>>;
 
   /**
-   * Create a client from a {@link ServiceDefinition}.
+   * Create a send client from a {@link ServiceDefinition}.
    */
   serviceSendClient<D>(
     opts: ServiceDefinitionFrom<D>
   ): IngressSendClient<Service<D>>;
 
   /**
-   * Create a client from a {@link VirtualObjectDefinition}.
+   * Create a send client from a {@link VirtualObjectDefinition}.
    */
   objectSendClient<D>(
     opts: VirtualObjectDefinitionFrom<D>,
     key: string
   ): IngressSendClient<VirtualObject<D>>;
+
+  /**
+   * Create a request/response client from a service interface / `Descriptor`.
+   *
+   * @example
+   * ```ts
+   * ingress.client(greeter).greet(req);      // service
+   * ingress.client(counter, "k").add(1);     // virtual object / workflow
+   * ```
+   */
+  client<P extends string, H extends Record<string, HandlerDescriptor>>(
+    serviceInterface: ServiceDescriptor<P, H>
+  ): IngressClientFromDescriptors<H>;
+  client<P extends string, H extends Record<string, HandlerDescriptor>>(
+    objectOrWorkflowInterface:
+      | ObjectDescriptor<P, H>
+      | WorkflowDescriptor<P, H>,
+    key: string
+  ): IngressClientFromDescriptors<H>;
+
+  /**
+   * Send-client (one-way) counterpart of {@link Ingress.client}.
+   *
+   * @example
+   * ```ts
+   * ingress.sendClient(greeter).greet(req);
+   * ingress.sendClient(counter, "k").add(1);
+   * ```
+   */
+  sendClient<P extends string, H extends Record<string, HandlerDescriptor>>(
+    serviceInterface: ServiceDescriptor<P, H>
+  ): IngressSendClientFromDescriptors<H>;
+  sendClient<P extends string, H extends Record<string, HandlerDescriptor>>(
+    objectOrWorkflowInterface:
+      | ObjectDescriptor<P, H>
+      | WorkflowDescriptor<P, H>,
+    key: string
+  ): IngressSendClientFromDescriptors<H>;
 
   /**
    * Resolve an awakeable from the ingress client.
@@ -188,6 +232,8 @@ export type ScopedIngress = Pick<
   | "objectClient"
   | "objectSendClient"
   | "workflowClient"
+  | "client"
+  | "sendClient"
 >;
 
 export interface IngressCallOptions<I = unknown, O = unknown> {
@@ -295,6 +341,37 @@ export type IngressClient<M> = {
   ) => PromiseLike<infer O>
     ? (...args: [...P, ...[opts?: Opts<InferArgType<P>, O>]]) => PromiseLike<O>
     : never;
+};
+
+/**
+ * Typed ingress request/response client derived from a service interface's
+ * handler descriptor map `H` (see `iface` in `@restatedev/restate-sdk-core`).
+ * Recovers the input/output types directly from the descriptors, so a code-free
+ * interface value produces a fully typed client that reuses the declared serdes.
+ */
+export type IngressClientFromDescriptors<
+  H extends Record<string, HandlerDescriptor>,
+> = {
+  readonly [K in keyof H]: [InferInput<H[K]>] extends [void]
+    ? (
+        opts?: Opts<InferInput<H[K]>, InferOutput<H[K]>>
+      ) => Promise<InferOutput<H[K]>>
+    : (
+        input: InferInput<H[K]>,
+        opts?: Opts<InferInput<H[K]>, InferOutput<H[K]>>
+      ) => Promise<InferOutput<H[K]>>;
+};
+
+/** One-way (send) counterpart of {@link IngressClientFromDescriptors}. */
+export type IngressSendClientFromDescriptors<
+  H extends Record<string, HandlerDescriptor>,
+> = {
+  readonly [K in keyof H]: [InferInput<H[K]>] extends [void]
+    ? (opts?: SendOpts<InferInput<H[K]>>) => Promise<Send<InferOutput<H[K]>>>
+    : (
+        input: InferInput<H[K]>,
+        opts?: SendOpts<InferInput<H[K]>>
+      ) => Promise<Send<InferOutput<H[K]>>>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/libs/restate-sdk-clients/src/index.ts
+++ b/packages/libs/restate-sdk-clients/src/index.ts
@@ -33,6 +33,8 @@ export type {
   IngressClient,
   IngressSendClient,
   IngressWorkflowClient,
+  IngressClientFromDescriptors,
+  IngressSendClientFromDescriptors,
   IngressCallOptions,
   RetryPolicy,
   RetryFailure,

--- a/packages/libs/restate-sdk-clients/src/ingress.ts
+++ b/packages/libs/restate-sdk-clients/src/ingress.ts
@@ -8,24 +8,20 @@
  * directory of this repository or package, or at
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
+// The client methods implement the overloaded `Ingress` interface (classic
+// definition OR service interface), which requires an `any` return on the
+// implementation signatures.
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
-  type Service,
-  type ServiceDefinitionFrom,
-  type VirtualObject,
-  type WorkflowDefinitionFrom,
-  type Workflow,
-  type VirtualObjectDefinitionFrom,
   type Serde,
   serde,
   type JournalValueCodec,
+  type HandlerDescriptor,
 } from "@restatedev/restate-sdk-core";
 import {
   ConnectionOpts,
   Ingress,
-  IngressClient,
-  IngressSendClient,
-  IngressWorkflowClient,
   Output,
   Send,
   ScopedIngress,
@@ -52,6 +48,18 @@ export function connect(opts: ConnectionOpts): Ingress {
   return new HttpIngress(opts);
 }
 
+/**
+ * The runtime shape a client method needs off a definition value: the service
+ * name, plus (for interface / `implement()` values) the per-handler serde
+ * descriptors. Classic definitions carry no `_handlers`, so serde reuse is a
+ * no-op for them.
+ */
+type ClientTarget = {
+  name: string;
+  _handlers?: Record<string, HandlerDescriptor>;
+  _kind?: "service" | "object" | "workflow";
+};
+
 export class HttpCallError extends Error {
   constructor(
     public readonly status: number,
@@ -71,6 +79,8 @@ type InvocationParameters<I> = {
   parameter?: I;
   method?: string;
   scope?: string;
+  /** Serdes declared by the callee's service interface, if the client was built from one. */
+  handlerDesc?: HandlerDescriptor;
 };
 
 function optsFromArgs(args: unknown[]): {
@@ -288,7 +298,11 @@ const doComponentInvocation = async <I, O>(
   //
   // request body
   //
-  const inputSerde = params.opts?.opts.input ?? opts.serde ?? serde.json;
+  const inputSerde =
+    params.opts?.opts.input ??
+    params.handlerDesc?._inputSerde ??
+    opts.serde ??
+    serde.json;
 
   const { body, contentType } = serializeBodyWithContentType(
     params.parameter,
@@ -346,7 +360,11 @@ const doComponentInvocation = async <I, O>(
     const decodedBuf = opts.journalValueCodec
       ? await opts.journalValueCodec.decode(responseBuf)
       : responseBuf;
-    const outputSerde = params.opts?.opts.output ?? opts.serde ?? serde.json;
+    const outputSerde =
+      params.opts?.opts.output ??
+      params.handlerDesc?._outputSerde ??
+      opts.serde ??
+      serde.json;
     return outputSerde.deserialize(decodedBuf) as O;
   }
   const json = serde.json.deserialize(responseBuf) as O;
@@ -358,9 +376,11 @@ const doWorkflowHandleCall = async <O>(
   wfName: string,
   wfKey: string,
   op: "output" | "attach",
-  callOpts?: Opts<unknown, O> | SendOpts<unknown>
+  callOpts?: Opts<unknown, O> | SendOpts<unknown>,
+  runOutputSerde?: Serde<unknown>
 ): Promise<O> => {
-  const outputSerde = callOpts?.opts.output ?? opts.serde ?? serde.json;
+  const outputSerde =
+    callOpts?.opts.output ?? runOutputSerde ?? opts.serde ?? serde.json;
   //
   // headers
   //
@@ -393,7 +413,12 @@ const doWorkflowHandleCall = async <O>(
 class HttpIngress implements Ingress {
   constructor(private readonly opts: ConnectionOpts) {}
 
-  private proxy(component: string, key?: string, send?: boolean) {
+  private proxy(
+    component: string,
+    key?: string,
+    send?: boolean,
+    handlers?: Record<string, HandlerDescriptor>
+  ) {
     return new Proxy(
       {},
       {
@@ -408,6 +433,7 @@ class HttpIngress implements Ingress {
               parameter,
               opts,
               send,
+              handlerDesc: handlers?.[handler],
             });
           };
         },
@@ -415,22 +441,18 @@ class HttpIngress implements Ingress {
     );
   }
 
-  serviceClient<D>(opts: ServiceDefinitionFrom<D>): IngressClient<Service<D>> {
-    return this.proxy(opts.name) as IngressClient<Service<D>>;
+  serviceClient(opts: ClientTarget): any {
+    return this.proxy(opts.name, undefined, undefined, opts._handlers);
   }
 
-  objectClient<D>(
-    opts: VirtualObjectDefinitionFrom<D>,
-    key: string
-  ): IngressClient<VirtualObject<D>> {
-    return this.proxy(opts.name, key) as IngressClient<VirtualObject<D>>;
+  objectClient(opts: ClientTarget, key: string): any {
+    return this.proxy(opts.name, key, undefined, opts._handlers);
   }
 
-  workflowClient<D>(
-    opts: WorkflowDefinitionFrom<D>,
-    key: string
-  ): IngressWorkflowClient<Workflow<D>> {
+  workflowClient(opts: ClientTarget, key: string): any {
     const component = opts.name;
+    const handlers = opts._handlers;
+    const runOutputSerde = handlers?.run?._outputSerde;
     const conn = this.opts;
 
     const workflowSubmit = async (
@@ -446,6 +468,7 @@ class HttpIngress implements Ingress {
           send: true,
           parameter,
           opts,
+          handlerDesc: handlers?.run,
         },
         true
       );
@@ -458,7 +481,14 @@ class HttpIngress implements Ingress {
     };
 
     const workflowAttach = (opts?: Opts<void, unknown>) =>
-      doWorkflowHandleCall(conn, component, key, "attach", opts);
+      doWorkflowHandleCall(
+        conn,
+        component,
+        key,
+        "attach",
+        opts,
+        runOutputSerde
+      );
 
     const workflowOutput = async (
       opts?: Opts<void, unknown>
@@ -469,7 +499,8 @@ class HttpIngress implements Ingress {
           component,
           key,
           "output",
-          opts
+          opts,
+          runOutputSerde
         );
 
         return {
@@ -511,33 +542,44 @@ class HttpIngress implements Ingress {
               key,
               parameter,
               opts,
+              handlerDesc: handlers?.[handler],
             });
           };
         },
       }
-    ) as IngressWorkflowClient<Workflow<D>>;
+    );
   }
 
-  objectSendClient<D>(
-    opts: VirtualObjectDefinitionFrom<D>,
-    key: string
-  ): IngressSendClient<VirtualObject<D>> {
-    return this.proxy(opts.name, key, true) as IngressSendClient<
-      VirtualObject<D>
-    >;
+  objectSendClient(opts: ClientTarget, key: string): any {
+    return this.proxy(opts.name, key, true, opts._handlers);
   }
 
-  serviceSendClient<D>(
-    opts: ServiceDefinitionFrom<D>
-  ): IngressSendClient<Service<D>> {
-    return this.proxy(opts.name, undefined, true) as IngressSendClient<
-      Service<D>
-    >;
+  serviceSendClient(opts: ClientTarget): any {
+    return this.proxy(opts.name, undefined, true, opts._handlers);
+  }
+
+  // Factory that dispatches on the interface's kind — mirrors the generator
+  // SDK's `client(ingress, def)` / `sendClient(ingress, def)` ergonomics.
+  client(opts: ClientTarget, key?: string): any {
+    return opts._kind === "service"
+      ? this.serviceClient(opts)
+      : this.objectClient(opts, key as string);
+  }
+
+  sendClient(opts: ClientTarget, key?: string): any {
+    return opts._kind === "service"
+      ? this.serviceSendClient(opts)
+      : this.objectSendClient(opts, key as string);
   }
 
   scope(scopeKey: string): ScopedIngress {
     const conn = this.opts;
-    const scopedProxy = (component: string, key?: string, send?: boolean) =>
+    const scopedProxy = (
+      component: string,
+      key?: string,
+      send?: boolean,
+      handlers?: Record<string, HandlerDescriptor>
+    ) =>
       new Proxy(
         {},
         {
@@ -553,6 +595,7 @@ class HttpIngress implements Ingress {
                 opts,
                 send,
                 scope: scopeKey,
+                handlerDesc: handlers?.[handler],
               });
             };
           },
@@ -560,26 +603,26 @@ class HttpIngress implements Ingress {
       );
 
     return {
-      serviceClient: <D>(opts: ServiceDefinitionFrom<D>) =>
-        scopedProxy(opts.name) as IngressClient<Service<D>>,
-      serviceSendClient: <D>(opts: ServiceDefinitionFrom<D>) =>
-        scopedProxy(opts.name, undefined, true) as IngressSendClient<
-          Service<D>
-        >,
-      objectClient: <D>(opts: VirtualObjectDefinitionFrom<D>, key: string) =>
-        scopedProxy(opts.name, key) as IngressClient<VirtualObject<D>>,
-      objectSendClient: <D>(
-        opts: VirtualObjectDefinitionFrom<D>,
-        key: string
-      ) =>
-        scopedProxy(opts.name, key, true) as IngressSendClient<
-          VirtualObject<D>
-        >,
-      workflowClient: <D>(
-        opts: WorkflowDefinitionFrom<D>,
-        key: string
-      ): IngressWorkflowClient<Workflow<D>> => {
+      serviceClient: (opts: ClientTarget): any =>
+        scopedProxy(opts.name, undefined, undefined, opts._handlers),
+      serviceSendClient: (opts: ClientTarget): any =>
+        scopedProxy(opts.name, undefined, true, opts._handlers),
+      objectClient: (opts: ClientTarget, key: string): any =>
+        scopedProxy(opts.name, key, undefined, opts._handlers),
+      objectSendClient: (opts: ClientTarget, key: string): any =>
+        scopedProxy(opts.name, key, true, opts._handlers),
+      client: (opts: ClientTarget, key?: string): any =>
+        opts._kind === "service"
+          ? scopedProxy(opts.name, undefined, undefined, opts._handlers)
+          : scopedProxy(opts.name, key, undefined, opts._handlers),
+      sendClient: (opts: ClientTarget, key?: string): any =>
+        opts._kind === "service"
+          ? scopedProxy(opts.name, undefined, true, opts._handlers)
+          : scopedProxy(opts.name, key, true, opts._handlers),
+      workflowClient: (opts: ClientTarget, key: string): any => {
         const component = opts.name;
+        const handlers = opts._handlers;
+        const runOutputSerde = handlers?.run?._outputSerde;
 
         const workflowSubmit = async (
           ...args: unknown[]
@@ -595,6 +638,7 @@ class HttpIngress implements Ingress {
               parameter,
               opts,
               scope: scopeKey,
+              handlerDesc: handlers?.run,
             },
             true
           );
@@ -606,7 +650,14 @@ class HttpIngress implements Ingress {
         };
 
         const workflowAttach = (opts?: Opts<void, unknown>) =>
-          doWorkflowHandleCall(conn, component, key, "attach", opts);
+          doWorkflowHandleCall(
+            conn,
+            component,
+            key,
+            "attach",
+            opts,
+            runOutputSerde
+          );
 
         const workflowOutput = async (
           opts?: Opts<void, unknown>
@@ -617,7 +668,8 @@ class HttpIngress implements Ingress {
               component,
               key,
               "output",
-              opts
+              opts,
+              runOutputSerde
             );
             return { ready: true, result };
           } catch (e) {
@@ -654,11 +706,12 @@ class HttpIngress implements Ingress {
                   parameter,
                   opts,
                   scope: scopeKey,
+                  handlerDesc: handlers?.[handler],
                 });
               };
             },
           }
-        ) as IngressWorkflowClient<Workflow<D>>;
+        );
       },
     };
   }

--- a/packages/libs/restate-sdk-core/src/index.ts
+++ b/packages/libs/restate-sdk-core/src/index.ts
@@ -46,3 +46,20 @@ export type {
   StandardSchemaV1,
   StandardJSONSchemaV1,
 } from "./standard_schema.js";
+
+export { iface, makeHandlerDescriptor } from "./interface.js";
+export type {
+  ServiceInterface,
+  HandlerDescriptor,
+  Descriptor,
+  ServiceDescriptor,
+  ObjectDescriptor,
+  WorkflowDescriptor,
+  ImplementedServiceDefinition,
+  ImplementedObjectDefinition,
+  ImplementedWorkflowDefinition,
+  ImplementedDefinition,
+  InferInput,
+  InferOutput,
+  SerdeType,
+} from "./interface.js";

--- a/packages/libs/restate-sdk-core/src/interface.ts
+++ b/packages/libs/restate-sdk-core/src/interface.ts
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { Serde } from "./serde_api.js";
+import { serde } from "./serde_api.js";
+import type { StandardSchemaV1 } from "./standard_schema.js";
+import type {
+  ServiceDefinition,
+  VirtualObjectDefinition,
+  WorkflowDefinition,
+} from "./core.js";
+
+/**
+ * Minimal descriptor stored in {@link Descriptor}._handlers per handler.
+ */
+export type HandlerDescriptor<
+  I = any,
+  O = any,
+  Shared extends boolean = boolean,
+> = {
+  readonly _inputSerde?: Serde<I>;
+  readonly _outputSerde?: Serde<O>;
+  /** @internal virtual-object handler shared/exclusive marker (phantom + runtime) */
+  readonly _shared?: Shared;
+};
+
+export function makeHandlerDescriptor<I, O, Shared extends boolean = false>(
+  inputSerde?: Serde<I>,
+  outputSerde?: Serde<O>,
+  shared?: Shared
+): HandlerDescriptor<I, O, Shared> {
+  return {
+    _inputSerde: inputSerde,
+    _outputSerde: outputSerde,
+    _shared: shared,
+  };
+}
+
+/** Recover the input type declared by a {@link HandlerDescriptor}. */
+export type InferInput<D> =
+  D extends HandlerDescriptor<infer I, any, any> ? I : any;
+/** Recover the output type declared by a {@link HandlerDescriptor}. */
+export type InferOutput<D> =
+  D extends HandlerDescriptor<any, infer O, any> ? O : any;
+/** Recover the value type carried by a {@link Serde}. */
+export type SerdeType<S> = S extends Serde<infer T> ? T : never;
+
+// =============================================================================
+// Descriptor — the client-facing definition value carrying `_handlers`.
+//
+// - `iface.service/object/workflow(...)` return a pure Descriptor (no fn), safe
+//   to place in a shared package imported by both server and callers.
+// - the SDKs' `implement()` / `service()` factories return an
+//   `Implemented*Definition`, which is a Descriptor that is ALSO bindable.
+// =============================================================================
+
+export type Descriptor<
+  P extends string = string,
+  H extends Record<string, HandlerDescriptor> = Record<
+    string,
+    HandlerDescriptor
+  >,
+  Kind extends "service" | "object" | "workflow" =
+    | "service"
+    | "object"
+    | "workflow",
+> = {
+  readonly name: P;
+  readonly _kind: Kind;
+  readonly _handlers: H;
+};
+
+export type ServiceDescriptor<
+  P extends string = string,
+  H extends Record<string, HandlerDescriptor> = Record<
+    string,
+    HandlerDescriptor
+  >,
+> = Descriptor<P, H, "service">;
+
+export type ObjectDescriptor<
+  P extends string = string,
+  H extends Record<string, HandlerDescriptor> = Record<
+    string,
+    HandlerDescriptor
+  >,
+> = Descriptor<P, H, "object">;
+
+export type WorkflowDescriptor<
+  P extends string = string,
+  H extends Record<string, HandlerDescriptor> = Record<
+    string,
+    HandlerDescriptor
+  >,
+> = Descriptor<P, H, "workflow">;
+
+/** Implemented definition — a Descriptor that is also bindable to an endpoint. */
+export type ImplementedServiceDefinition<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+> = ServiceDefinition<P, any> & ServiceDescriptor<P, H>;
+
+export type ImplementedObjectDefinition<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+> = VirtualObjectDefinition<P, any> & ObjectDescriptor<P, H>;
+
+export type ImplementedWorkflowDefinition<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+> = WorkflowDefinition<P, any> & WorkflowDescriptor<P, H>;
+
+export type ImplementedDefinition<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+  Kind extends "service" | "object" | "workflow",
+> = Kind extends "service"
+  ? ImplementedServiceDefinition<P, H>
+  : Kind extends "object"
+    ? ImplementedObjectDefinition<P, H>
+    : ImplementedWorkflowDefinition<P, H>;
+
+/** The shape of the {@link iface} service-interface declaration API. */
+export interface ServiceInterface {
+  service<P extends string, H extends Record<string, HandlerDescriptor>>(
+    name: P,
+    handlers: H
+  ): ServiceDescriptor<P, H>;
+  object<P extends string, H extends Record<string, HandlerDescriptor>>(
+    name: P,
+    handlers: H
+  ): ObjectDescriptor<P, H>;
+  workflow<P extends string, H extends Record<string, HandlerDescriptor>>(
+    name: P,
+    handlers: H
+  ): WorkflowDescriptor<P, H>;
+  /** `json<I, O>()` — type params, default JSON serde. */
+  json<I = void, O = void>(): HandlerDescriptor<I, O, false>;
+  /** `serdes({ input, output })` — explicit Serde per direction. */
+  serdes<SI extends Serde<any>, SO extends Serde<any>>(opts: {
+    input?: SI;
+    output?: SO;
+  }): HandlerDescriptor<SerdeType<SI>, SerdeType<SO>, false>;
+  /** `schemas({ input, output })` — Standard Schema per direction. */
+  schemas<
+    SI extends StandardSchemaV1<any>,
+    SO extends StandardSchemaV1<any>,
+  >(opts: {
+    input?: SI;
+    output?: SO;
+  }): HandlerDescriptor<
+    StandardSchemaV1.InferOutput<NonNullable<SI>>,
+    StandardSchemaV1.InferOutput<NonNullable<SO>>,
+    false
+  >;
+  /** Shared (read-only) virtual-object / non-`run` workflow handler declarators. */
+  shared: {
+    json<I = void, O = void>(): HandlerDescriptor<I, O, true>;
+    serdes<SI extends Serde<any>, SO extends Serde<any>>(opts: {
+      input?: SI;
+      output?: SO;
+    }): HandlerDescriptor<SerdeType<SI>, SerdeType<SO>, true>;
+    schemas<
+      SI extends StandardSchemaV1<any>,
+      SO extends StandardSchemaV1<any>,
+    >(opts: {
+      input?: SI;
+      output?: SO;
+    }): HandlerDescriptor<
+      StandardSchemaV1.InferOutput<NonNullable<SI>>,
+      StandardSchemaV1.InferOutput<NonNullable<SO>>,
+      true
+    >;
+  };
+}
+
+/**
+ * Declare a service interface (contract) as a runtime value carrying handler
+ * names + input/output serdes, without an implementation. Place it in a shared
+ * package that both the server (via `implement()`) and callers (via
+ * `ctx.serviceClient(iface)` / `connect().serviceClient(iface)`) import.
+ *
+ * @example
+ * ```ts
+ * const greeter = iface.service("greeter", {
+ *   greet: iface.schemas({ input: GreetReq, output: GreetRes }),
+ *   ping:  iface.json<void, string>(),
+ * });
+ * ```
+ */
+export const iface: ServiceInterface = {
+  service: function <
+    P extends string,
+    H extends Record<string, HandlerDescriptor>,
+  >(name: P, handlers: H): ServiceDescriptor<P, H> {
+    return { name, _kind: "service", _handlers: handlers };
+  },
+  object: function <
+    P extends string,
+    H extends Record<string, HandlerDescriptor>,
+  >(name: P, handlers: H): ObjectDescriptor<P, H> {
+    return { name, _kind: "object", _handlers: handlers };
+  },
+  workflow: function <
+    P extends string,
+    H extends Record<string, HandlerDescriptor>,
+  >(name: P, handlers: H): WorkflowDescriptor<P, H> {
+    return { name, _kind: "workflow", _handlers: handlers };
+  },
+  json: function <I = void, O = void>(): HandlerDescriptor<I, O, false> {
+    return makeHandlerDescriptor<I, O, false>(undefined, undefined, false);
+  },
+  serdes: function <SI extends Serde<any>, SO extends Serde<any>>(opts: {
+    input?: SI;
+    output?: SO;
+  }): HandlerDescriptor<SerdeType<SI>, SerdeType<SO>, false> {
+    return makeHandlerDescriptor<any, any, false>(
+      opts.input,
+      opts.output,
+      false
+    );
+  },
+  schemas: function <
+    SI extends StandardSchemaV1<any>,
+    SO extends StandardSchemaV1<any>,
+  >(opts: {
+    input?: SI;
+    output?: SO;
+  }): HandlerDescriptor<
+    StandardSchemaV1.InferOutput<NonNullable<SI>>,
+    StandardSchemaV1.InferOutput<NonNullable<SO>>,
+    false
+  > {
+    return makeHandlerDescriptor<any, any, false>(
+      opts.input ? serde.schema(opts.input) : undefined,
+      opts.output ? serde.schema(opts.output) : undefined,
+      false
+    );
+  },
+  shared: {
+    json: function <I = void, O = void>(): HandlerDescriptor<I, O, true> {
+      return makeHandlerDescriptor<I, O, true>(undefined, undefined, true);
+    },
+    serdes: function <SI extends Serde<any>, SO extends Serde<any>>(opts: {
+      input?: SI;
+      output?: SO;
+    }): HandlerDescriptor<SerdeType<SI>, SerdeType<SO>, true> {
+      return makeHandlerDescriptor<any, any, true>(
+        opts.input,
+        opts.output,
+        true
+      );
+    },
+    schemas: function <
+      SI extends StandardSchemaV1<any>,
+      SO extends StandardSchemaV1<any>,
+    >(opts: {
+      input?: SI;
+      output?: SO;
+    }): HandlerDescriptor<
+      StandardSchemaV1.InferOutput<NonNullable<SI>>,
+      StandardSchemaV1.InferOutput<NonNullable<SO>>,
+      true
+    > {
+      return makeHandlerDescriptor<any, any, true>(
+        opts.input ? serde.schema(opts.input) : undefined,
+        opts.output ? serde.schema(opts.output) : undefined,
+        true
+      );
+    },
+  },
+};

--- a/packages/libs/restate-sdk-gen/e2e/abandon.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/abandon.e2e.test.ts
@@ -30,8 +30,8 @@ import {
   race,
   sleep,
   type Operation,
-  clients,
 } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -97,14 +97,14 @@ const modes = [
 
 describe.each(modes)("abandon — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [abandonSvc],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -112,12 +112,12 @@ describe.each(modes)("abandon — $name mode", ({ alwaysReplay }) => {
   });
 
   test("fire-and-forget spawn parked on a never-settling source does not hang the handler", async () => {
-    const client = clients.client(ingress, abandonSvc);
+    const client = ingress.client(abandonSvc);
     expect(await client.fireAndForget()).toBe("main-result");
   });
 
   test("race loser routine parked on a never-settling source is abandoned, winner returned", async () => {
-    const client = clients.client(ingress, abandonSvc);
+    const client = ingress.client(abandonSvc);
     expect(await client.raceWithStuckLoser()).toBe("fast");
   });
 });

--- a/packages/libs/restate-sdk-gen/e2e/channels.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/channels.e2e.test.ts
@@ -28,9 +28,9 @@ import {
   select,
   all,
   type Operation,
-  clients,
   gen,
 } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -120,14 +120,14 @@ const modes = [
 
 describe.each(modes)("channels — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [channelsSvc],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -135,24 +135,24 @@ describe.each(modes)("channels — $name mode", ({ alwaysReplay }) => {
   });
 
   test("basic send/receive in the same fiber", async () => {
-    const client = clients.client(ingress, channelsSvc);
+    const client = ingress.client(channelsSvc);
     expect(await client.basicSend("hello")).toBe("hello");
   });
 
   test("spawn coordinate: spawned fiber sends, parent receives", async () => {
-    const client = clients.client(ingress, channelsSvc);
+    const client = ingress.client(channelsSvc);
     expect(await client.spawnCoordinate("from-spawn")).toBe("from-spawn");
   });
 
   test("multi-reader broadcast: all readers see the same value", async () => {
-    const client = clients.client(ingress, channelsSvc);
+    const client = ingress.client(channelsSvc);
     expect(await client.multiReaderBroadcast("payload")).toBe(
       "A:payload|B:payload|C:payload"
     );
   });
 
   test("stop with reason: typed channel carrying structured data", async () => {
-    const client = clients.client(ingress, channelsSvc);
+    const client = ingress.client(channelsSvc);
     expect(await client.stopWithReason({ reason: "user-cancelled" })).toBe(
       "stopped:user-cancelled"
     );

--- a/packages/libs/restate-sdk-gen/e2e/concurrency.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/concurrency.e2e.test.ts
@@ -26,8 +26,8 @@ import {
   race,
   select,
   type Operation,
-  clients,
 } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -153,14 +153,14 @@ const modes = [
 
 describe.each(modes)("concurrency — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [concurrencySvc],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -168,27 +168,27 @@ describe.each(modes)("concurrency — $name mode", ({ alwaysReplay }) => {
   });
 
   test("all returns both values in input order", async () => {
-    const client = clients.client(ingress, concurrencySvc);
+    const client = ingress.client(concurrencySvc);
     expect(await client.all()).toBe("alpha+bravo");
   });
 
   test("race returns the fast one", async () => {
-    const client = clients.client(ingress, concurrencySvc);
+    const client = ingress.client(concurrencySvc);
     expect(await client.race()).toBe("fast-result");
   });
 
   test("select returns the winning tag and the value via r.future", async () => {
-    const client = clients.client(ingress, concurrencySvc);
+    const client = ingress.client(concurrencySvc);
     expect(await client.selectTagged()).toBe("fast-won:F");
   });
 
   test("spawn pair: all over routine-backed futures", async () => {
-    const client = clients.client(ingress, concurrencySvc);
+    const client = ingress.client(concurrencySvc);
     expect(await client.spawnPair()).toBe("A|B");
   });
 
   test("mixed sources: run + spawn in one all", async () => {
-    const client = clients.client(ingress, concurrencySvc);
+    const client = ingress.client(concurrencySvc);
     expect(await client.mixedAllOf()).toBe("from-run + from-spawn");
   });
 });

--- a/packages/libs/restate-sdk-gen/e2e/context.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/context.e2e.test.ts
@@ -34,9 +34,9 @@ import {
   sleep,
   spawn,
   contextLocal,
-  clients,
   type Operation,
 } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 // Defined once at module scope — each invocation gets its own bag.
 const requestId = contextLocal<string>();
@@ -109,14 +109,14 @@ const modes = [
 
 describe.each(modes)("contextLocal — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [ambient],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -124,7 +124,7 @@ describe.each(modes)("contextLocal — $name mode", ({ alwaysReplay }) => {
   });
 
   test("value set before a suspension is readable after, by main / nested / spawned", async () => {
-    const client = clients.client(ingress, ambient);
+    const client = ingress.client(ambient);
     const out = await client.propagate({ id: "42", tenant: "acme" });
     expect(out.afterSleep).toBe("req-42");
     expect(out.nested).toBe("[req-42 | acme] nested");
@@ -132,20 +132,20 @@ describe.each(modes)("contextLocal — $name mode", ({ alwaysReplay }) => {
   });
 
   test("default applies when a slot is left unset within the invocation", async () => {
-    const client = clients.client(ingress, ambient);
+    const client = ingress.client(ambient);
     const out = await client.propagate({ id: "7" }); // no tenant → default
     expect(out.nested).toBe("[req-7 | public] nested");
   });
 
   test("scoped per invocation: a fresh invocation does not see a prior one's value", async () => {
-    const client = clients.client(ingress, ambient);
+    const client = ingress.client(ambient);
     await client.propagate({ id: "999", tenant: "acme" });
     // whoami is a brand-new invocation; it never set requestId.
     expect(await client.whoami()).toBe("unset");
   });
 
   test("get/set inside a run closure throws (off the advance span)", async () => {
-    const client = clients.client(ingress, ambient);
+    const client = ingress.client(ambient);
     expect(await client.runBoundary()).toBe("threw");
   });
 });

--- a/packages/libs/restate-sdk-gen/e2e/interrupt.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/interrupt.e2e.test.ts
@@ -33,8 +33,8 @@ import {
   allSettled,
   type Operation,
   type Task,
-  clients,
 } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 // Out-of-band observation channel (same process as the test).
 const obs: Record<string, string> = {};
@@ -349,14 +349,14 @@ const modes = [
 
 describe.each(modes)("interrupt — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [interruptSvc],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -364,53 +364,53 @@ describe.each(modes)("interrupt — $name mode", ({ alwaysReplay }) => {
   });
 
   test("interrupt past a sleep: handler completes promptly, sleep command abandoned", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.interruptPastSleep()).toBe("interrupted:stop");
   });
 
   test("interrupt-then-join runs journaled cleanup in the catch", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.interruptThenJoinCleanup()).toBe("interrupted:stop:audited");
   });
 
   test("uncaught interrupt fails the routine; joiner sees the verbatim error", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.uncaughtInterruptFails()).toBe("rejected:boom");
   });
 
   test("interrupting one input of allSettled: rejected for it, fulfilled for the other", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.interruptCombinatorInput()).toBe("rej:boom|ok:two");
   });
 
   test("interrupt cascades to a spawned child; both run journaled cleanup", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.cascadeInterrupt()).toBe(
       "parent:boom:parent-cleaned|child:boom:child-cleaned"
     );
   });
 
   test("cascade reaches a grandchild re-homed when its intermediate parent finished", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.cascadeReHome()).toBe(
       "sup:boom:sup-cleaned|g:boom:g-cleaned"
     );
   });
 
   test("self-interrupt: the throw lands at the worker's next yield and replays consistently", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.selfInterrupt()).toBe("interrupted:self:audited");
   });
 
   test("interrupt before first advance is caught inside the worker and replays consistently", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     expect(await c.interruptBeforeFirstAdvance()).toBe(
       "interrupted:pre-start:audited"
     );
   });
 
   test("interrupt mid-run: the caught error is the verbatim interrupt error, identical record vs replay", async () => {
-    const c = clients.client(ingress, interruptSvc);
+    const c = ingress.client(interruptSvc);
     // The in-memory interrupt wake (verbatim InterruptedError) wins over
     // the run's journaled (coerced) outcome; the per-tick journaled race
     // combinator keeps this ordering stable across replay.
@@ -421,7 +421,7 @@ describe.each(modes)("interrupt — $name mode", ({ alwaysReplay }) => {
 
   test("interrupt aborts the worker's run signal and delivers the error; main's signal is unaffected", async () => {
     obs.worker = "init";
-    const client = clients.client(ingress, interruptSvc);
+    const client = ingress.client(interruptSvc);
     const result = await client.scopedInterrupt();
     expect(result).toBe("worker-interrupted:stop|mainAbortedAtStart=false");
     // The worker's in-flight run signal fired (scoped per fiber).

--- a/packages/libs/restate-sdk-gen/e2e/polling.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/polling.e2e.test.ts
@@ -35,8 +35,8 @@ import {
   select,
   type Operation,
   type Channel,
-  clients,
 } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 // Job state is read-only from the polling closure's perspective: a
 // background timer flips `done` exactly once. Calling takePoll multiple
@@ -123,14 +123,14 @@ const modes = [
 
 describe.each(modes)("polling — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [pollingSvc],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -140,14 +140,14 @@ describe.each(modes)("polling — $name mode", ({ alwaysReplay }) => {
   test("pollUntilDone: completes after the job finishes", async () => {
     const jobId = `poll-${alwaysReplay ? "replay" : "default"}`;
     startJob(jobId, 200, "complete");
-    const client = clients.client(ingress, pollingSvc);
+    const client = ingress.client(pollingSvc);
     expect(await client.pollUntilDone(jobId)).toBe("complete");
   });
 
   test("pollWithStop: worker returns the result before budget elapses", async () => {
     const jobId = `stop-fast-${alwaysReplay ? "replay" : "default"}`;
     startJob(jobId, 100, "got-it");
-    const client = clients.client(ingress, pollingSvc);
+    const client = ingress.client(pollingSvc);
     expect(await client.pollWithStop({ jobId, budgetMs: 5_000 })).toBe(
       "got-it"
     );
@@ -158,14 +158,14 @@ describe.each(modes)(
   "polling — channel-based stop — $name mode",
   ({ alwaysReplay }) => {
     let env: RestateTestEnvironment;
-    let ingress: clients.GenIngress;
+    let ingress: Ingress;
 
     beforeAll(async () => {
       env = await RestateTestEnvironment.start({
         services: [pollingSvc],
         alwaysReplay,
       });
-      ingress = clients.connect({ url: env.baseUrl() });
+      ingress = connect({ url: env.baseUrl() });
     });
 
     afterAll(async () => {
@@ -185,7 +185,7 @@ describe.each(modes)(
       // freshly-constructed channel.
       const jobId = `stop-never-${alwaysReplay ? "replay" : "default"}`;
       startJob(jobId, -1, "never-seen");
-      const client = clients.client(ingress, pollingSvc);
+      const client = ingress.client(pollingSvc);
       expect(await client.pollWithStop({ jobId, budgetMs: 250 })).toBeNull();
     });
   }

--- a/packages/libs/restate-sdk-gen/e2e/saga.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/saga.e2e.test.ts
@@ -24,7 +24,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import * as restate from "@restatedev/restate-sdk";
 import { RestateTestEnvironment } from "@restatedev/restate-sdk-testcontainers";
-import { service, run, clients } from "@restatedev/restate-sdk-gen";
+import { service, run } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 const released = new Map<string, number>();
 const released_bump = (key: string): void => {
@@ -92,7 +93,7 @@ const modes = [
 
 describe.each(modes)("saga compensation — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
@@ -102,7 +103,7 @@ describe.each(modes)("saga compensation — $name mode", ({ alwaysReplay }) => {
       disableRetries: true,
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -112,7 +113,7 @@ describe.each(modes)("saga compensation — $name mode", ({ alwaysReplay }) => {
   test("success: all three steps run, no compensation", async () => {
     released.clear();
     const key = `ok-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, sagaSvc);
+    const client = ingress.client(sagaSvc);
     const out = await client.placeOrder({ key });
     expect(out.orderId).toBe(`order-res-${key}-chg-${key}`);
     // Compensation never ran.
@@ -122,7 +123,7 @@ describe.each(modes)("saga compensation — $name mode", ({ alwaysReplay }) => {
   test("charge fails: release compensation runs, original error surfaces", async () => {
     released.clear();
     const key = `charge-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, sagaSvc);
+    const client = ingress.client(sagaSvc);
     await expect(client.placeOrder({ key, failAt: "charge" })).rejects.toThrow(
       /charge failed/
     );
@@ -133,7 +134,7 @@ describe.each(modes)("saga compensation — $name mode", ({ alwaysReplay }) => {
   test("create fails: release compensation runs, original error surfaces", async () => {
     released.clear();
     const key = `create-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, sagaSvc);
+    const client = ingress.client(sagaSvc);
     await expect(client.placeOrder({ key, failAt: "create" })).rejects.toThrow(
       /create failed/
     );
@@ -143,7 +144,7 @@ describe.each(modes)("saga compensation — $name mode", ({ alwaysReplay }) => {
   test("reserve fails: no compensation needed (nothing to undo)", async () => {
     released.clear();
     const key = `reserve-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, sagaSvc);
+    const client = ingress.client(sagaSvc);
     await expect(client.placeOrder({ key, failAt: "reserve" })).rejects.toThrow(
       /reserve failed/
     );

--- a/packages/libs/restate-sdk-gen/e2e/signal-sharing.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/signal-sharing.e2e.test.ts
@@ -40,12 +40,16 @@ import {
   allSettled,
   race,
   invocation,
-  clients,
 } from "@restatedev/restate-sdk-gen";
+import {
+  connect,
+  type Ingress,
+  SendOpts,
+} from "@restatedev/restate-sdk-clients";
 
 let idempotencyKeySeq = 0;
 const idem = () =>
-  clients.SendOpts.from<void>({
+  SendOpts.from<void>({
     idempotencyKey: `test-${++idempotencyKeySeq}`,
   });
 
@@ -139,14 +143,14 @@ describe.each(modes)(
   "signal-sharing combinators — $name mode",
   ({ alwaysReplay }) => {
     let env: RestateTestEnvironment;
-    let ingress: clients.GenIngress;
+    let ingress: Ingress;
 
     beforeAll(async () => {
       env = await RestateTestEnvironment.start({
         services: [combinatorSvc, signalSenderSvc],
         alwaysReplay,
       });
-      ingress = clients.connect({ url: env.baseUrl() });
+      ingress = connect({ url: env.baseUrl() });
     });
 
     afterAll(async () => {
@@ -154,7 +158,7 @@ describe.each(modes)(
     });
 
     const sendSignal = (invocationId: string, name: string, value: string) =>
-      clients.client(ingress, signalSenderSvc).resolve({
+      ingress.client(signalSenderSvc).resolve({
         invocationId,
         name,
         value,
@@ -163,8 +167,8 @@ describe.each(modes)(
     // ---- scenario 1: allSettled(race(p1, p2), race(p1, p3)) ----------------
 
     test("allSettled — p1 fires first: both races settle with p1's value", async () => {
-      const handle = await clients
-        .sendClient(ingress, combinatorSvc)
+      const handle = await ingress
+        .sendClient(combinatorSvc)
         .allSettledSharedSignal(idem());
       const invocationId = handle.invocationId;
 
@@ -184,8 +188,8 @@ describe.each(modes)(
     }, 30_000);
 
     test("allSettled — p2 fires first on race1, p3 fires first on race2", async () => {
-      const handle = await clients
-        .sendClient(ingress, combinatorSvc)
+      const handle = await ingress
+        .sendClient(combinatorSvc)
         .allSettledSharedSignal(idem());
       const invocationId = handle.invocationId;
 
@@ -208,8 +212,8 @@ describe.each(modes)(
     // ---- scenario 2: all(race(p1→throws, p2), race(p1, p3)) ---------------
 
     test("all — p1 fires first: spawned transform throws, all rejects", async () => {
-      const handle = await clients
-        .sendClient(ingress, combinatorSvc)
+      const handle = await ingress
+        .sendClient(combinatorSvc)
         .allWithMappedSignal(idem());
       const invocationId = handle.invocationId;
 
@@ -222,8 +226,8 @@ describe.each(modes)(
     }, 30_000);
 
     test("all — p2 fires first on race1: all resolves with both values", async () => {
-      const handle = await clients
-        .sendClient(ingress, combinatorSvc)
+      const handle = await ingress
+        .sendClient(combinatorSvc)
         .allWithMappedSignal(idem());
       const invocationId = handle.invocationId;
 
@@ -233,7 +237,7 @@ describe.each(modes)(
       // p1 fires last — the races already settled without it.
       await sendSignal(invocationId, "p1", "from-p1");
 
-      const result = (await ingress.result(handle)) as string[];
+      const result = await ingress.result(handle);
       expect(result).toHaveLength(2);
       expect(result[0]).toBe("from-p2");
       expect(result[1]).toBe("from-p3");

--- a/packages/libs/restate-sdk-gen/e2e/state.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/state.e2e.test.ts
@@ -27,12 +27,8 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { RestateTestEnvironment } from "@restatedev/restate-sdk-testcontainers";
-import {
-  object,
-  state,
-  sharedState,
-  clients,
-} from "@restatedev/restate-sdk-gen";
+import { object, state, sharedState } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 // Typed-state shape for the counter object. Keys and value types here
 // flow through to state<CounterState>() at every call site below.
@@ -91,14 +87,14 @@ const modes = [
 
 describe.each(modes)("state — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
       services: [counterObj],
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -107,7 +103,7 @@ describe.each(modes)("state — $name mode", ({ alwaysReplay }) => {
 
   test("get/set: counter accumulates across calls", async () => {
     const key = `acc-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, counterObj, key);
+    const client = ingress.client(counterObj, key);
     expect(await client.add(1)).toBe(1);
     expect(await client.add(2)).toBe(3);
     expect(await client.add(7)).toBe(10);
@@ -117,8 +113,8 @@ describe.each(modes)("state — $name mode", ({ alwaysReplay }) => {
   test("isolation: each VO key has independent state", async () => {
     const k1 = `iso1-${alwaysReplay ? "replay" : "default"}`;
     const k2 = `iso2-${alwaysReplay ? "replay" : "default"}`;
-    const c1 = clients.client(ingress, counterObj, k1);
-    const c2 = clients.client(ingress, counterObj, k2);
+    const c1 = ingress.client(counterObj, k1);
+    const c2 = ingress.client(counterObj, k2);
     await c1.add(5);
     await c2.add(11);
     expect(await c1.current()).toBe(5);
@@ -127,7 +123,7 @@ describe.each(modes)("state — $name mode", ({ alwaysReplay }) => {
 
   test("keys(): lists all set keys, drops cleared ones", async () => {
     const key = `keys-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, counterObj, key);
+    const client = ingress.client(counterObj, key);
     await client.add(1);
     await client.setSecondary("hello");
     expect((await client.keys()).sort()).toEqual(["count", "secondary"]);
@@ -137,7 +133,7 @@ describe.each(modes)("state — $name mode", ({ alwaysReplay }) => {
 
   test("clearAll: wipes all state for this object", async () => {
     const key = `clear-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, counterObj, key);
+    const client = ingress.client(counterObj, key);
     await client.add(42);
     await client.setSecondary("alongside");
     expect((await client.keys()).sort()).toEqual(["count", "secondary"]);

--- a/packages/libs/restate-sdk-gen/e2e/terminal-errors.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/terminal-errors.e2e.test.ts
@@ -26,12 +26,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import * as restate from "@restatedev/restate-sdk";
 import { RestateTestEnvironment } from "@restatedev/restate-sdk-testcontainers";
-import {
-  service,
-  run,
-  type Operation,
-  clients,
-} from "@restatedev/restate-sdk-gen";
+import { service, run, type Operation } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 // Module-scope counters: handlers record how many times their throwing
 // code path executed. Cleared per-test inside describe.each blocks.
@@ -71,7 +67,7 @@ const modes = [
 
 describe.each(modes)("terminal errors — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
@@ -81,7 +77,7 @@ describe.each(modes)("terminal errors — $name mode", ({ alwaysReplay }) => {
       disableRetries: true,
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -91,7 +87,7 @@ describe.each(modes)("terminal errors — $name mode", ({ alwaysReplay }) => {
   test("inside ops.run", async () => {
     attempts.clear();
     const key = `inside-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, terminalSvc);
+    const client = ingress.client(terminalSvc);
     await expect(client.insideRun(key)).rejects.toThrow(/inside-run-fatal/);
     // Closure ran exactly once — terminal errors don't retry, and the
     // journaled terminal outcome is replayed (not re-executed) under
@@ -102,7 +98,7 @@ describe.each(modes)("terminal errors — $name mode", ({ alwaysReplay }) => {
   test("outside ops.run (raw throw in the gen body)", async () => {
     attempts.clear();
     const key = `outside-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, terminalSvc);
+    const client = ingress.client(terminalSvc);
     await expect(client.outsideRun(key)).rejects.toThrow(/outside-run-fatal/);
     // No journal entries before the throw → no suspension → no replay
     // even in alwaysReplay mode. Body runs exactly once.

--- a/packages/libs/restate-sdk-gen/e2e/transient-errors.e2e.test.ts
+++ b/packages/libs/restate-sdk-gen/e2e/transient-errors.e2e.test.ts
@@ -26,12 +26,8 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { RestateTestEnvironment } from "@restatedev/restate-sdk-testcontainers";
-import {
-  service,
-  run,
-  type Operation,
-  clients,
-} from "@restatedev/restate-sdk-gen";
+import { service, run, type Operation } from "@restatedev/restate-sdk-gen";
+import { connect, type Ingress } from "@restatedev/restate-sdk-clients";
 
 const attempts = new Map<string, number>();
 const bump = (key: string): number => {
@@ -95,7 +91,7 @@ const modes = [
 
 describe.each(modes)("transient errors — $name mode", ({ alwaysReplay }) => {
   let env: RestateTestEnvironment;
-  let ingress: clients.GenIngress;
+  let ingress: Ingress;
 
   beforeAll(async () => {
     env = await RestateTestEnvironment.start({
@@ -103,7 +99,7 @@ describe.each(modes)("transient errors — $name mode", ({ alwaysReplay }) => {
       // Retries must be enabled — that's the whole point.
       alwaysReplay,
     });
-    ingress = clients.connect({ url: env.baseUrl() });
+    ingress = connect({ url: env.baseUrl() });
   });
 
   afterAll(async () => {
@@ -113,7 +109,7 @@ describe.each(modes)("transient errors — $name mode", ({ alwaysReplay }) => {
   test("inside ops.run: closure retries, eventually returns", async () => {
     attempts.clear();
     const key = `inside-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, transientSvc);
+    const client = ingress.client(transientSvc);
     expect(await client.insideRun(key)).toBe("ok-after-3");
     // Closure ran exactly 3 times — once-success is journaled and not
     // re-run on subsequent replays.
@@ -123,7 +119,7 @@ describe.each(modes)("transient errors — $name mode", ({ alwaysReplay }) => {
   test("outside ops.run: whole handler retries, eventually returns", async () => {
     attempts.clear();
     const key = `outside-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, transientSvc);
+    const client = ingress.client(transientSvc);
     expect(await client.outsideRun(key)).toBe("ok-after-3");
     // The body's bump() is non-journaled state. In default mode it
     // runs once per retry up to success → exactly 3. In alwaysReplay
@@ -136,7 +132,7 @@ describe.each(modes)("transient errors — $name mode", ({ alwaysReplay }) => {
   test("bounded retry: maxRetryAttempts hit → TerminalError", async () => {
     attempts.clear();
     const key = `bounded-${alwaysReplay ? "replay" : "default"}`;
-    const client = clients.client(ingress, transientSvc);
+    const client = ingress.client(transientSvc);
     await expect(client.boundedRetry(key)).rejects.toThrow(/doomed/);
     // 2 attempts before the SDK gives up.
     expect(attempts.get(key)).toBe(2);

--- a/packages/libs/restate-sdk-gen/src/define.ts
+++ b/packages/libs/restate-sdk-gen/src/define.ts
@@ -12,108 +12,38 @@
 
 import * as restate from "@restatedev/restate-sdk";
 import type { StandardSchemaV1 } from "@restatedev/restate-sdk-core";
+import {
+  type HandlerDescriptor,
+  type Descriptor,
+  type ServiceDescriptor,
+  type ObjectDescriptor,
+  type WorkflowDescriptor,
+  type ImplementedServiceDefinition,
+  type ImplementedObjectDefinition,
+  type ImplementedWorkflowDefinition,
+  type ImplementedDefinition,
+  makeHandlerDescriptor,
+  serde,
+} from "@restatedev/restate-sdk-core";
 import { execute } from "./restate-operations.js";
 import { type Operation } from "./operation.js";
 import { ServiceHandlerOpts } from "@restatedev/restate-sdk";
 
 // =============================================================================
-// Shared types (consumed here and by interface.ts)
+// Shared interface/descriptor layer — moved to @restatedev/restate-sdk-core and
+// re-exported here so this package's public API is unchanged.
 // =============================================================================
-
-// --- HandlerDescriptor -------------------------------------------------------
-
-/**
- * Minimal descriptor stored in Descriptor._handlers per handler.
- */
-export type HandlerDescriptor<I = any, O = any> = {
-  readonly _inputSerde?: restate.Serde<I>;
-  readonly _outputSerde?: restate.Serde<O>;
+export type {
+  HandlerDescriptor,
+  Descriptor,
+  ServiceDescriptor,
+  ObjectDescriptor,
+  WorkflowDescriptor,
+  ImplementedServiceDefinition,
+  ImplementedObjectDefinition,
+  ImplementedWorkflowDefinition,
+  ImplementedDefinition,
 };
-
-export function makeDescriptor<I, O>(
-  inputSerde?: restate.Serde<I>,
-  outputSerde?: restate.Serde<O>
-): HandlerDescriptor<I, O> {
-  return {
-    _inputSerde: inputSerde,
-    _outputSerde: outputSerde,
-  };
-}
-
-// --- Descriptor -----------------------------------------------------
-
-/**
- * The single client-facing type for all definition styles.
- * - Returned by service() / object() / workflow() (also bindable to serve())
- * - Returned by restate.interface.service/object/workflow (pure, not bindable)
- * - Returned by implement() (also bindable)
- */
-export type Descriptor<
-  P extends string = string,
-  H extends Record<string, HandlerDescriptor> = Record<
-    string,
-    HandlerDescriptor
-  >,
-  Kind extends "service" | "object" | "workflow" =
-    | "service"
-    | "object"
-    | "workflow",
-> = {
-  readonly name: P;
-  readonly _kind: Kind;
-  readonly _handlers: H;
-};
-
-/** Kind-specific aliases for the common Descriptor type */
-export type ServiceDescriptor<
-  P extends string = string,
-  H extends Record<string, HandlerDescriptor> = Record<
-    string,
-    HandlerDescriptor
-  >,
-> = Descriptor<P, H, "service">;
-
-export type ObjectDescriptor<
-  P extends string = string,
-  H extends Record<string, HandlerDescriptor> = Record<
-    string,
-    HandlerDescriptor
-  >,
-> = Descriptor<P, H, "object">;
-
-export type WorkflowDescriptor<
-  P extends string = string,
-  H extends Record<string, HandlerDescriptor> = Record<
-    string,
-    HandlerDescriptor
-  >,
-> = Descriptor<P, H, "workflow">;
-
-/** Implemented definition — extends Descriptor and also bindable to serve() */
-export type ImplementedServiceDefinition<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
-> = restate.ServiceDefinition<P, any> & ServiceDescriptor<P, H>;
-
-export type ImplementedObjectDefinition<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
-> = restate.VirtualObjectDefinition<P, any> & ObjectDescriptor<P, H>;
-
-export type ImplementedWorkflowDefinition<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
-> = restate.WorkflowDefinition<P, any> & WorkflowDescriptor<P, H>;
-
-export type ImplementedDefinition<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
-  Kind extends "service" | "object" | "workflow",
-> = Kind extends "service"
-  ? ImplementedServiceDefinition<P, H>
-  : Kind extends "object"
-    ? ImplementedObjectDefinition<P, H>
-    : ImplementedWorkflowDefinition<P, H>;
 
 // =============================================================================
 // HandlerDef — result of serdes()
@@ -208,11 +138,6 @@ function isHandlerDef(
   );
 }
 
-/** Convert a Standard Schema to a Serde via restate.serde.schema() */
-export function toSerde<T>(schema: StandardSchemaV1<T>): restate.Serde<T> {
-  return restate.serde.schema(schema as any) as restate.Serde<T>;
-}
-
 function extractEntry(entry: HandlerOrHandlerDescriptor): {
   genFn: AnyGenFn;
   inputSerde: restate.Serde<any> | undefined;
@@ -263,8 +188,8 @@ export function schemas<
 > {
   return {
     _genFn: fn as AnyGenFn,
-    _inputSerde: toSerde(opts.input),
-    _outputSerde: toSerde(opts.output),
+    _inputSerde: serde.schema(opts.input),
+    _outputSerde: serde.schema(opts.output),
   };
 }
 
@@ -300,7 +225,7 @@ export function service<
       async (ctx: restate.Context, input: any) => execute(ctx, genFn(input))
     );
 
-    descriptors[handlerName] = makeDescriptor(inputSerde, outputSerde);
+    descriptors[handlerName] = makeHandlerDescriptor(inputSerde, outputSerde);
   }
 
   const coreDef = restate.service({
@@ -359,7 +284,7 @@ export function object<
       ? restate.handlers.object.shared(sdkOpts, fn as any)
       : restate.handlers.object.exclusive(sdkOpts, fn as any);
 
-    descriptors[handlerName] = makeDescriptor(inputSerde, outputSerde);
+    descriptors[handlerName] = makeHandlerDescriptor(inputSerde, outputSerde);
   }
 
   const coreDef = restate.object({
@@ -418,7 +343,7 @@ export function workflow<
         ? restate.handlers.workflow.workflow(sdkOpts, fn as any)
         : restate.handlers.workflow.shared(sdkOpts, fn as any);
 
-    descriptors[handlerName] = makeDescriptor(inputSerde, outputSerde);
+    descriptors[handlerName] = makeHandlerDescriptor(inputSerde, outputSerde);
   }
 
   const coreDef = restate.workflow({

--- a/packages/libs/restate-sdk-gen/src/index.ts
+++ b/packages/libs/restate-sdk-gen/src/index.ts
@@ -97,10 +97,14 @@ export {
   type GenWorkflowHandlerOpts,
 } from "./define.js";
 
-// Interface / implement pattern
+// Interface / implement pattern.
+// The declarators/factories (`service`/`object`/`workflow`/`json`/`serdes`/
+// `schemas`/`shared`) live in @restatedev/restate-sdk-core; `implement` is
+// generator-specific and lives here. Merge them under one `iface` namespace.
 export { implement } from "./interface.js";
-import * as _iface from "./interface.js";
-export { _iface as iface };
+import { iface as _coreIface } from "@restatedev/restate-sdk-core";
+import { implement as _implement } from "./interface.js";
+export const iface = { ..._coreIface, implement: _implement };
 
 // Ingress adapters, exported as `clients` namespace
 import * as _ingress from "./ingress.js";
@@ -125,6 +129,8 @@ export type {
   VirtualObjectDefinition,
   Duration,
   StandardTypedV1,
+  ServiceInterface,
+  SerdeType,
 } from "@restatedev/restate-sdk-core";
 
 export type { ContextDate, Rand } from "@restatedev/restate-sdk";

--- a/packages/libs/restate-sdk-gen/src/ingress.ts
+++ b/packages/libs/restate-sdk-gen/src/ingress.ts
@@ -8,7 +8,25 @@
  * directory of this repository or package, or at
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument */
+
+/**
+ * @deprecated The `clients` ingress adapter is superseded by
+ * `@restatedev/restate-sdk-clients`. The service interface / `Descriptor`
+ * values produced by this package (`service`/`object`/`workflow`/`iface` /
+ * `implement`) are now first-class inputs to that package's ingress client,
+ * which reuses their declared serdes automatically:
+ *
+ * ```ts
+ * import { connect } from "@restatedev/restate-sdk-clients";
+ * const ingress = connect({ url });
+ * await ingress.client(greeter).greet(req);       // service
+ * await ingress.client(counter, "k").add(1);      // virtual object / workflow (with key)
+ * ```
+ *
+ * Every export here now delegates to that client and will be removed in a
+ * future release.
+ */
 
 import {
   Opts,
@@ -44,28 +62,18 @@ export {
 };
 
 /**
- * Connect to the Restate Ingress.
- *
- * @param opts connection options
- * @returns a connection the the restate ingress
+ * @deprecated Use `connect` from `@restatedev/restate-sdk-clients` and its typed
+ * client methods, e.g. `connect({ url }).serviceClient(def)`
  */
 export function connect(opts: ConnectionOpts): GenIngress {
   return clientsConnect(opts);
 }
 
 /**
- * Minimal ingress interface required by the sdk-gen ingress helpers.
- * Structurally compatible with `Ingress` from `@restatedev/restate-sdk-clients`
- * — any object returned by `connect()` satisfies this.
+ * @deprecated Use `connect` from `@restatedev/restate-sdk-clients` and its typed
+ * client methods, e.g. `connect({ url }).serviceClient(def)`
  */
-export type GenIngress = Omit<
-  Ingress,
-  | "serviceClient"
-  | "serviceSendClient"
-  | "objectClient"
-  | "objectSendClient"
-  | "workflowClient"
->;
+export type GenIngress = Ingress;
 
 // =============================================================================
 // Typed ingress client types
@@ -74,7 +82,12 @@ export type GenIngress = Omit<
 type InferInput<D> = D extends HandlerDescriptor<infer I, any> ? I : unknown;
 type InferOutput<D> = D extends HandlerDescriptor<any, infer O> ? O : unknown;
 
-/** Typed ingress call client — each method returns Promise<O> */
+/**
+ * Typed ingress call client — each method returns Promise<O>.
+ *
+ * @deprecated Use the client returned by `ingress.serviceClient(def)` /
+ * `ingress.objectClient(def, key)` from `@restatedev/restate-sdk-clients`.
+ */
 export type IngressHandlerClient<H extends Record<string, HandlerDescriptor>> =
   {
     readonly [K in keyof H]: (
@@ -83,7 +96,12 @@ export type IngressHandlerClient<H extends Record<string, HandlerDescriptor>> =
     ) => Promise<InferOutput<H[K]>>;
   };
 
-/** Typed ingress send client — each method returns Promise<Send> */
+/**
+ * Typed ingress send client — each method returns Promise<Send>.
+ *
+ * @deprecated Use the client returned by `ingress.serviceSendClient(def)` /
+ * `ingress.objectSendClient(def, key)` from `@restatedev/restate-sdk-clients`.
+ */
 export type IngressSendHandlerClient<
   H extends Record<string, HandlerDescriptor>,
 > = {
@@ -96,9 +114,13 @@ export type IngressSendHandlerClient<
 };
 
 // =============================================================================
-// client / sendClient
+// client / sendClient — thin wrappers over the regular ingress client.
 // =============================================================================
 
+/**
+ * @deprecated Call the regular ingress client directly: `ingress.client(def)`
+ * for a service, or `ingress.client(def, key)` for a virtual object / workflow.
+ */
 export function client<H extends Record<string, HandlerDescriptor>>(
   ingress: GenIngress,
   def: Descriptor<string, H, "service">
@@ -113,9 +135,15 @@ export function client(
   def: Descriptor<string, any, any>,
   key?: string
 ): IngressHandlerClient<any> {
-  return makeIngressClient(ingress, def, key);
+  return (key === undefined
+    ? ingress.client(def as any)
+    : ingress.client(def as any, key)) as unknown as IngressHandlerClient<any>;
 }
 
+/**
+ * @deprecated Call the regular ingress client directly: `ingress.sendClient(def)`
+ * for a service, or `ingress.sendClient(def, key)` for a virtual object / workflow.
+ */
 export function sendClient<H extends Record<string, HandlerDescriptor>>(
   ingress: GenIngress,
   def: Descriptor<string, H, "service">
@@ -130,13 +158,17 @@ export function sendClient(
   def: Descriptor<string, any, any>,
   key?: string
 ): IngressSendHandlerClient<any> {
-  return makeIngressSendClient(ingress, def, key);
+  return (key === undefined
+    ? ingress.sendClient(def as any)
+    : ingress.sendClient(
+        def as any,
+        key
+      )) as unknown as IngressSendHandlerClient<any>;
 }
 
 /**
- * Ingress client bundle bound to a specific scope, returned by {@link scope}.
- * Mirrors the in-handler `scope(...)` surface: same `client`/`sendClient`
- * overloads, but every call/send routes within the bound scope.
+ * @deprecated Use `ingress.scope(scopeKey)` from
+ * `@restatedev/restate-sdk-clients` and its `client`/`sendClient` methods.
  */
 export interface ScopedGenIngress {
   client<H extends Record<string, HandlerDescriptor>>(
@@ -156,117 +188,20 @@ export interface ScopedGenIngress {
 }
 
 /**
- * Route all ingress calls/sends through a named scope. The in-handler
- * `scope(scopeKey)` and this `scope(ingress, scopeKey)` produce the same
- * `.client(def)` / `.sendClient(def)` shape, so handler and ingress code
- * read identically (modulo the explicit `ingress`).
- *
- * @example
- *   await clients.scope(ingress, "tenant-123").client(Greeter).greet(name);
- *   await clients.scope(ingress, "tenant-123").client(Cart, "cart-42").add(item);
+ * @deprecated Use `ingress.scope(scopeKey)` from
+ * `@restatedev/restate-sdk-clients`, then `.client(def)` / `.sendClient(def)`
+ * on the returned scoped ingress.
  */
 export function scope(ingress: GenIngress, scopeKey: string): ScopedGenIngress {
+  const scoped = ingress.scope(scopeKey);
   return {
     client: (def: Descriptor<string, any, any>, key?: string) =>
-      makeIngressClient(ingress, def, key, scopeKey),
+      (key === undefined
+        ? scoped.client(def as any)
+        : scoped.client(def as any, key)) as unknown,
     sendClient: (def: Descriptor<string, any, any>, key?: string) =>
-      makeIngressSendClient(ingress, def, key, scopeKey),
+      (key === undefined
+        ? scoped.sendClient(def as any)
+        : scoped.sendClient(def as any, key)) as unknown,
   } as ScopedGenIngress;
-}
-
-function makeIngressClient(
-  ingress: GenIngress,
-  def: Descriptor<string, any, any>,
-  key?: string,
-  scope?: string
-): IngressHandlerClient<any> {
-  return new Proxy({} as any, {
-    get(_target, methodName: string) {
-      return (...args: unknown[]) => {
-        const { parameter, opts } = optsFromArgs(args);
-        const desc = def._handlers[methodName] as HandlerDescriptor | undefined;
-        const mergedOpts = Opts.from({
-          ...opts?.opts,
-          input: opts?.opts?.input ?? desc?._inputSerde,
-          output: opts?.opts?.output ?? desc?._outputSerde,
-        });
-        return ingress.call<unknown, unknown>({
-          service: def.name,
-          handler: methodName,
-          parameter,
-          key,
-          scope,
-          opts: mergedOpts,
-        });
-      };
-    },
-  });
-}
-
-function makeIngressSendClient(
-  ingress: GenIngress,
-  def: Descriptor<string, any, any>,
-  key?: string,
-  scope?: string
-): IngressSendHandlerClient<any> {
-  return new Proxy({} as any, {
-    get(_target, methodName: string) {
-      return (...args: unknown[]) => {
-        const { parameter, opts } = optsFromArgs(args);
-        const desc = def._handlers[methodName] as HandlerDescriptor | undefined;
-        const mergedOpts = SendOpts.from<unknown>({
-          ...opts?.opts,
-          input: opts?.opts?.input ?? desc?._inputSerde,
-        } as any);
-        return ingress.send({
-          service: def.name,
-          handler: methodName,
-          parameter,
-          key,
-          scope,
-          opts: mergedOpts,
-        });
-      };
-    },
-  });
-}
-
-// =============================================================================
-// optsFromArgs — parses (input, opts?) or (opts?) call signatures
-// =============================================================================
-
-function optsFromArgs(args: unknown[]): {
-  parameter?: unknown;
-  opts?: Opts<unknown, unknown> | SendOpts<unknown>;
-} {
-  let parameter: unknown;
-  let opts: Opts<unknown, unknown> | SendOpts<unknown> | undefined;
-  switch (args.length) {
-    case 0:
-      break;
-    case 1:
-      if (args[0] instanceof Opts) {
-        opts = args[0];
-      } else if (args[0] instanceof SendOpts) {
-        opts = args[0];
-      } else {
-        parameter = args[0];
-      }
-      break;
-    case 2:
-      parameter = args[0];
-      if (args[1] instanceof Opts) {
-        opts = args[1];
-      } else if (args[1] instanceof SendOpts) {
-        opts = args[1];
-      } else {
-        throw new TypeError(
-          "The second argument must be either Opts or SendOpts"
-        );
-      }
-      break;
-    default:
-      throw new TypeError("unexpected number of arguments");
-  }
-  return { parameter, opts };
 }

--- a/packages/libs/restate-sdk-gen/src/interface.ts
+++ b/packages/libs/restate-sdk-gen/src/interface.ts
@@ -8,105 +8,42 @@
  * directory of this repository or package, or at
  * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment */
 
 import type * as restate from "@restatedev/restate-sdk";
-import type { StandardSchemaV1 } from "@restatedev/restate-sdk-core";
-import type { Operation } from "./operation.js";
 import {
   type HandlerDescriptor,
   type Descriptor,
+  type ServiceDescriptor,
+  type ObjectDescriptor,
+  type WorkflowDescriptor,
+  type ImplementedServiceDefinition,
+  type ImplementedObjectDefinition,
+  type ImplementedWorkflowDefinition,
   type ImplementedDefinition,
+  type InferInput,
+  type InferOutput,
+} from "@restatedev/restate-sdk-core";
+import type { Operation } from "./operation.js";
+import {
   type GenHandlerOpts,
   type GenObjectHandlerOpts,
   type GenWorkflowHandlerOpts,
-  makeDescriptor,
-  toSerde,
   service as _defineService,
   object as _defineObject,
   workflow as _defineWorkflow,
-  ObjectDescriptor,
-  WorkflowDescriptor,
-  ServiceDescriptor,
-  ImplementedServiceDefinition,
-  ImplementedObjectDefinition,
-  ImplementedWorkflowDefinition,
 } from "./define.js";
 
-// =============================================================================
-// restate.interface descriptor helpers — no fn, type info only
-// =============================================================================
-
-/** json<I, O>() — type params, default JSON serde */
-export function json<I = void, O = void>(): HandlerDescriptor<I, O> {
-  return makeDescriptor<I, O>(undefined, undefined);
-}
-
-/** serdes(opts) — explicit Serde per field */
-export function serdes<
-  SI extends restate.Serde<any>,
-  SO extends restate.Serde<any>,
->(opts: {
-  input?: SI;
-  output?: SO;
-}): HandlerDescriptor<
-  SI extends restate.Serde<infer I> ? I : never,
-  SO extends restate.Serde<infer O> ? O : never
-> {
-  return makeDescriptor(opts.input, opts.output) as HandlerDescriptor<any, any>;
-}
-
-/** schemas(opts) — Standard Schema (Zod, TypeBox, Valibot, …) per field */
-export function schemas<
-  SI extends StandardSchemaV1<any>,
-  SO extends StandardSchemaV1<any>,
->(opts: {
-  input?: SI;
-  output?: SO;
-}): HandlerDescriptor<
-  StandardSchemaV1.InferOutput<NonNullable<SI>>,
-  StandardSchemaV1.InferOutput<NonNullable<SO>>
-> {
-  return makeDescriptor(
-    opts.input ? toSerde(opts.input) : undefined,
-    opts.output ? toSerde(opts.output) : undefined
-  ) as HandlerDescriptor<any, any>;
-}
+// The pure interface declarators (`json`/`serdes`/`schemas`) and the
+// `iface.service/object/workflow` factories now live in
+// @restatedev/restate-sdk-core and are re-exported through this package's
+// `iface` namespace (see index.ts). InferInput/InferOutput are re-exported for
+// API Extractor traceability.
+export type { InferInput, InferOutput };
 
 // =============================================================================
-// restate.interface.service / object / workflow
+// implement() — bind generator handlers to a service interface (contract)
 // =============================================================================
-
-export function service<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
->(name: P, handlers: H): ServiceDescriptor<P, H> {
-  return { name, _kind: "service", _handlers: handlers };
-}
-
-export function object<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
->(name: P, handlers: H): ObjectDescriptor<P, H> {
-  return { name, _kind: "object", _handlers: handlers };
-}
-
-export function workflow<
-  P extends string,
-  H extends Record<string, HandlerDescriptor>,
->(name: P, handlers: H): WorkflowDescriptor<P, H> {
-  return { name, _kind: "workflow", _handlers: handlers };
-}
-
-// =============================================================================
-// implement() — standalone free function
-// =============================================================================
-
-/** @internal */
-export type InferInput<D> = D extends HandlerDescriptor<infer I, any> ? I : any;
-/** @internal */
-export type InferOutput<D> =
-  D extends HandlerDescriptor<any, infer O> ? O : any;
 
 /** @internal */
 export type ImplementHandlers<H extends Record<string, HandlerDescriptor>> = {

--- a/packages/libs/restate-sdk-gen/test/clients-scope.test.ts
+++ b/packages/libs/restate-sdk-gen/test/clients-scope.test.ts
@@ -13,7 +13,6 @@
 
 import { describe, expect, test } from "vitest";
 import * as restate from "@restatedev/restate-sdk";
-import { Opts as IngressOpts } from "@restatedev/restate-sdk-clients";
 import { service, object } from "../src/index.js";
 import { makeClient, makeSendClient } from "../src/clients.js";
 import {
@@ -119,67 +118,114 @@ describe("in-handler client — scope + limitKey threading", () => {
   });
 });
 
-describe("ingress client — scope threading", () => {
-  function fakeIngress(): { ingress: GenIngress; calls: any[]; sends: any[] } {
-    const calls: any[] = [];
-    const sends: any[] = [];
+// The (deprecated) ingress adapter now delegates to the regular ingress
+// client's `client`/`sendClient` factory: a service forwards with no key, a
+// virtual object / workflow with its key, and `scope(...)` to `ingress.scope`.
+describe("ingress client — delegates to the regular ingress client", () => {
+  function fakeIngress(): { ingress: GenIngress; invocations: any[] } {
+    const invocations: any[] = [];
+    const handlerProxy = (
+      kind: "call" | "send",
+      def: any,
+      key: string | undefined,
+      scope: string | undefined
+    ) =>
+      new Proxy(
+        {},
+        {
+          get:
+            (_t, handler: string) =>
+            (...args: any[]) => {
+              invocations.push({
+                kind,
+                service: def.name,
+                handler,
+                key,
+                scope,
+                args,
+              });
+              return Promise.resolve(undefined);
+            },
+        }
+      );
+    const scopedFor = (scope: string | undefined) => ({
+      client: (def: any, key?: string) => handlerProxy("call", def, key, scope),
+      sendClient: (def: any, key?: string) =>
+        handlerProxy("send", def, key, scope),
+    });
     const ingress = {
-      call: (opts: any) => {
-        calls.push(opts);
-        return Promise.resolve(undefined);
-      },
-      send: (opts: any) => {
-        sends.push(opts);
-        return Promise.resolve(undefined);
-      },
+      ...scopedFor(undefined),
+      scope: (scopeKey: string) => scopedFor(scopeKey),
     } as unknown as GenIngress;
-    return { ingress, calls, sends };
+    return { ingress, invocations };
   }
 
-  test("scope(ingress, key).client(def) stamps scope on the request", async () => {
-    const { ingress, calls } = fakeIngress();
+  test("client(def) forwards a service with no key", async () => {
+    const { ingress, invocations } = fakeIngress();
 
-    await ingressScope(ingress, "tenant-1").client(greeter).greet("sam");
+    await ingressClient(ingress, greeter).greet("sam");
 
-    expect(calls).toHaveLength(1);
-    expect(calls[0].service).toBe("greeter");
-    expect(calls[0].handler).toBe("greet");
-    expect(calls[0].scope).toBe("tenant-1");
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toMatchObject({
+      kind: "call",
+      service: "greeter",
+      handler: "greet",
+      key: undefined,
+      scope: undefined,
+    });
   });
 
-  test("scope(ingress, key).client(def, key) carries object key + scope", async () => {
-    const { ingress, calls } = fakeIngress();
+  test("client(def, key) forwards an object with its key", async () => {
+    const { ingress, invocations } = fakeIngress();
 
-    await ingressScope(ingress, "tenant-1").client(counter, "obj-key").add(1);
+    await ingressClient(ingress, counter, "obj-key").add(1);
 
-    expect(calls[0].key).toBe("obj-key");
-    expect(calls[0].scope).toBe("tenant-1");
+    expect(invocations[0]).toMatchObject({
+      kind: "call",
+      service: "counter",
+      handler: "add",
+      key: "obj-key",
+      scope: undefined,
+    });
   });
 
-  test("scope(ingress, key).sendClient(def) stamps scope on the send", async () => {
-    const { ingress, sends } = fakeIngress();
-
-    await ingressScope(ingress, "tenant-1").sendClient(greeter).greet("sam");
-
-    expect(sends[0].scope).toBe("tenant-1");
-  });
-
-  test("unscoped ingress client leaves scope undefined", async () => {
-    const { ingress, calls } = fakeIngress();
-
-    await ingressClient(ingress, greeter).greet(
-      "sam",
-      IngressOpts.from({ idempotencyKey: "k" })
-    );
-
-    expect(calls[0].scope).toBeUndefined();
-  });
-
-  test("unscoped ingress sendClient leaves scope undefined", async () => {
-    const { ingress, sends } = fakeIngress();
+  test("sendClient(def) forwards a service send", async () => {
+    const { ingress, invocations } = fakeIngress();
 
     await ingressSendClient(ingress, greeter).greet("sam");
 
-    expect(sends[0].scope).toBeUndefined();
+    expect(invocations[0]).toMatchObject({ kind: "send", scope: undefined });
+  });
+
+  test("scope(ingress, key).client(def) threads the scope", async () => {
+    const { ingress, invocations } = fakeIngress();
+
+    await ingressScope(ingress, "tenant-1").client(greeter).greet("sam");
+
+    expect(invocations[0]).toMatchObject({
+      kind: "call",
+      service: "greeter",
+      handler: "greet",
+      scope: "tenant-1",
+    });
+  });
+
+  test("scope(ingress, key).client(def, key) carries object key + scope", async () => {
+    const { ingress, invocations } = fakeIngress();
+
+    await ingressScope(ingress, "tenant-1").client(counter, "obj-key").add(1);
+
+    expect(invocations[0]).toMatchObject({
+      key: "obj-key",
+      scope: "tenant-1",
+    });
+  });
+
+  test("scope(ingress, key).sendClient(def) threads the scope", async () => {
+    const { ingress, invocations } = fakeIngress();
+
+    await ingressScope(ingress, "tenant-1").sendClient(greeter).greet("sam");
+
+    expect(invocations[0]).toMatchObject({ kind: "send", scope: "tenant-1" });
   });
 });

--- a/packages/libs/restate-sdk/src/common_api.ts
+++ b/packages/libs/restate-sdk/src/common_api.ts
@@ -74,6 +74,8 @@ export { serde } from "@restatedev/restate-sdk-core";
 export type {
   Client,
   SendClient,
+  ClientFromDescriptors,
+  SendClientFromDescriptors,
   ClientCallOptions,
   ClientSendOptions,
   RemoveVoidArgument,
@@ -105,6 +107,39 @@ export type {
   VirtualObjectDefinition,
   WorkflowDefinition,
 } from "@restatedev/restate-sdk-core";
+
+export { iface } from "@restatedev/restate-sdk-core";
+export type {
+  ServiceInterface,
+  HandlerDescriptor,
+  Descriptor,
+  ServiceDescriptor,
+  ObjectDescriptor,
+  WorkflowDescriptor,
+  ImplementedServiceDefinition,
+  ImplementedObjectDefinition,
+  ImplementedWorkflowDefinition,
+  ImplementedDefinition,
+  InferInput,
+  InferOutput,
+} from "@restatedev/restate-sdk-core";
+export { implement } from "./types/interface.js";
+export type {
+  /** @internal */
+  FnOf,
+  /** @internal */
+  ServiceImplHandlers,
+  /** @internal */
+  ObjectImplHandlers,
+  /** @internal */
+  WorkflowImplHandlers,
+  /** @internal */
+  ServicePerHandlerOpts,
+  /** @internal */
+  ObjectPerHandlerOpts,
+  /** @internal */
+  WorkflowPerHandlerOpts,
+} from "./types/interface.js";
 
 export type {
   RestateEndpoint,

--- a/packages/libs/restate-sdk/src/context.ts
+++ b/packages/libs/restate-sdk/src/context.ts
@@ -12,6 +12,8 @@
 import type {
   Client,
   SendClient,
+  ClientFromDescriptors,
+  SendClientFromDescriptors,
   //eslint-disable-next-line @typescript-eslint/no-unused-vars
   ClientCallOptions,
 } from "./types/rpc.js";
@@ -29,6 +31,10 @@ import type {
   WorkflowDefinitionFrom,
   Serde,
   Duration,
+  HandlerDescriptor,
+  ServiceDescriptor,
+  ObjectDescriptor,
+  WorkflowDescriptor,
 } from "@restatedev/restate-sdk-core";
 import type { TerminalError } from "./types/errors.js";
 import {
@@ -324,6 +330,8 @@ export type ScopedContext = Pick<
   | "objectSendClient"
   | "workflowClient"
   | "workflowSendClient"
+  | "client"
+  | "sendClient"
 >;
 
 /**
@@ -631,6 +639,44 @@ export interface Context extends RestateContext {
     obj: VirtualObjectDefinitionFrom<D>,
     key: string
   ): SendClient<VirtualObject<D>>;
+
+  /**
+   * Create a request/response client from a service interface / `Descriptor`.
+   *
+   * @example
+   * ```ts
+   * ctx.client(greeter).greet(req);        // service
+   * ctx.client(counter, "k").add(1);       // virtual object / workflow
+   * ```
+   */
+  client<P extends string, H extends Record<string, HandlerDescriptor>>(
+    serviceInterface: ServiceDescriptor<P, H>
+  ): ClientFromDescriptors<H>;
+  client<P extends string, H extends Record<string, HandlerDescriptor>>(
+    objectOrWorkflowInterface:
+      | ObjectDescriptor<P, H>
+      | WorkflowDescriptor<P, H>,
+    key: string
+  ): ClientFromDescriptors<H>;
+
+  /**
+   * Send-client (one-way) counterpart of {@link Context.client}.
+   *
+   * @example
+   * ```ts
+   * ctx.sendClient(greeter).greet(req);
+   * ctx.sendClient(counter, "k").add(1);
+   * ```
+   */
+  sendClient<P extends string, H extends Record<string, HandlerDescriptor>>(
+    serviceInterface: ServiceDescriptor<P, H>
+  ): SendClientFromDescriptors<H>;
+  sendClient<P extends string, H extends Record<string, HandlerDescriptor>>(
+    objectOrWorkflowInterface:
+      | ObjectDescriptor<P, H>
+      | WorkflowDescriptor<P, H>,
+    key: string
+  ): SendClientFromDescriptors<H>;
 
   /**
    * Returns a {@link ScopedContext} that routes all outgoing calls within the given scope.

--- a/packages/libs/restate-sdk/src/context_impl.ts
+++ b/packages/libs/restate-sdk/src/context_impl.ts
@@ -45,7 +45,6 @@ import {
   TerminalError,
   UNKNOWN_ERROR_CODE,
 } from "./types/errors.js";
-import type { Client, SendClient } from "./types/rpc.js";
 import {
   HandlerKind,
   makeRpcCallProxy,
@@ -55,12 +54,7 @@ import type {
   Duration,
   JournalValueCodec,
   Serde,
-  Service,
-  ServiceDefinitionFrom,
-  VirtualObject,
-  VirtualObjectDefinitionFrom,
-  Workflow,
-  WorkflowDefinitionFrom,
+  HandlerDescriptor,
 } from "@restatedev/restate-sdk-core";
 import { millisOrDurationToMillis, serde } from "@restatedev/restate-sdk-core";
 import { RandImpl } from "./utils/rand.js";
@@ -77,6 +71,15 @@ import { ExternalProgressChannel } from "./utils/external_progress_channel.js";
 import type { ContextInternal } from "./internal.js";
 import { InputReader, OutputWriter } from "./endpoint/handlers/types.js";
 import { ExecutionOptions } from "./endpoint/components.js";
+
+/**
+ * The runtime shape a client method needs. implement() and type manipulations respect this.
+ */
+type ClientTarget = {
+  name: string;
+  _handlers?: Record<string, HandlerDescriptor>;
+  _kind?: "service" | "object" | "workflow";
+};
 
 export class ContextImpl
   implements ObjectContext, WorkflowContext, ContextInternal
@@ -384,132 +387,163 @@ export class ContextImpl
     }
   }
 
-  serviceClient<D>({ name }: ServiceDefinitionFrom<D>): Client<Service<D>> {
+  // The public overloaded signatures (classic definition OR service interface)
+  // live on the Context interface; these implementations are permissive and
+  // forward `def._handlers` (present on interface / implement() values, absent
+  // on classic definitions → serde reuse is a no-op there).
+  serviceClient(def: ClientTarget): any {
     return makeRpcCallProxy(
       (call) => this.genericCall(call),
       this.defaultSerde,
-
-      name
+      def.name,
+      undefined,
+      undefined,
+      def._handlers
     );
   }
 
-  objectClient<D>(
-    { name }: VirtualObjectDefinitionFrom<D>,
-    key: string
-  ): Client<VirtualObject<D>> {
+  objectClient(def: ClientTarget, key: string): any {
     return makeRpcCallProxy(
       (call) => this.genericCall(call),
       this.defaultSerde,
-      name,
-      key
+      def.name,
+      key,
+      undefined,
+      def._handlers
     );
   }
 
-  workflowClient<D>(
-    { name }: WorkflowDefinitionFrom<D>,
-    key: string
-  ): Client<Workflow<D>> {
+  workflowClient(def: ClientTarget, key: string): any {
     return makeRpcCallProxy(
       (call) => this.genericCall(call),
       this.defaultSerde,
-      name,
-      key
+      def.name,
+      key,
+      undefined,
+      def._handlers
     );
   }
 
-  public serviceSendClient<D>({
-    name,
-  }: ServiceDefinitionFrom<D>): SendClient<Service<D>> {
+  public serviceSendClient(def: ClientTarget): any {
     return makeRpcSendProxy(
       (send) => this.genericSend(send),
       this.defaultSerde,
-      name,
-      undefined
+      def.name,
+      undefined,
+      undefined,
+      def._handlers
     );
   }
 
-  public objectSendClient<D>(
-    { name }: VirtualObjectDefinitionFrom<D>,
-    key: string
-  ): SendClient<VirtualObject<D>> {
+  public objectSendClient(def: ClientTarget, key: string): any {
     return makeRpcSendProxy(
       (send) => this.genericSend(send),
       this.defaultSerde,
-      name,
-      key
+      def.name,
+      key,
+      undefined,
+      def._handlers
     );
   }
 
-  workflowSendClient<D>(
-    { name }: WorkflowDefinitionFrom<D>,
-    key: string
-  ): SendClient<Workflow<D>> {
+  workflowSendClient(def: ClientTarget, key: string): any {
     return makeRpcSendProxy(
       (send) => this.genericSend(send),
       this.defaultSerde,
-      name,
-      key
+      def.name,
+      key,
+      undefined,
+      def._handlers
     );
+  }
+
+  // Factory that dispatches on the interface's kind — mirrors the ingress
+  // client's `client(def)` / `sendClient(def)` ergonomics.
+  client(def: ClientTarget, key?: string): any {
+    return def._kind === "service"
+      ? this.serviceClient(def)
+      : this.objectClient(def, key as string);
+  }
+
+  sendClient(def: ClientTarget, key?: string): any {
+    return def._kind === "service"
+      ? this.serviceSendClient(def)
+      : this.objectSendClient(def, key as string);
   }
 
   scope(scopeKey: string): ScopedContext {
     return {
-      serviceClient: <D>({ name }: ServiceDefinitionFrom<D>) =>
-        makeRpcCallProxy<Client<Service<D>>>(
+      serviceClient: (def: ClientTarget): any =>
+        makeRpcCallProxy(
           (call) => this.genericCall(call),
           this.defaultSerde,
-          name,
+          def.name,
           undefined,
-          scopeKey
+          scopeKey,
+          def._handlers
         ),
-      serviceSendClient: <D>({ name }: ServiceDefinitionFrom<D>) =>
-        makeRpcSendProxy<SendClient<Service<D>>>(
+      serviceSendClient: (def: ClientTarget): any =>
+        makeRpcSendProxy(
           (send) => this.genericSend(send),
           this.defaultSerde,
-          name,
+          def.name,
           undefined,
-          scopeKey
+          scopeKey,
+          def._handlers
         ),
-      objectClient: <D>(
-        { name }: VirtualObjectDefinitionFrom<D>,
-        key: string
-      ) =>
-        makeRpcCallProxy<Client<VirtualObject<D>>>(
+      objectClient: (def: ClientTarget, key: string): any =>
+        makeRpcCallProxy(
           (call) => this.genericCall(call),
           this.defaultSerde,
-          name,
+          def.name,
           key,
-          scopeKey
+          scopeKey,
+          def._handlers
         ),
-      objectSendClient: <D>(
-        { name }: VirtualObjectDefinitionFrom<D>,
-        key: string
-      ) =>
-        makeRpcSendProxy<SendClient<VirtualObject<D>>>(
+      objectSendClient: (def: ClientTarget, key: string): any =>
+        makeRpcSendProxy(
           (send) => this.genericSend(send),
           this.defaultSerde,
-          name,
+          def.name,
           key,
-          scopeKey
+          scopeKey,
+          def._handlers
         ),
-      workflowClient: <D>({ name }: WorkflowDefinitionFrom<D>, key: string) =>
-        makeRpcCallProxy<Client<Workflow<D>>>(
+      workflowClient: (def: ClientTarget, key: string): any =>
+        makeRpcCallProxy(
           (call) => this.genericCall(call),
           this.defaultSerde,
-          name,
+          def.name,
           key,
-          scopeKey
+          scopeKey,
+          def._handlers
         ),
-      workflowSendClient: <D>(
-        { name }: WorkflowDefinitionFrom<D>,
-        key: string
-      ) =>
-        makeRpcSendProxy<SendClient<Workflow<D>>>(
+      workflowSendClient: (def: ClientTarget, key: string): any =>
+        makeRpcSendProxy(
           (send) => this.genericSend(send),
           this.defaultSerde,
-          name,
+          def.name,
           key,
-          scopeKey
+          scopeKey,
+          def._handlers
+        ),
+      client: (def: ClientTarget, key?: string): any =>
+        makeRpcCallProxy(
+          (call) => this.genericCall(call),
+          this.defaultSerde,
+          def.name,
+          def._kind === "service" ? undefined : key,
+          scopeKey,
+          def._handlers
+        ),
+      sendClient: (def: ClientTarget, key?: string): any =>
+        makeRpcSendProxy(
+          (send) => this.genericSend(send),
+          this.defaultSerde,
+          def.name,
+          def._kind === "service" ? undefined : key,
+          scopeKey,
+          def._handlers
         ),
     };
   }

--- a/packages/libs/restate-sdk/src/types/interface.ts
+++ b/packages/libs/restate-sdk/src/types/interface.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+
+import type {
+  Context,
+  ObjectContext,
+  ObjectSharedContext,
+  WorkflowContext,
+  WorkflowSharedContext,
+} from "../context.js";
+import type {
+  ServiceDefinition,
+  VirtualObjectDefinition,
+  WorkflowDefinition,
+  Descriptor,
+  HandlerDescriptor,
+  ServiceDescriptor,
+  ObjectDescriptor,
+  WorkflowDescriptor,
+  InferInput,
+  InferOutput,
+} from "@restatedev/restate-sdk-core";
+import {
+  handlers,
+  service,
+  object,
+  workflow,
+  type ServiceHandlerOpts,
+  type ObjectHandlerOpts,
+  type WorkflowHandlerOpts,
+  type ServiceOptions,
+  type ObjectOptions,
+  type WorkflowOptions,
+} from "./rpc.js";
+
+// =============================================================================
+// implement() — provide handler implementations for a service interface
+// (contract) declared with `iface` (see @restatedev/restate-sdk-core), and
+// obtain a normal, bindable service/object/workflow definition.
+// =============================================================================
+
+/** @internal A handler function whose input argument is dropped when `I` is `void`. */
+export type FnOf<C, I, O> = [I] extends [void]
+  ? (ctx: C) => Promise<O>
+  : (ctx: C, input: I) => Promise<O>;
+
+/** @internal */
+export type ServiceImplHandlers<H extends Record<string, HandlerDescriptor>> = {
+  [K in keyof H]: FnOf<Context, InferInput<H[K]>, InferOutput<H[K]>>;
+};
+
+/** @internal Object handler contexts follow the descriptor's shared flag. */
+export type ObjectImplHandlers<H extends Record<string, HandlerDescriptor>> = {
+  [K in keyof H]: H[K] extends HandlerDescriptor<any, any, infer Shared>
+    ? FnOf<
+        Shared extends true ? ObjectSharedContext : ObjectContext,
+        InferInput<H[K]>,
+        InferOutput<H[K]>
+      >
+    : never;
+};
+
+/** @internal `run` gets a WorkflowContext; every other handler a shared one. */
+export type WorkflowImplHandlers<H extends Record<string, HandlerDescriptor>> =
+  {
+    [K in keyof H]: K extends "run"
+      ? FnOf<WorkflowContext, InferInput<H[K]>, InferOutput<H[K]>>
+      : FnOf<WorkflowSharedContext, InferInput<H[K]>, InferOutput<H[K]>>;
+  };
+
+/** @internal */
+export type ServicePerHandlerOpts = Omit<
+  ServiceHandlerOpts<unknown, unknown>,
+  "input" | "output"
+>;
+/** @internal */
+export type ObjectPerHandlerOpts = Omit<
+  ObjectHandlerOpts<unknown, unknown>,
+  "input" | "output"
+>;
+/** @internal */
+export type WorkflowPerHandlerOpts = Omit<
+  WorkflowHandlerOpts<unknown, unknown>,
+  "input" | "output"
+>;
+
+export function implement<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+>(
+  serviceInterface: ServiceDescriptor<P, H>,
+  config: {
+    handlers: ServiceImplHandlers<H>;
+    description?: string;
+    metadata?: Record<string, string>;
+    options?: ServiceOptions & {
+      handlers?: Partial<Record<keyof H, ServicePerHandlerOpts>>;
+    };
+  }
+): ServiceDefinition<P, ServiceImplHandlers<H>> & ServiceDescriptor<P, H>;
+
+export function implement<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+>(
+  objectInterface: ObjectDescriptor<P, H>,
+  config: {
+    handlers: ObjectImplHandlers<H>;
+    description?: string;
+    metadata?: Record<string, string>;
+    options?: ObjectOptions & {
+      handlers?: Partial<Record<keyof H, ObjectPerHandlerOpts>>;
+    };
+  }
+): VirtualObjectDefinition<P, ObjectImplHandlers<H>> & ObjectDescriptor<P, H>;
+
+export function implement<
+  P extends string,
+  H extends Record<string, HandlerDescriptor>,
+>(
+  workflowInterface: WorkflowDescriptor<P, H>,
+  config: {
+    handlers: WorkflowImplHandlers<H>;
+    description?: string;
+    metadata?: Record<string, string>;
+    options?: WorkflowOptions & {
+      handlers?: Partial<Record<keyof H, WorkflowPerHandlerOpts>>;
+    };
+  }
+): WorkflowDefinition<P, WorkflowImplHandlers<H>> & WorkflowDescriptor<P, H>;
+
+export function implement(
+  contract: Descriptor<any, any, any>,
+  config: {
+    handlers: Record<string, any>;
+    description?: string;
+    metadata?: Record<string, string>;
+    options?: any;
+  }
+): any {
+  const { handlers: perHandlerOpts, ...serviceOptions } = config.options ?? {};
+
+  const coreHandlers: Record<string, any> = {};
+  for (const [name, desc] of Object.entries(
+    contract._handlers as Record<string, HandlerDescriptor>
+  )) {
+    const fn = config.handlers[name];
+    if (typeof fn !== "function") {
+      throw new Error(`implement(): missing handler "${name}"`);
+    }
+    const sdkOpts = {
+      input: desc._inputSerde,
+      output: desc._outputSerde,
+      ...((perHandlerOpts?.[name] as object) ?? {}),
+    };
+
+    if (contract._kind === "service") {
+      coreHandlers[name] = handlers.handler(sdkOpts as any, fn);
+    } else if (contract._kind === "object") {
+      coreHandlers[name] = desc._shared
+        ? handlers.object.shared(sdkOpts as any, fn)
+        : handlers.object.exclusive(sdkOpts as any, fn);
+    } else {
+      coreHandlers[name] =
+        name === "run"
+          ? handlers.workflow.workflow(sdkOpts as any, fn)
+          : handlers.workflow.shared(sdkOpts as any, fn);
+    }
+  }
+
+  const common = {
+    name: contract.name,
+    handlers: coreHandlers as any,
+    description: config.description,
+    metadata: config.metadata,
+    options: serviceOptions,
+  };
+
+  const def =
+    contract._kind === "service"
+      ? service(common)
+      : contract._kind === "object"
+        ? object(common)
+        : workflow(common);
+
+  return Object.assign(def, {
+    _kind: contract._kind,
+    _handlers: contract._handlers,
+  });
+}

--- a/packages/libs/restate-sdk/src/types/rpc.ts
+++ b/packages/libs/restate-sdk/src/types/rpc.ts
@@ -38,6 +38,10 @@ import {
   type WorkflowSharedHandler,
   type Serde,
   type Duration,
+  type HandlerDescriptor,
+  type InferInput,
+  type InferOutput,
+  makeHandlerDescriptor,
 } from "@restatedev/restate-sdk-core";
 import { ensureError, TerminalError } from "./errors.js";
 import type { HooksProvider } from "../hooks.js";
@@ -253,7 +257,8 @@ export const makeRpcCallProxy = <T>(
   defaultSerde: Serde<any>,
   service: string,
   key?: string,
-  scope?: string
+  scope?: string,
+  handlers?: Record<string, HandlerDescriptor>
 ): T => {
   const clientProxy = new Proxy(
     {},
@@ -262,9 +267,12 @@ export const makeRpcCallProxy = <T>(
         const method = prop as string;
         return (...args: unknown[]) => {
           const { parameter, opts } = optsFromArgs(args);
-          const requestSerde = opts?.input ?? defaultSerde;
+          const descriptor = handlers?.[method];
+          const requestSerde =
+            opts?.input ?? descriptor?._inputSerde ?? defaultSerde;
           const responseSerde =
             (opts as ClientCallOptions<unknown, unknown> | undefined)?.output ??
+            descriptor?._outputSerde ??
             defaultSerde;
           return genericCall({
             service,
@@ -292,7 +300,8 @@ export const makeRpcSendProxy = <T>(
   defaultSerde: Serde<any>,
   service: string,
   key?: string,
-  scope?: string
+  scope?: string,
+  handlers?: Record<string, HandlerDescriptor>
 ): T => {
   const clientProxy = new Proxy(
     {},
@@ -301,7 +310,9 @@ export const makeRpcSendProxy = <T>(
         const method = prop as string;
         return (...args: unknown[]) => {
           const { parameter, opts } = optsFromArgs(args);
-          const requestSerde = opts?.input ?? defaultSerde;
+          const descriptor = handlers?.[method];
+          const requestSerde =
+            opts?.input ?? descriptor?._inputSerde ?? defaultSerde;
           const delay = (opts as ClientSendOptions<unknown> | undefined)?.delay;
           return genericSend({
             service,
@@ -344,6 +355,39 @@ export type SendClient<M> = {
   ) => void
     ? (...args: [...P, ...[opts?: SendOpts<InferArg<P>>]]) => InvocationHandle
     : never;
+};
+
+/**
+ * Typed request/response client derived from a service interface's handler
+ * descriptor map `H` (see `iface` in `@restatedev/restate-sdk-core`). Unlike
+ * {@link Client}, which recovers the phantom handler-map from a
+ * `ServiceDefinition`, this recovers the input/output types directly from the
+ * descriptors, so a code-free interface value produces a fully typed client.
+ */
+export type ClientFromDescriptors<H extends Record<string, HandlerDescriptor>> =
+  {
+    readonly [K in keyof H]: [InferInput<H[K]>] extends [void]
+      ? (
+          opts?: Opts<InferInput<H[K]>, InferOutput<H[K]>>
+        ) => InvocationPromise<InferOutput<H[K]>>
+      : (
+          input: InferInput<H[K]>,
+          opts?: Opts<InferInput<H[K]>, InferOutput<H[K]>>
+        ) => InvocationPromise<InferOutput<H[K]>>;
+  };
+
+/**
+ * One-way (send) counterpart of {@link ClientFromDescriptors}.
+ */
+export type SendClientFromDescriptors<
+  H extends Record<string, HandlerDescriptor>,
+> = {
+  readonly [K in keyof H]: [InferInput<H[K]>] extends [void]
+    ? (opts?: SendOpts<InferInput<H[K]>>) => InvocationHandle
+    : (
+        input: InferInput<H[K]>,
+        opts?: SendOpts<InferInput<H[K]>>
+      ) => InvocationHandle;
 };
 
 // ----------- handlers ----------------------------------------------
@@ -1213,6 +1257,31 @@ export type ServiceOptions = {
  * @type P the name of the service
  * @type M the handlers for the service
  */
+/**
+ * Build the per-handler serde descriptor map that lets a caller reuse a
+ * definition's declared serdes (see `HandlerDescriptor` /
+ * `ingress.client(def)`). The serde recorded per handler is its effective one —
+ * explicit `input`/`output`, else the handler-level `serde`, else the
+ * service-level `serde`; left `undefined` (→ caller default, i.e. JSON) when
+ * nothing was declared.
+ */
+const buildHandlerDescriptors = (
+  routes: object,
+  serviceSerde: Serde<any> | undefined
+): Record<string, HandlerDescriptor> => {
+  const descriptors: Record<string, HandlerDescriptor> = {};
+  for (const [name, handler] of Object.entries(routes)) {
+    const wrapper = HandlerWrapper.fromHandler(handler);
+    const opts = wrapper?.options;
+    descriptors[name] = makeHandlerDescriptor(
+      opts?.input ?? opts?.serde ?? serviceSerde,
+      opts?.output ?? opts?.serde ?? serviceSerde,
+      wrapper?.kind === HandlerKind.SHARED
+    );
+  }
+  return descriptors;
+};
+
 export const service = <P extends string, M>(service: {
   name: P;
   handlers: ServiceOpts<M> & ThisType<M>;
@@ -1236,13 +1305,20 @@ export const service = <P extends string, M>(service: {
     throw new TypeError(`Unexpected handler type ${name}`);
   });
 
-  return {
-    name: service.name,
-    service: Object.fromEntries(handlers) as object,
-    metadata: service.metadata,
-    description: service.description,
-    options: service.options,
-  } as ServiceDefinition<P, M>;
+  const routes = Object.fromEntries(handlers) as Record<string, unknown>;
+  return Object.assign(
+    {
+      name: service.name,
+      service: routes,
+      metadata: service.metadata,
+      description: service.description,
+      options: service.options,
+    },
+    {
+      _kind: "service" as const,
+      _handlers: buildHandlerDescriptors(routes, service.options?.serde),
+    }
+  ) as ServiceDefinition<P, M>;
 };
 
 // ----------- objects ----------------------------------------------
@@ -1346,13 +1422,20 @@ export const object = <P extends string, M>(object: {
     throw new TypeError(`Unexpected handler type ${name}`);
   });
 
-  return {
-    name: object.name,
-    object: Object.fromEntries(handlers) as object,
-    metadata: object.metadata,
-    description: object.description,
-    options: object.options,
-  } as VirtualObjectDefinition<P, M>;
+  const routes = Object.fromEntries(handlers) as Record<string, unknown>;
+  return Object.assign(
+    {
+      name: object.name,
+      object: routes,
+      metadata: object.metadata,
+      description: object.description,
+      options: object.options,
+    },
+    {
+      _kind: "object" as const,
+      _handlers: buildHandlerDescriptors(routes, object.options?.serde),
+    }
+  ) as VirtualObjectDefinition<P, M>;
 };
 
 // ----------- workflows ----------------------------------------------
@@ -1499,11 +1582,18 @@ export const workflow = <P extends string, M>(workflow: {
     handlers.push([name, wrapper.transpose()]);
   }
 
-  return {
-    name: workflow.name,
-    workflow: Object.fromEntries(handlers) as object,
-    metadata: workflow.metadata,
-    description: workflow.description,
-    options: workflow.options,
-  } as WorkflowDefinition<P, M>;
+  const routes = Object.fromEntries(handlers) as Record<string, unknown>;
+  return Object.assign(
+    {
+      name: workflow.name,
+      workflow: routes,
+      metadata: workflow.metadata,
+      description: workflow.description,
+      options: workflow.options,
+    },
+    {
+      _kind: "workflow" as const,
+      _handlers: buildHandlerDescriptors(routes, workflow.options?.serde),
+    }
+  ) as WorkflowDefinition<P, M>;
 };

--- a/packages/libs/restate-sdk/test/interface.test.ts
+++ b/packages/libs/restate-sdk/test/interface.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2023-2026 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import * as restate from "../src/index.js";
+import { makeRpcCallProxy, makeRpcSendProxy } from "../src/types/rpc.js";
+import type { GenericCall, GenericSend } from "../src/context.js";
+import { toServiceDiscovery } from "./testutils.js";
+
+// A shared contract using a non-JSON serde on one handler.
+const greeter = restate.iface.service("greeter", {
+  greet: restate.iface.serdes({
+    input: restate.serde.binary,
+    output: restate.serde.binary,
+  }),
+  ping: restate.iface.json<{ name: string }, string>(),
+});
+
+const counter = restate.iface.object("counter", {
+  add: restate.iface.json<number, number>(),
+  get: restate.iface.shared.json<void, number>(),
+});
+
+describe("iface + implement", () => {
+  it("carries the declared serdes on the interface value", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handlers = (greeter as any)._handlers;
+    expect(handlers.greet._inputSerde).toBe(restate.serde.binary);
+    expect(handlers.greet._outputSerde).toBe(restate.serde.binary);
+    // json handlers declare no serde (JSON is the default)
+    expect(handlers.ping._inputSerde).toBeUndefined();
+  });
+
+  it("produces a bindable service definition with the right content types", () => {
+    const def = restate.implement(greeter, {
+      handlers: {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        greet: async (_ctx, audio) => audio,
+        // eslint-disable-next-line @typescript-eslint/require-await
+        ping: async (_ctx, req) => req.name,
+      },
+    });
+
+    const svc = toServiceDiscovery(def);
+    const greet = svc.handlers.find((h) => h.name === "greet");
+    const ping = svc.handlers.find((h) => h.name === "ping");
+
+    expect(greet?.input?.contentType).toEqual(restate.serde.binary.contentType);
+    expect(ping?.input?.contentType).toEqual(restate.serde.json.contentType);
+    // the implemented definition still carries the descriptors for callers
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((def as any)._handlers.greet._inputSerde).toBe(restate.serde.binary);
+  });
+
+  it("implements object exclusive vs shared handlers and binds", () => {
+    const def = restate.implement(counter, {
+      handlers: {
+        add: async (ctx, amount) => {
+          const current = (await ctx.get<number>("count")) ?? 0;
+          ctx.set("count", current + amount);
+          return current + amount;
+        },
+        // shared handlers get a read-only context
+        get: async (ctx) => (await ctx.get<number>("count")) ?? 0,
+      },
+    });
+
+    const svc = toServiceDiscovery(def);
+    expect(svc.ty).toEqual("VIRTUAL_OBJECT");
+    expect(svc.handlers.map((h) => h.name).sort()).toEqual(["add", "get"]);
+    const get = svc.handlers.find((h) => h.name === "get");
+    expect(get?.ty).toEqual("SHARED");
+  });
+
+  it("rejects a bare (un-implemented) interface at bind time", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => toServiceDiscovery(greeter as any)).toThrow();
+  });
+});
+
+describe("client serde reuse", () => {
+  it("uses the interface serdes when no call opts are provided", async () => {
+    const call = vi.fn(
+      (_c: GenericCall<unknown, unknown>): Promise<unknown> =>
+        Promise.resolve(new Uint8Array())
+    );
+    const client = makeRpcCallProxy<{
+      greet: (i: Uint8Array) => Promise<unknown>;
+    }>(
+      call,
+      restate.serde.json,
+      greeter.name,
+      undefined,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (greeter as any)._handlers
+    );
+
+    await client.greet(new Uint8Array([1, 2, 3]));
+
+    expect(call).toHaveBeenCalledOnce();
+    const arg = call.mock.calls[0]![0];
+    expect(arg.inputSerde).toBe(restate.serde.binary);
+    expect(arg.outputSerde).toBe(restate.serde.binary);
+  });
+
+  it("lets explicit call opts override the interface serdes", async () => {
+    const call = vi.fn(
+      (_c: GenericCall<unknown, unknown>): Promise<unknown> =>
+        Promise.resolve(new Uint8Array())
+    );
+    const client = makeRpcCallProxy<{
+      greet: (i: Uint8Array, opts?: unknown) => Promise<unknown>;
+    }>(
+      call,
+      restate.serde.json,
+      greeter.name,
+      undefined,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (greeter as any)._handlers
+    );
+
+    await client.greet(
+      new Uint8Array(),
+      restate.rpc.opts({ input: restate.serde.empty })
+    );
+
+    const arg = call.mock.calls[0]![0];
+    expect(arg.inputSerde).toBe(restate.serde.empty);
+    // output still comes from the interface descriptor
+    expect(arg.outputSerde).toBe(restate.serde.binary);
+  });
+
+  it("falls back to the default serde when no descriptor map is present", async () => {
+    const call = vi.fn(
+      (_c: GenericCall<unknown, unknown>): Promise<unknown> =>
+        Promise.resolve(new Uint8Array())
+    );
+    const client = makeRpcCallProxy<{
+      greet: (i: unknown) => Promise<unknown>;
+    }>(call, restate.serde.json, "greeter");
+
+    await client.greet({});
+    const arg = call.mock.calls[0]![0];
+    expect(arg.inputSerde).toBe(restate.serde.json);
+    expect(arg.outputSerde).toBe(restate.serde.json);
+  });
+
+  it("reuses the interface serde on the send path too", () => {
+    const send = vi.fn((_s: GenericSend<unknown>) => {});
+    const client = makeRpcSendProxy<{ greet: (i: Uint8Array) => void }>(
+      send,
+      restate.serde.json,
+      greeter.name,
+      undefined,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (greeter as any)._handlers
+    );
+
+    client.greet(new Uint8Array());
+    expect(send.mock.calls[0]![0].inputSerde).toBe(restate.serde.binary);
+  });
+});
+
+describe("client typing (compile-time)", () => {
+  it("derives the client type from the interface", () => {
+    // Never executed — this only needs to type-check.
+    const _typeChecks = () => {
+      const ctx = undefined as unknown as restate.Context;
+
+      const p: PromiseLike<string> = ctx.client(greeter).ping({
+        name: "a",
+      });
+      void p;
+
+      // @ts-expect-error ping requires a { name: string } argument
+      ctx.client(greeter).ping(123);
+
+      // object client via the same factory (kind-dispatched, needs the key)
+      const n: PromiseLike<number> = ctx.client(counter, "k").add(1);
+      void n;
+    };
+    void _typeChecks;
+    expect(true).toBe(true);
+  });
+});
+
+// The runtime enrichment: plain service()/object()/workflow() values now carry
+// the `_kind` + `_handlers` descriptor contract, so their serdes flow to callers
+// (via serviceClient/objectClient/client) — without any change to their type.
+describe("service()/object()/workflow() carry the Descriptor contract", () => {
+  const svc = restate.service({
+    name: "svc",
+    handlers: {
+      echo: restate.handlers.handler(
+        { input: restate.serde.binary, output: restate.serde.binary },
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async (_ctx: restate.Context, x: Uint8Array) => x
+      ),
+      // eslint-disable-next-line @typescript-eslint/require-await
+      ping: async (_ctx: restate.Context, x: string) => x, // JSON default
+    },
+  });
+
+  const obj = restate.object({
+    name: "obj",
+    handlers: {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      add: async (_ctx: restate.ObjectContext, n: number) => n,
+      get: restate.handlers.object.shared(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async (_ctx: restate.ObjectSharedContext) => 0
+      ),
+    },
+  });
+
+  it("plain service() carries _kind + _handlers with the declared serdes", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const d = svc as any;
+    expect(d._kind).toBe("service");
+    expect(d._handlers.echo._inputSerde).toBe(restate.serde.binary);
+    expect(d._handlers.echo._outputSerde).toBe(restate.serde.binary);
+    // JSON-default handler records no serde → caller falls back to JSON.
+    expect(d._handlers.ping._inputSerde).toBeUndefined();
+    // The type is unchanged: `{ name }` reconstruction still works.
+    const reconstructed: typeof svc = { name: "svc" };
+    expect(reconstructed.name).toBe("svc");
+  });
+
+  it("plain object() carries _kind and the shared flag per handler", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const d = obj as any;
+    expect(d._kind).toBe("object");
+    expect(d._handlers.get._shared).toBe(true);
+    expect(d._handlers.add._shared).toBe(false);
+  });
+
+  it("a client built from a plain service() reuses its declared serdes", async () => {
+    const call = vi.fn(
+      (_c: GenericCall<unknown, unknown>): Promise<unknown> =>
+        Promise.resolve(new Uint8Array())
+    );
+    const client = makeRpcCallProxy<{
+      echo: (i: Uint8Array) => Promise<unknown>;
+    }>(
+      call,
+      restate.serde.json,
+      svc.name,
+      undefined,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (svc as any)._handlers
+    );
+
+    await client.echo(new Uint8Array([1, 2, 3]));
+
+    const arg = call.mock.calls[0]![0];
+    expect(arg.inputSerde).toBe(restate.serde.binary);
+    expect(arg.outputSerde).toBe(restate.serde.binary);
+  });
+});

--- a/packages/tests/restate-e2e-services/src/awakeable_holder.ts
+++ b/packages/tests/restate-e2e-services/src/awakeable_holder.ts
@@ -12,22 +12,25 @@ import { REGISTRY } from "./services.js";
 
 const ID_KEY = "id";
 
-type Ctx = restate.ObjectContext;
+export const AwakeableHolder = restate.iface.object("AwakeableHolder", {
+  hold: restate.iface.json<string, void>(),
+  hasAwakeable: restate.iface.json<void, boolean>(),
+  unlock: restate.iface.json<string, void>(),
+});
 
-const service = restate.object({
-  name: "AwakeableHolder",
+const impl = restate.implement(AwakeableHolder, {
   handlers: {
-    hold(ctx: restate.ObjectContext, id: string) {
+    hold(ctx, id) {
       ctx.set(ID_KEY, id);
       return Promise.resolve();
     },
 
-    async hasAwakeable(ctx: Ctx): Promise<boolean> {
+    async hasAwakeable(ctx): Promise<boolean> {
       const maybe = await ctx.get<string>(ID_KEY);
       return maybe !== null && maybe !== undefined;
     },
 
-    async unlock(ctx: Ctx, request: string) {
+    async unlock(ctx, request) {
       const id = await ctx.get<string>(ID_KEY);
       if (id === null || id === undefined) {
         throw new Error("No awakeable registered");
@@ -38,6 +41,4 @@ const service = restate.object({
   },
 });
 
-REGISTRY.addObject(service);
-
-export type AwakeableHolder = typeof service;
+REGISTRY.addObject(impl);

--- a/packages/tests/restate-e2e-services/src/cancel_test.ts
+++ b/packages/tests/restate-e2e-services/src/cancel_test.ts
@@ -8,12 +8,11 @@
 // https://github.com/restatedev/e2e/blob/main/LICENSE
 
 import * as restate from "@restatedev/restate-sdk";
-import { type AwakeableHolder } from "./awakeable_holder.js";
+import { AwakeableHolder } from "./awakeable_holder.js";
 import { REGISTRY } from "./services.js";
 
 export const CancelTestServiceFQN = "CancelTestRunner";
 export const BlockingServiceFQN = "CancelTestBlockingService";
-const AwakeableHolder: AwakeableHolder = { name: "AwakeableHolder" };
 
 enum BlockingOperation {
   CALL = "CALL",
@@ -48,7 +47,7 @@ const blockingService = restate.object({
   handlers: {
     async block(ctx: restate.ObjectContext, request: BlockingOperation) {
       const { id, promise } = ctx.awakeable();
-      await ctx.objectClient(AwakeableHolder, ctx.key).hold(id);
+      await ctx.client(AwakeableHolder, ctx.key).hold(id);
       await promise;
 
       switch (request) {

--- a/packages/tests/restate-e2e-services/src/counter.ts
+++ b/packages/tests/restate-e2e-services/src/counter.ts
@@ -9,11 +9,8 @@
 
 import * as restate from "@restatedev/restate-sdk";
 import { REGISTRY } from "./services.js";
-import type { AwakeableHolder } from "./awakeable_holder.js";
 
 const COUNTER_KEY = "counter";
-
-const AwakeableHolder: AwakeableHolder = { name: "AwakeableHolder" };
 
 const service = restate.object({
   name: "Counter",

--- a/packages/tests/restate-e2e-services/src/kill.ts
+++ b/packages/tests/restate-e2e-services/src/kill.ts
@@ -9,7 +9,7 @@
 
 import * as restate from "@restatedev/restate-sdk";
 import { REGISTRY } from "./services.js";
-import type { AwakeableHolder } from "./awakeable_holder.js";
+import { AwakeableHolder } from "./awakeable_holder.js";
 
 const kill = restate.object({
   name: "KillTestRunner",
@@ -25,9 +25,7 @@ const killSingleton = restate.object({
   handlers: {
     async recursiveCall(ctx: restate.ObjectContext) {
       const { id, promise } = ctx.awakeable();
-      ctx
-        .objectSendClient<AwakeableHolder>({ name: "AwakeableHolder" }, ctx.key)
-        .hold(id);
+      ctx.sendClient(AwakeableHolder, ctx.key).hold(id);
       await promise;
 
       await ctx.objectClient(killSingleton, ctx.key).recursiveCall();


### PR DESCRIPTION
* restate.interface lives in restate-sdk-core and can be used as base module for users that want to define service interfaces
* Now restate-sdk-clients package can do requests both to promise sdk and gen sdk
* Deprecate ingress client wrapper in gen sdk
* Add ingressClient.client/sendClient and ctx.client/sendClient for the new interface approach
* Old behavior with type exporting is preserved as it is.