### PR TITLE
Allow Typed State when implementing an iface

### DIFF
--- a/packages/libs/restate-sdk/src/common_api.ts
+++ b/packages/libs/restate-sdk/src/common_api.ts
@@ -123,7 +123,7 @@ export type {
   InferInput,
   InferOutput,
 } from "@restatedev/restate-sdk-core";
-export { implement } from "./types/interface.js";
+export { implement, typed } from "./types/interface.js";
 export type {
   /** @internal */
   FnOf,

--- a/packages/libs/restate-sdk/src/common_api.ts
+++ b/packages/libs/restate-sdk/src/common_api.ts
@@ -123,7 +123,7 @@ export type {
   InferInput,
   InferOutput,
 } from "@restatedev/restate-sdk-core";
-export { implement, typed } from "./types/interface.js";
+export { implement, state } from "./types/interface.js";
 export type {
   /** @internal */
   FnOf,

--- a/packages/libs/restate-sdk/src/types/interface.ts
+++ b/packages/libs/restate-sdk/src/types/interface.ts
@@ -16,6 +16,8 @@ import type {
   ObjectSharedContext,
   WorkflowContext,
   WorkflowSharedContext,
+  TypedState,
+  UntypedState,
 } from "../context.js";
 import type {
   ServiceDefinition,
@@ -59,10 +61,10 @@ export type ServiceImplHandlers<H extends Record<string, HandlerDescriptor>> = {
 };
 
 /** @internal Object handler contexts follow the descriptor's shared flag. */
-export type ObjectImplHandlers<H extends Record<string, HandlerDescriptor>> = {
+export type ObjectImplHandlers<H extends Record<string, HandlerDescriptor>, S extends TypedState> = {
   [K in keyof H]: H[K] extends HandlerDescriptor<any, any, infer Shared>
     ? FnOf<
-        Shared extends true ? ObjectSharedContext : ObjectContext,
+        Shared extends true ? ObjectSharedContext<S> : ObjectContext<S>,
         InferInput<H[K]>,
         InferOutput<H[K]>
       >
@@ -70,11 +72,11 @@ export type ObjectImplHandlers<H extends Record<string, HandlerDescriptor>> = {
 };
 
 /** @internal `run` gets a WorkflowContext; every other handler a shared one. */
-export type WorkflowImplHandlers<H extends Record<string, HandlerDescriptor>> =
+export type WorkflowImplHandlers<H extends Record<string, HandlerDescriptor>, S extends TypedState> =
   {
     [K in keyof H]: K extends "run"
-      ? FnOf<WorkflowContext, InferInput<H[K]>, InferOutput<H[K]>>
-      : FnOf<WorkflowSharedContext, InferInput<H[K]>, InferOutput<H[K]>>;
+      ? FnOf<WorkflowContext<S>, InferInput<H[K]>, InferOutput<H[K]>>
+      : FnOf<WorkflowSharedContext<S>, InferInput<H[K]>, InferOutput<H[K]>>;
   };
 
 /** @internal */
@@ -111,32 +113,42 @@ export function implement<
 export function implement<
   P extends string,
   H extends Record<string, HandlerDescriptor>,
+  S extends TypedState = UntypedState,
 >(
   objectInterface: ObjectDescriptor<P, H>,
   config: {
-    handlers: ObjectImplHandlers<H>;
+    handlers: ObjectImplHandlers<H, S>;
     description?: string;
     metadata?: Record<string, string>;
     options?: ObjectOptions & {
       handlers?: Partial<Record<keyof H, ObjectPerHandlerOpts>>;
+      /**
+       * Use `restate.typed<YourStateType>()` to populate this
+       */
+      typedState?: S | undefined;
     };
   }
-): VirtualObjectDefinition<P, ObjectImplHandlers<H>> & ObjectDescriptor<P, H>;
+): VirtualObjectDefinition<P, ObjectImplHandlers<H, S>> & ObjectDescriptor<P, H>;
 
 export function implement<
   P extends string,
   H extends Record<string, HandlerDescriptor>,
+  S extends TypedState = UntypedState,
 >(
   workflowInterface: WorkflowDescriptor<P, H>,
   config: {
-    handlers: WorkflowImplHandlers<H>;
+    handlers: WorkflowImplHandlers<H, S>;
     description?: string;
     metadata?: Record<string, string>;
     options?: WorkflowOptions & {
       handlers?: Partial<Record<keyof H, WorkflowPerHandlerOpts>>;
+      /**
+       * Use `restate.typed<YourStateType>()` to populate this
+       */
+      typedState?: S | undefined;
     };
   }
-): WorkflowDefinition<P, WorkflowImplHandlers<H>> & WorkflowDescriptor<P, H>;
+): WorkflowDefinition<P, WorkflowImplHandlers<H, S>> & WorkflowDescriptor<P, H>;
 
 export function implement(
   contract: Descriptor<any, any, any>,
@@ -196,4 +208,8 @@ export function implement(
     _kind: contract._kind,
     _handlers: contract._handlers,
   });
+}
+
+export function typed<S extends TypedState>(): S | undefined {
+  return undefined;
 }

--- a/packages/libs/restate-sdk/src/types/interface.ts
+++ b/packages/libs/restate-sdk/src/types/interface.ts
@@ -122,11 +122,11 @@ export function implement<
     metadata?: Record<string, string>;
     options?: ObjectOptions & {
       handlers?: Partial<Record<keyof H, ObjectPerHandlerOpts>>;
-      /**
-       * Use `restate.typed<YourStateType>()` to populate this
-       */
-      typedState?: S | undefined;
     };
+    /**
+     * Use `restate.state<YourStateType>()` to populate this.
+     */
+    states?: S | null;
   }
 ): VirtualObjectDefinition<P, ObjectImplHandlers<H, S>> & ObjectDescriptor<P, H>;
 
@@ -142,11 +142,11 @@ export function implement<
     metadata?: Record<string, string>;
     options?: WorkflowOptions & {
       handlers?: Partial<Record<keyof H, WorkflowPerHandlerOpts>>;
-      /**
-       * Use `restate.typed<YourStateType>()` to populate this
-       */
-      typedState?: S | undefined;
     };
+    /**
+     * Use `restate.state<YourStateType>()` to populate this.
+     */
+    states?: S | null;
   }
 ): WorkflowDefinition<P, WorkflowImplHandlers<H, S>> & WorkflowDescriptor<P, H>;
 
@@ -210,6 +210,13 @@ export function implement(
   });
 }
 
-export function typed<S extends TypedState>(): S | undefined {
-  return undefined;
+/**
+ * Define the value of TypedState for a Virtual Object or Workflow.
+ */
+export function state<S extends TypedState>(): S | null {
+  /**
+   * @internal In future, add a parameter `default?: Partial<S>` to allow default state values, then
+   * `return default ?? null`
+   */
+  return null;
 }


### PR DESCRIPTION
Fixes #791

Usage: (UPDATED to reflect latest PR changes)
```ts
import * as restate from '@restatedev/restate-sdk'

const fooIface = restate.iface.object('foo', {
  getFoo: restate.iface.json<void, string | null>(),
})

export const foo = restate.implement(fooIface, {
  handlers: {
    getFoo: async (ctx) => {
      const value = await ctx.get('foo')
      // Correctly inferred as `string | null`
      return value
    },
  },
  states: restate.state<{ foo: string }>(),
})
```